### PR TITLE
meta(gh): Set codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default code owners
-*   @getsentry/team-foundational-storage
+*   @getsentry/foundational-storage
 
 # Legal
-/LICENSE.md  @getsentry/owners-legal  @getsentry/team-foundational-storage
+/LICENSE.md   @getsentry/foundational-storage @getsentry/owners-legal


### PR DESCRIPTION
Codeowner approval is not enforced at the moment, this is just to tag the team
with review requests automatically.

