### PR TITLE
meta(vscode): Add recommended vscode settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,16 @@
+{
+  // See http://go.microsoft.com/fwlink/?LinkId=827846
+  // for the documentation about the extensions.json format
+  "recommendations": [
+    // TOML language support
+    "tamasfe.even-better-toml",
+    // Rust language server
+    "rust-lang.rust-analyzer",
+    // Crates.io dependency versions
+    "fill-labs.dependi",
+    // Debugger support for Rust and native
+    "vadimcn.vscode-lldb",
+    // Snapshot tests integration
+    "mitsuhiko.insta",
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,23 @@
+{
+  // Formatting
+  "editor.formatOnPaste": true,
+  "editor.formatOnSave": true,
+  "editor.formatOnType": true,
+  "editor.tabSize": 4,
+  "editor.rulers": [100],
+  "files.autoSave": "onWindowChange",
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true,
+
+  // Rust Analyzer
+  "rust-analyzer.cargo.features": "all",
+  "rust-analyzer.check.command": "clippy",
+  "rust-analyzer.imports.granularity.group": "module",
+  "rust-analyzer.imports.prefix": "crate",
+
+  // Language-specific overrides
+  "[markdown]": {
+    "editor.rulers": [80],
+    "editor.tabSize": 2,
+  }
+}


### PR DESCRIPTION
Useful VSCode extensions and settings. Particularly, once Rust Analyzer is installed and enabled, this enables format-on-save with rustfmt and linting with clippy.