### PR TITLE
fix: Read YAML directly without nested profiles

### DIFF
--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -29,7 +29,7 @@ impl Config {
 
         let mut figment = figment::Figment::from(Serialized::defaults(Config::default()));
         if let Some(config_path) = &args.config {
-            figment = figment.merge(Yaml::file(config_path).nested());
+            figment = figment.merge(Yaml::file(config_path));
         }
         let config = figment.merge(Env::prefixed(ENV_PREFIX)).extract()?;
 


### PR DESCRIPTION
When introducing YAML config, we accidentally enabled `nested()` configurations,
treat top-level keys as profiles. Since we do not want that, we disabled nesting
now. 
