### PR TITLE
fix(docker): Remove gosu and launch directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,22 +32,14 @@ FROM debian:bookworm-slim
 
 RUN apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends ca-certificates gosu \
+    && apt-get install -y --no-install-recommends ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-ENV \
-    SERVER_UID=10001 \
-    SERVER_GID=10001 \
-    FSS_PATH="/data"
-
-# Create a new user and group with fixed uid/gid
-RUN groupadd --system fss --gid $SERVER_GID \
-    && useradd --system --gid fss --uid $SERVER_UID fss
-
+ENV FSS_PATH="/data"
 VOLUME ["/data"]
-EXPOSE 50051
 
 COPY --from=build-server /work/target/release/server /bin
-COPY docker-entrypoint.sh /docker-entrypoint.sh
 
-ENTRYPOINT ["/bin/bash", "/docker-entrypoint.sh"]
+ENTRYPOINT ["/bin/server"]
+EXPOSE 50051
+EXPOSE 8888

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -eu
-
-if [ "$(id -u)" == "0" ]; then
-  exec gosu fss /bin/server "$@"
-else
-  exec /bin/server "$@"
-fi


### PR DESCRIPTION
We will run the server directly without `gosu` and configure the correct UID and
GID via k8s. This removes the `docker-entrypoint.sh` and related configuration.
Also exposes port `8888`, which was recently added as HTTP port

Ref FS-54

