### PR TITLE
Make the `Backend` fully dyn-compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2361,6 +2361,7 @@ dependencies = [
  "api",
  "async-compression",
  "async-stream",
+ "async-trait",
  "bytes",
  "futures-core",
  "futures-util",

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "1.0.98"
 api = { path = "../api" }
 async-compression = { version = "0.4.25", features = ["tokio", "zstd"] }
 async-stream = "0.3.6"
+async-trait = "0.1.88"
 bytes = "1.10.1"
 futures-core = "0.3.31"
 futures-util = "0.3.31"

--- a/service/src/backend/gcs.rs
+++ b/service/src/backend/gcs.rs
@@ -36,6 +36,7 @@ impl Gcs {
     }
 }
 
+#[async_trait::async_trait]
 impl Backend for Gcs {
     async fn put_file(
         &self,

--- a/service/src/backend/local_fs.rs
+++ b/service/src/backend/local_fs.rs
@@ -21,6 +21,7 @@ impl LocalFs {
     }
 }
 
+#[async_trait::async_trait]
 impl Backend for LocalFs {
     async fn put_file(
         &self,

--- a/service/src/backend/mod.rs
+++ b/service/src/backend/mod.rs
@@ -8,6 +8,9 @@ pub use local_fs::LocalFs;
 use bytes::Bytes;
 use std::io;
 
+pub type BoxedBackend = Box<dyn Backend + Send + Sync + 'static>;
+
+#[async_trait::async_trait]
 pub trait Backend {
     async fn put_file(
         &self,

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -14,7 +14,6 @@ use std::sync::Arc;
 use anyhow::Context;
 use async_compression::tokio::bufread::ZstdDecoder;
 use bytes::Bytes;
-use futures_core::stream::BoxStream;
 use futures_util::StreamExt as _;
 use tokio::io::{AsyncReadExt as _, BufReader};
 use tokio_stream::Stream;
@@ -23,7 +22,7 @@ use uuid::Uuid;
 
 use watto::Pod;
 
-use crate::backend::Backend;
+use crate::backend::BoxedBackend;
 use crate::datamodel::{
     Compression, FILE_MAGIC, FILE_VERSION, File, FilePart, PART_MAGIC, PART_VERSION, Part,
 };
@@ -31,44 +30,21 @@ use crate::datamodel::{
 #[derive(Clone)]
 pub struct StorageService(Arc<StorageServiceInner>);
 
-enum StorageServiceInner {
-    Fs(backend::LocalFs),
-    Gcs(backend::Gcs),
-}
-
-impl backend::Backend for StorageServiceInner {
-    async fn put_file(
-        &self,
-        path: &str,
-        stream: BoxStream<'static, io::Result<Bytes>>,
-    ) -> anyhow::Result<()> {
-        match self {
-            StorageServiceInner::Fs(local_fs) => local_fs.put_file(path, stream).await,
-            StorageServiceInner::Gcs(gcs) => gcs.put_file(path, stream).await,
-        }
-    }
-
-    async fn get_file(
-        &self,
-        path: &str,
-    ) -> anyhow::Result<Option<BoxStream<'static, io::Result<Bytes>>>> {
-        match self {
-            StorageServiceInner::Fs(local_fs) => local_fs.get_file(path).await,
-            StorageServiceInner::Gcs(gcs) => gcs.get_file(path).await,
-        }
-    }
+struct StorageServiceInner {
+    backend: BoxedBackend,
 }
 
 impl StorageService {
     pub async fn new(path: &Path, bucket: Option<&str>) -> anyhow::Result<Self> {
-        let inner = if let Some(bucket) = bucket {
+        let backend: BoxedBackend = if let Some(bucket) = bucket {
             let gcs = backend::Gcs::new(bucket).await?;
-            StorageServiceInner::Gcs(gcs)
+            Box::new(gcs)
         } else {
             let fs = backend::LocalFs::new(path);
-            StorageServiceInner::Fs(fs)
+            Box::new(fs)
         };
 
+        let inner = StorageServiceInner { backend };
         Ok(Self(Arc::new(inner)))
     }
 
@@ -85,7 +61,7 @@ impl StorageService {
     ) -> anyhow::Result<Option<impl Stream<Item = anyhow::Result<Bytes>> + use<>>> {
         let file_path = format!("files/{key}.bin");
 
-        let Some(reader) = self.0.get_file(&file_path).await? else {
+        let Some(reader) = self.0.backend.get_file(&file_path).await? else {
             return Ok(None);
         };
 
@@ -134,7 +110,7 @@ impl StorageService {
 
         let file_path = format!("files/{key}.bin");
         let stream = tokio_stream::once(io::Result::Ok(buffer.into()));
-        self.0.put_file(&file_path, stream.boxed()).await?;
+        self.0.backend.put_file(&file_path, stream.boxed()).await?;
 
         Ok(())
     }
@@ -161,7 +137,7 @@ impl StorageService {
 
         let part_path = format!("parts/{part_uuid}.bin");
         let stream = tokio_stream::once(io::Result::Ok(buffer.into()));
-        self.0.put_file(&part_path, stream.boxed()).await?;
+        self.0.backend.put_file(&part_path, stream.boxed()).await?;
 
         Ok(FilePart {
             part_size: part_size.into(),
@@ -172,7 +148,7 @@ impl StorageService {
     async fn get_part(&self, part_uuid: Uuid) -> anyhow::Result<Option<Bytes>> {
         let part_path = format!("parts/{part_uuid}.bin");
 
-        let Some(reader) = self.0.get_file(&part_path).await? else {
+        let Some(reader) = self.0.backend.get_file(&part_path).await? else {
             return Ok(None);
         };
 


### PR DESCRIPTION
This is using `async-trait` for the trait itself, and boxes the input/output streams to avoid generics.