### PR TITLE
Directly stream uploads to the backend, no buffering or processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,6 +2365,7 @@ dependencies = [
  "axum-extra",
  "elegant-departure",
  "figment",
+ "futures-util",
  "sentry",
  "serde",
  "serde_json",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -11,6 +11,7 @@ axum = "0.8.4"
 axum-extra = "0.10.1"
 elegant-departure = { version = "0.3.1", features = ["tokio"] }
 figment = { version = "0.10.19", features = ["env", "test", "yaml"] }
+futures-util = "0.3.31"
 sentry = { version = "0.41.0", features = [
     "tower-axum-matched-path",
     "tracing",

--- a/service/src/backend/mod.rs
+++ b/service/src/backend/mod.rs
@@ -8,19 +8,12 @@ pub use local_fs::LocalFs;
 pub use s3_compatible::S3Compatible;
 
 use bytes::Bytes;
-use std::io;
 
 pub type BoxedBackend = Box<dyn Backend + Send + Sync + 'static>;
+pub type BackendStream = BoxStream<'static, anyhow::Result<Bytes>>;
 
 #[async_trait::async_trait]
 pub trait Backend {
-    async fn put_file(
-        &self,
-        path: &str,
-        stream: BoxStream<'static, io::Result<Bytes>>,
-    ) -> anyhow::Result<()>;
-    async fn get_file(
-        &self,
-        path: &str,
-    ) -> anyhow::Result<Option<BoxStream<'static, io::Result<Bytes>>>>;
+    async fn put_file(&self, path: &str, stream: BackendStream) -> anyhow::Result<()>;
+    async fn get_file(&self, path: &str) -> anyhow::Result<Option<BackendStream>>;
 }


### PR DESCRIPTION
This circumvents our `datamodel` abstraction, and does not split uploads into `parts` anymore. This might just be a temporary solution for now, but speeds up things a bit. It also does not do any server-side `zstd` anymore.