### PR TITLE
build: add CI workflow that builds/pushes images to GHCR

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,101 @@
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - release/**
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            platform: amd64
+          - os: ubuntu-24.04-arm
+            platform: arm64
+    name: build-${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          cache-from: ghcr.io/getsentry/foundational-storage:latest
+          cache-to: type=inline
+          platforms: linux/${{ matrix.platform }}
+          tags: server:${{ matrix.platform }}
+          outputs: type=docker,dest=/tmp/server-${{ matrix.platform }}.tar
+          push: false
+
+      - name: Upload Image
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-${{ matrix.platform }}
+          path: /tmp/server-${{ matrix.platform }}.tar
+
+  assemble-server-image:
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: ${{ github.event_name != 'pull_request' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: docker login --username '${{ github.actor }}' --password-stdin ghcr.io <<< "$GHCR_TOKEN"
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Download amd64 Image
+        uses: actions/download-artifact@v4
+        with:
+          name: server-amd64
+          path: /tmp
+
+      - name: Load amd64 Image
+        run: docker load --input /tmp/server-amd64.tar
+
+      - name: Download arm64 Image
+        uses: actions/download-artifact@v4
+        with:
+          name: server-arm64
+          path: /tmp
+
+      - name: Load arm64 Image
+        run: docker load --input /tmp/server-arm64.tar
+
+      - name: Push to GitHub Container Registry
+        run: |
+          docker tag server:amd64 ghcr.io/getsentry/foundational-storage:${{ github.sha }}-amd64
+          docker push ghcr.io/getsentry/foundational-storage:${{ github.sha }}-amd64
+
+          docker tag taskbroker:arm64 ghcr.io/getsentry/foundational-storage:${{ github.sha }}-arm64
+          docker push ghcr.io/getsentry/foundational-storage:${{ github.sha }}-arm64
+
+          docker manifest create \
+            ghcr.io/getsentry/foundational-storage:${{ github.sha }} \
+            --amend ghcr.io/getsentry/foundational-storage:${{ github.sha }}-amd64 \
+            --amend ghcr.io/getsentry/foundational-storage:${{ github.sha }}-arm64
+
+          docker manifest push ghcr.io/getsentry/foundational-storage:${{ github.sha }}
+
+          docker manifest create \
+            ghcr.io/getsentry/foundational-storage:latest \
+            --amend ghcr.io/getsentry/foundational-storage:${{ github.sha }}-amd64 \
+            --amend ghcr.io/getsentry/foundational-storage:${{ github.sha }}-arm64
+
+          docker manifest push ghcr.io/getsentry/foundational-storage:latest
+
+          docker manifest create \
+            ghcr.io/getsentry/foundational-storage:nightly \
+            --amend ghcr.io/getsentry/foundational-storage:${{ github.sha }}-amd64 \
+            --amend ghcr.io/getsentry/foundational-storage:${{ github.sha }}-arm64
+
+          docker manifest push ghcr.io/getsentry/foundational-storage:nightly

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV CARGO_FEATURES=${CARGO_FEATURES}
 
 RUN apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends protobuf-compiler \
+    && apt-get install -y --no-install-recommends protobuf-compiler libssl-dev pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build-planner /work/recipe.json recipe.json


### PR DESCRIPTION
builds a multi-arch image and, for merges to `master`, pushes that image to GHCR. [swiped from taskbroker](https://github.com/getsentry/taskbroker/blob/main/.github/workflows/image.yml) (thanks, taskbroker team!)

just a starting point for whatever we ultimately want to do w.r.t. registries, CD, etc