### PR TITLE
chore: Remove unused .env file with postgres env

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-DATABASE_URL="postgres://postgres@localhost"


### PR DESCRIPTION
This is a leftover from when we had postgres included and is no longer needed.