### PR TITLE
Make stresstest allocate its own keys

### DIFF
--- a/stresstest/example.yaml
+++ b/stresstest/example.yaml
@@ -1,4 +1,5 @@
 remote: http://localhost:8888
+# remote: http://localhost:8333
 prefix: some/bucket
 
 duration: 5s

--- a/stresstest/src/http.rs
+++ b/stresstest/src/http.rs
@@ -1,10 +1,10 @@
 use std::io::Read;
 
 use reqwest::Body;
-use serde::Deserialize;
+// use serde::Deserialize;
 use tokio_util::io::ReaderStream;
 
-use crate::workload::Payload;
+use crate::workload::{InternalId, Payload};
 
 pub struct HttpRemote {
     pub remote: String,
@@ -12,24 +12,25 @@ pub struct HttpRemote {
     pub client: reqwest::Client,
 }
 
-#[derive(Debug, Deserialize)]
-struct PutBlobResponse {
-    key: String,
-}
+// #[derive(Debug, Deserialize)]
+// struct PutBlobResponse {
+//     key: String,
+// }
 
 impl HttpRemote {
-    pub async fn write(&self, payload: Payload) -> String {
+    pub async fn write(&self, id: InternalId, payload: Payload) -> String {
         let stream = ReaderStream::new(payload);
 
-        let put_url = format!("{}/{}", self.remote, self.prefix);
-        let response = self
+        let key = format!("{}/{id}", self.prefix);
+        let put_url = format!("{}/{}", self.remote, key);
+        let _response = self
             .client
             .put(put_url)
             .body(Body::wrap_stream(stream))
             .send()
             .await
             .unwrap();
-        let PutBlobResponse { key } = response.json().await.unwrap();
+        // let response = response.json().await.unwrap();
 
         key
     }

--- a/stresstest/src/stresstest.rs
+++ b/stresstest/src/stresstest.rs
@@ -137,7 +137,7 @@ async fn run_workload(
                     match action {
                         Action::Write(internal_id, payload) => {
                             let file_size = payload.len;
-                            let external_id = remote.write(payload).await;
+                            let external_id = remote.write(internal_id, payload).await;
                             workload.lock().unwrap().push_file(internal_id, external_id);
                             let mut metrics = metrics.lock().unwrap();
                             metrics.write_timing.add(start.elapsed().as_secs_f64());

--- a/stresstest/src/workload.rs
+++ b/stresstest/src/workload.rs
@@ -1,6 +1,6 @@
 use std::pin::Pin;
 use std::thread::available_parallelism;
-use std::{io, task};
+use std::{fmt, io, task};
 
 use rand::rngs::SmallRng;
 use rand::{Rng, RngCore, SeedableRng};
@@ -160,8 +160,14 @@ impl Workload {
     }
 }
 
-#[derive(Eq, Hash, PartialEq)]
+#[derive(Eq, Hash, PartialEq, Clone, Copy)]
 pub struct InternalId(u64);
+
+impl fmt::Display for InternalId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 pub type ExternalId = String;
 


### PR DESCRIPTION
Instead of using the opaque "allocate me some ids" request, it will now use its own random ids as keys, so that makes it work with any s3-compatible storage directly.