### PR TITLE
ci: Render and deploy cargo docs to GH pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,3 +108,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v4
+        if: github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,31 @@ jobs:
 
       - name: Run Tests
         run: cargo test --workspace --all-features
+
+  docs:
+    name: Cargo Docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --component rust-docs --no-self-update
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          key: ${{ github.job }}
+
+      - name: Build Docs
+        run: cargo doc --workspace --all-features --no-deps
+        env:
+          RUSTDOCFLAGS: -Dwarnings
+
+      - run: echo '<meta http-equiv="refresh" content="0; url=objectstore-server/" />Redirecting to <a href="objectstore-server/">objectstore-server</a>' > target/doc/index.html
+
+      - name: Deploy
+        # if: github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: target/doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,11 @@ jobs:
     name: Cargo Docs
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
     steps:
       - uses: actions/checkout@v4
 
@@ -93,9 +98,13 @@ jobs:
 
       - run: echo '<meta http-equiv="refresh" content="0; url=objectstore-server/" />Redirecting to <a href="objectstore-server/">objectstore-server</a>' > target/doc/index.html
 
-      - name: Deploy
-        # if: github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: target/doc
+          path: "target/doc"
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         env:
           RUSTDOCFLAGS: -Dwarnings
 
-      - run: echo '<meta http-equiv="refresh" content="0; url=objectstore-server/" />Redirecting to <a href="objectstore-server/">objectstore-server</a>' > target/doc/index.html
+      - run: echo '<meta http-equiv="refresh" content="0; url=objectstore/" />Redirecting to <a href="objectstore/">objectstore</a>' > target/doc/index.html
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,11 @@ jobs:
       - name: Install Rust Toolchain
         run: rustup toolchain install stable --profile minimal --component rust-docs --no-self-update
 
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: swatinem/rust-cache@v2
         with:
           key: ${{ github.job }}


### PR DESCRIPTION
Uses the same approach as Relay to render cargo docs and deploy them to GitHub
pages so that they can be accessed via getsentry.github.io/objectstore. This
allows us to publish code-level architecture documentation and usage docs for
the Rust client.

