### PR TITLE
test: Add an integration test using stresstest as a library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,6 +471,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,6 +1442,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,10 +1526,13 @@ dependencies = [
  "figment",
  "futures-util",
  "jsonwebtoken",
+ "nix",
  "objectstore-service",
+ "rand",
  "sentry",
  "serde",
  "serde_json",
+ "stresstest",
  "tempfile",
  "tokio",
  "tokio-stream",

--- a/objectstore-server/Cargo.toml
+++ b/objectstore-server/Cargo.toml
@@ -13,6 +13,7 @@ figment = { version = "0.10.19", features = ["env", "test", "yaml"] }
 futures-util = "0.3.31"
 jsonwebtoken = "9.3.1"
 objectstore-service = { path = "../objectstore-service" }
+rand = { version = "0.9.1" }
 sentry = { version = "0.41.0", features = [
     "tower-axum-matched-path",
     "tracing",
@@ -28,7 +29,9 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 uuid = { version = "1.17.0", features = ["v4", "v7"] }
 
 [dev-dependencies]
+nix = { version = "0.30.1", features = ["signal"] }
 serde_json = "1.0.140"
+stresstest = { path = "../stresstest" }
 tempfile = "3.20.0"
 
 [[bin]]

--- a/objectstore-server/tests/stresstest.rs
+++ b/objectstore-server/tests/stresstest.rs
@@ -1,0 +1,56 @@
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+use nix::sys::signal::{self, Signal};
+use nix::unistd::Pid;
+use stresstest::Workload;
+use stresstest::http::HttpRemote;
+
+const OBJECTSTORE_EXE: &str = env!("CARGO_BIN_EXE_objectstore");
+const JWT_SECRET: &str = "secret";
+
+fn assert_clean_shutdown(mut child: Child) {
+    // Send SIGINT to the child process
+    let pid = Pid::from_raw(child.id() as i32);
+    signal::kill(pid, Signal::SIGINT).expect("Failed to send SIGINT");
+
+    // Wait for the process to exit and retrieve its exit code
+    let output = child.wait().expect("Failed to wait on child process");
+
+    assert!(
+        output.success(),
+        "Process exited with non-zero status: {:?}",
+        output.code()
+    );
+}
+
+#[tokio::test]
+async fn test_basic() {
+    // generate a random number between 10k and 20k as port number for the server
+    let port = 10000 + rand::random::<u16>() % 10000;
+    let addr = format!("127.0.0.1:{port}");
+
+    let child = Command::new(OBJECTSTORE_EXE)
+        .env("FSS_HTTP_ADDR", &addr)
+        .env("FSS_JWT_SECRET", JWT_SECRET)
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("Failed to spawn subprocess");
+
+    // Give the server time to start.
+    std::thread::sleep(Duration::from_secs(1));
+
+    let remote = HttpRemote::new(format!("http://{addr}")).with_secret(JWT_SECRET);
+    let workload = Workload::builder("test")
+        .concurrency(10)
+        .size_distribution(1000, 10_000)
+        .action_weights(8, 1, 1)
+        .build();
+
+    stresstest::run(remote, vec![workload], Duration::from_secs(10))
+        .await
+        .expect("Failed to run stress test");
+
+    assert_clean_shutdown(child);
+}

--- a/objectstore-server/tests/stresstest.rs
+++ b/objectstore-server/tests/stresstest.rs
@@ -10,11 +10,9 @@ const OBJECTSTORE_EXE: &str = env!("CARGO_BIN_EXE_objectstore");
 const JWT_SECRET: &str = "secret";
 
 fn assert_clean_shutdown(mut child: Child) {
-    // Send SIGINT to the child process
     let pid = Pid::from_raw(child.id() as i32);
     signal::kill(pid, Signal::SIGINT).expect("Failed to send SIGINT");
 
-    // Wait for the process to exit and retrieve its exit code
     let output = child.wait().expect("Failed to wait on child process");
 
     assert!(
@@ -26,7 +24,6 @@ fn assert_clean_shutdown(mut child: Child) {
 
 #[tokio::test]
 async fn test_basic() {
-    // generate a random number between 10k and 20k as port number for the server
     let port = 10000 + rand::random::<u16>() % 10000;
     let addr = format!("127.0.0.1:{port}");
 
@@ -38,7 +35,7 @@ async fn test_basic() {
         .spawn()
         .expect("Failed to spawn subprocess");
 
-    // Give the server time to start.
+    // Give the server time to start, or else stresstest might fail to connect.
     std::thread::sleep(Duration::from_secs(1));
 
     let remote = HttpRemote::new(format!("http://{addr}")).with_secret(JWT_SECRET);

--- a/stresstest/src/lib.rs
+++ b/stresstest/src/lib.rs
@@ -1,0 +1,23 @@
+//! This is a stresstest library which can run different [`Workload`]s against
+//! a backend storage service.
+//!
+//! The [`Workload`] currently supports configuring a *LogNormal* distribution
+//! of file sizes, defined by the `p50` and `p99` of file sizes.
+//! This models our real-world distribution of many small files, with a long
+//! tail of larger files as well.
+//!
+//! It also allows configuring a distribution of actions, such as write, read or delete.
+//! The goal is that we have a lot of *write-heavy* workloads which only write
+//! blobs, but never read those.
+//!
+//! *Read* or *delete* actions are using a *zipfian* distribution, meaning that
+//! more recently written blobs are the ones that will be read/deleted.
+#![warn(missing_docs)]
+#![warn(missing_debug_implementations)]
+
+pub mod http;
+pub mod stresstest;
+pub mod workload;
+
+pub use crate::stresstest::run;
+pub use crate::workload::Workload;

--- a/stresstest/src/stresstest.rs
+++ b/stresstest/src/stresstest.rs
@@ -1,3 +1,5 @@
+//! Run workloads concurrently against a remote storage service and print metrics.
+
 use std::fmt;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -13,11 +15,11 @@ use yansi::Paint;
 use crate::http::HttpRemote;
 use crate::workload::{Action, Workload};
 
-pub async fn perform_stresstest(
-    remote: HttpRemote,
-    workloads: Vec<Workload>,
-    duration: Duration,
-) -> Result<()> {
+/// Runs the given workloads concurrently against the remote.
+///
+/// The function runs all workloads concurrently, then prints metrics and finally deletes all
+/// objects from the remote.
+pub async fn run(remote: HttpRemote, workloads: Vec<Workload>, duration: Duration) -> Result<()> {
     let remote = Arc::new(remote);
     // run the workloads concurrently
     let tasks: Vec<_> = workloads


### PR DESCRIPTION
Adds an integration test to the `objectstore-server` crate that spawns the full
server in a subprocess and then runs the stresstest against it for 10 seconds.

To do so, the `stresstest` crate has been split into a library and binary:
- Workload definition and the stresstest itself are in the library and can be
  called via `stresstest::run`.
- YAML configuration and a main function that reads config, configures
  workloads, and then runs the stresstest remain in the binary.

The initial stresstest integration test is not meant to mimic any real workload
and it does not run in release mode. Rather, it is used to integration-test the
stresstest with the binary. In a follow-up, I want to use `objectstore-sdk` in
stresstest, to ensure the client can talk to the server.

