### PR TITLE
Implement the Rust-based Client as well

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tracing",
 ]
@@ -148,7 +148,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2",
+ "socket2 0.5.10",
  "time",
  "tracing",
  "url",
@@ -233,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40f6024f3f856663b45fd0c9b6f2024034a702f453549449e0d84a305900dad4"
+checksum = "ddb939d66e4ae03cee6091612804ba446b12878410cfa17f785f4dd67d4014e8"
 dependencies = [
  "futures-core",
  "memchr",
@@ -1068,7 +1068,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1511,6 +1511,15 @@ dependencies = [
 name = "objectstore-client"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "async-compression",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "jsonwebtoken",
+ "reqwest",
+ "serde",
+ "tokio-util",
  "uuid",
 ]
 
@@ -2437,6 +2446,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2630,9 +2649,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2643,9 +2662,9 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/objectstore-sdk/Cargo.toml
+++ b/objectstore-sdk/Cargo.toml
@@ -4,4 +4,13 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+anyhow = "1.0.98"
+async-compression = { version = "0.4.27", features = ["tokio", "zstd"] }
+bytes = "1.10.1"
+futures-core = "0.3.31"
+futures-util = "0.3.31"
+jsonwebtoken = "9.3.1"
+reqwest = { version = "0.12.22", features = ["stream", "json"] }
+serde = { version = "1.0.219", features = ["derive"] }
+tokio-util = { version = "0.7.15", features = ["io"] }
 uuid = { version = "1.17.0", features = ["v4"] }

--- a/objectstore-service/src/metadata.rs
+++ b/objectstore-service/src/metadata.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
 /// The storage scope for each object
@@ -10,7 +10,7 @@ use std::time::Duration;
 /// The organization / project scope defined here is hierarchical in the sense that
 /// analytical aggregations on an organzation level take into account all the project-level objects.
 /// However, accessing an object requires supplying both of these original values in order to retrieve it.
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct Scope {
     /// The organization ID


### PR DESCRIPTION
This implements the Client SDK in Rust as well. In a next step, this can be used directly in the stresstest to speak with our service.