### PR TITLE
ref(deps): Update elegant-departure to 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,12 +609,11 @@ dependencies = [
 
 [[package]]
 name = "elegant-departure"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "259261d0b72dc618a177af380b2944fa44e22fedbdabb920f7b47edffb1df337"
+checksum = "dd2dc636be64a7402771c4c26324d9fe6c6a36a3d718bc33047aaee981e0fa13"
 dependencies = [
- "futures",
- "lazy_static",
+ "futures-util",
  "pin-project-lite",
  "tokio",
  "tokio-util",

--- a/objectstore-server/Cargo.toml
+++ b/objectstore-server/Cargo.toml
@@ -8,7 +8,7 @@ anyhow = "1.0.98"
 argh = "0.1.13"
 axum = "0.8.4"
 axum-extra = "0.10.1"
-elegant-departure = { version = "0.3.1", features = ["tokio"] }
+elegant-departure = { version = "0.3.2", features = ["tokio"] }
 figment = { version = "0.10.19", features = ["env", "test", "yaml"] }
 futures-util = "0.3.31"
 jsonwebtoken = "9.3.1"

--- a/objectstore-server/src/http.rs
+++ b/objectstore-server/src/http.rs
@@ -35,13 +35,10 @@ pub async fn start_server(state: ServiceState) {
         .into_make_service();
 
     tracing::info!("HTTP server listening on {http_addr}");
-    let _guard = elegant_departure::get_shutdown_guard();
+    let guard = elegant_departure::get_shutdown_guard().shutdown_on_drop();
     let listener = tokio::net::TcpListener::bind(http_addr).await.unwrap();
     axum::serve(listener, app)
-        .with_graceful_shutdown(async {
-            let guard = elegant_departure::get_shutdown_guard();
-            guard.wait().await;
-        })
+        .with_graceful_shutdown(guard.wait_owned())
         .await
         .unwrap();
 }


### PR DESCRIPTION
0.3.2 introduces the `wait_owned()` wait variant which makes axum's `with_graceful_shutdown` a bit nicer.

Also a drive-by change, adding `.shutdown_on_drop()` to the guard, as presumably the service should stop if axum fails/panics.