### PR TITLE
Cleans up client stream errors, renames things

### DIFF
--- a/objectstore-client/Cargo.toml
+++ b/objectstore-client/Cargo.toml
@@ -9,9 +9,10 @@ async-compression = { version = "0.4.27", features = ["tokio", "zstd"] }
 bytes = "1.10.1"
 futures-util = "0.3.31"
 jsonwebtoken = "9.3.1"
-objectstore-types = { version = "0.1.0", path = "../objectstore-types" }
+objectstore-types = { path = "../objectstore-types" }
 reqwest = { version = "0.12.22", features = ["stream", "json"] }
 serde = { version = "1.0.219", features = ["derive"] }
+tokio = "1.47.0"
 tokio-util = { version = "0.7.15", features = ["io"] }
 uuid = { version = "1.17.0", features = ["v4"] }
 

--- a/objectstore-client/src/tests.rs
+++ b/objectstore-client/src/tests.rs
@@ -14,7 +14,7 @@ use super::*;
 #[tokio::test]
 async fn stores_uncompressed() {
     let server = TestServer::new();
-    let client = StorageService::new(&server.url("/"), "TEST", "test")
+    let client = ClientBuilder::new(&server.url("/"), "TEST", "test")
         .unwrap()
         .for_organization(12345);
 
@@ -25,7 +25,8 @@ async fn stores_uncompressed() {
         .buffer(body)
         .send()
         .await
-        .unwrap();
+        .unwrap()
+        .key;
     assert_eq!(stored_id, "foo");
 
     let GetResult {
@@ -41,12 +42,12 @@ async fn stores_uncompressed() {
 #[tokio::test]
 async fn uses_zstd_by_default() {
     let server = TestServer::new();
-    let client = StorageService::new(&server.url("/"), "TEST", "test")
+    let client = ClientBuilder::new(&server.url("/"), "TEST", "test")
         .unwrap()
         .for_organization(12345);
 
     let body = "oh hai!";
-    let stored_id = client.put("foo").buffer(body).send().await.unwrap();
+    let stored_id = client.put("foo").buffer(body).send().await.unwrap().key;
     assert_eq!(stored_id, "foo");
 
     // when the user indicates that it can deal with zstd, it gets zstd
@@ -78,7 +79,7 @@ async fn uses_zstd_by_default() {
 #[tokio::test]
 async fn stores_compressed_zstd() {
     let server = TestServer::new();
-    let client = StorageService::new(&server.url("/"), "TEST", "test")
+    let client = ClientBuilder::new(&server.url("/"), "TEST", "test")
         .unwrap()
         .for_organization(12345);
 
@@ -90,7 +91,8 @@ async fn stores_compressed_zstd() {
         .buffer(compressed.clone())
         .send()
         .await
-        .unwrap();
+        .unwrap()
+        .key;
     assert_eq!(stored_id, "foo");
 
     // when the user indicates that it can deal with zstd, it gets zstd
@@ -121,12 +123,12 @@ async fn stores_compressed_zstd() {
 #[tokio::test]
 async fn deletes_stores_stuff() {
     let server = TestServer::new();
-    let client = StorageService::new(&server.url("/"), "TEST", "test")
+    let client = ClientBuilder::new(&server.url("/"), "TEST", "test")
         .unwrap()
         .for_organization(12345);
 
     let body = "oh hai!";
-    let stored_id = client.put("foo").buffer(body).send().await.unwrap();
+    let stored_id = client.put("foo").buffer(body).send().await.unwrap().key;
     assert_eq!(stored_id, "foo");
 
     client.delete(&stored_id).await.unwrap();

--- a/objectstore-server/src/http.rs
+++ b/objectstore-server/src/http.rs
@@ -1,5 +1,6 @@
 #![allow(unused)]
 
+use std::io;
 use std::sync::Arc;
 
 use axum::body::{Body, to_bytes};
@@ -60,7 +61,7 @@ async fn put_blob_no_key(
     let key = claim.into_key(Uuid::new_v4().to_string());
     let metadata = extract_metadata_from_headers(&headers)?;
 
-    let stream = body.into_data_stream().map_err(anyhow::Error::from).boxed();
+    let stream = body.into_data_stream().map_err(io::Error::other).boxed();
     state.service.put_file(&key, &metadata, stream).await?;
 
     Ok(Json(PutBlobResponse { key: key.key }))
@@ -78,7 +79,7 @@ async fn put_blob(
     let key = claim.into_key(key);
     let metadata = extract_metadata_from_headers(&headers)?;
 
-    let stream = body.into_data_stream().map_err(anyhow::Error::from).boxed();
+    let stream = body.into_data_stream().map_err(io::Error::other).boxed();
     state.service.put_file(&key, &metadata, stream).await?;
 
     Ok(Json(PutBlobResponse { key: key.key }))

--- a/objectstore-service/Cargo.toml
+++ b/objectstore-service/Cargo.toml
@@ -12,7 +12,7 @@ bytes = "1.10.1"
 futures-util = "0.3.31"
 gcp_auth = "0.12.3"
 humantime = "2.2.0"
-objectstore-types = { version = "0.1.0", path = "../objectstore-types" }
+objectstore-types = { path = "../objectstore-types" }
 pack1 = "1.0.0"
 reqwest = { version = "0.12.22", features = ["stream"] }
 serde = { version = "1.0.219", features = ["derive"] }

--- a/objectstore-service/src/backend/local_fs.rs
+++ b/objectstore-service/src/backend/local_fs.rs
@@ -2,7 +2,7 @@ use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::pin::pin;
 
-use futures_util::{StreamExt, TryStreamExt};
+use futures_util::StreamExt;
 use objectstore_types::Metadata;
 use tokio::fs::OpenOptions;
 use tokio::io::{AsyncWriteExt, BufWriter};
@@ -37,7 +37,6 @@ impl Backend for LocalFs {
             .open(path)
             .await?;
 
-        let stream = stream.map_err(std::io::Error::other);
         let mut reader = pin!(StreamReader::new(stream));
         let mut writer = BufWriter::new(file);
 
@@ -60,7 +59,7 @@ impl Backend for LocalFs {
             err => err?,
         };
 
-        let stream = ReaderStream::new(file).map_err(anyhow::Error::from);
+        let stream = ReaderStream::new(file);
         Ok(Some((Default::default(), stream.boxed())))
     }
 

--- a/objectstore-service/src/backend/mod.rs
+++ b/objectstore-service/src/backend/mod.rs
@@ -1,4 +1,5 @@
 use std::fmt::Debug;
+use std::io;
 
 use bytes::Bytes;
 use futures_util::stream::BoxStream;
@@ -12,7 +13,7 @@ use objectstore_types::Metadata;
 pub use s3_compatible::S3Compatible;
 
 pub type BoxedBackend = Box<dyn Backend>;
-pub type BackendStream = BoxStream<'static, anyhow::Result<Bytes>>;
+pub type BackendStream = BoxStream<'static, io::Result<Bytes>>;
 
 #[async_trait::async_trait]
 pub trait Backend: Debug + Send + Sync + 'static {

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -1,6 +1,6 @@
-use std::fmt;
 use std::str::FromStr;
 use std::time::SystemTime;
+use std::{fmt, io};
 
 use futures_util::{StreamExt, TryStreamExt};
 use humantime::format_rfc3339_seconds;
@@ -135,7 +135,7 @@ impl<T: TokenProvider> Backend for S3Compatible<T> {
         }
         // TODO: the object *GET* should probably also contain the expiration time
 
-        let stream = response.bytes_stream().map_err(anyhow::Error::from);
+        let stream = response.bytes_stream().map_err(io::Error::other);
         Ok(Some((metadata, stream.boxed())))
     }
 

--- a/objectstore-service/src/lib.rs
+++ b/objectstore-service/src/lib.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use anyhow::Context;
 use async_compression::tokio::bufread::ZstdDecoder;
 use bytes::Bytes;
-use futures_util::{Stream, StreamExt, TryStreamExt};
+use futures_util::{Stream, StreamExt};
 use tokio::io::{AsyncReadExt, BufReader};
 use tokio_util::io::StreamReader;
 use uuid::Uuid;
@@ -116,7 +116,6 @@ impl StorageService {
             return Ok(None);
         };
 
-        let stream = stream.map_err(std::io::Error::other);
         let mut reader = BufReader::new(StreamReader::new(stream));
 
         let mut metadata_buf = vec![0; mem::size_of::<Part>()];
@@ -210,7 +209,6 @@ impl StorageService {
             return Ok(None);
         };
 
-        let stream = stream.map_err(std::io::Error::other);
         let mut reader = BufReader::new(StreamReader::new(stream));
 
         let mut metadata_buf = vec![0; mem::size_of::<Part>()];
@@ -237,6 +235,7 @@ impl StorageService {
 #[cfg(test)]
 mod tests {
     use bytes::BytesMut;
+    use futures_util::TryStreamExt;
     use objectstore_types::Scope;
 
     use super::*;

--- a/stresstest/Cargo.toml
+++ b/stresstest/Cargo.toml
@@ -12,7 +12,7 @@ futures = "0.3.31"
 futures-util = "0.3.31"
 humantime-serde = "1.1.1"
 jsonwebtoken = "9.3.1"
-objectstore-client = { version = "0.1.0", path = "../objectstore-client" }
+objectstore-client = { path = "../objectstore-client" }
 rand = { version = "0.9.1", features = ["small_rng"] }
 rand_distr = "0.5.1"
 reqwest = { version = "0.12.20", features = ["json", "stream", "multipart"] }

--- a/stresstest/src/workload.rs
+++ b/stresstest/src/workload.rs
@@ -208,18 +208,6 @@ pub struct Payload {
     pub rng: SmallRng,
 }
 
-// impl io::Read for Payload {
-//     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-//         let len_to_fill = (buf.len() as u64).min(self.len) as usize;
-
-//         let fill_buf = &mut buf[..len_to_fill];
-//         self.rng.fill_bytes(fill_buf);
-
-//         self.len -= len_to_fill as u64;
-//         Ok(len_to_fill)
-//     }
-// }
-
 impl AsyncRead for Payload {
     fn poll_read(
         mut self: Pin<&mut Self>,


### PR DESCRIPTION
This is mostly a followup addressing some other review comments.

The primary change is that it changes the Stream Error type into `io::Error` from `anyhow::Error`.

Otherwise, renames the `Client/Builder`, and adds a new convenience method to pass an `AsyncRead` (such as a tokio `File` handle) as an upload source.