### PR TITLE
Output metadata on GET

### DIFF
--- a/objectstore-server/src/http.rs
+++ b/objectstore-server/src/http.rs
@@ -98,7 +98,8 @@ async fn get_blob(
         return Ok(StatusCode::NOT_FOUND.into_response());
     };
 
-    Ok(Body::from_stream(stream).into_response())
+    let headers = metadata.to_headers("", false)?;
+    Ok((headers, Body::from_stream(stream)).into_response())
 }
 
 #[tracing::instrument(level = "trace", skip_all, fields(usecase, scope, key))]

--- a/objectstore-service/src/backend/local_fs.rs
+++ b/objectstore-service/src/backend/local_fs.rs
@@ -35,8 +35,9 @@ impl Backend for LocalFs {
         let path = self.path.join(path);
         tokio::fs::create_dir_all(path.parent().unwrap()).await?;
         let file = OpenOptions::new()
+            .create(true)
             .write(true)
-            .create_new(true)
+            .truncate(true)
             .open(path)
             .await?;
 


### PR DESCRIPTION
This will now correctly output all the metadata, like compression on GET requests.

As another change, the local FS backend will now correctly overwrite files.