### PR TITLE
feat(stresstest): Implement throughput mode

### DIFF
--- a/stresstest/example.yaml
+++ b/stresstest/example.yaml
@@ -1,14 +1,18 @@
 remote: http://localhost:8888
-jwt_secret: TODO
+jwt_secret: ""
 
 duration: 5s
 
 workloads:
   - name: attachments
-    concurrency: 8
+    mode: throughput
     file_sizes:
       p50: 50 KiB
       p99: 200 KiB
+    actions:
+      writes: 10
+      reads: 0
+      deletes: 0
   - name: profiling
     concurrency: 8
     file_sizes:

--- a/stresstest/src/config.rs
+++ b/stresstest/src/config.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use bytesize::ByteSize;
 use serde::Deserialize;
+use stresstest::workload::WorkloadMode;
 
 #[derive(Debug, Deserialize)]
 pub struct Config {
@@ -17,7 +18,10 @@ pub struct Config {
 #[derive(Debug, Deserialize)]
 pub struct Workload {
     pub name: String,
+    #[serde(default)]
     pub concurrency: usize,
+    #[serde(default)]
+    pub mode: WorkloadMode,
     pub file_sizes: FileSizes,
     #[serde(default)]
     pub actions: Actions,
@@ -31,9 +35,9 @@ pub struct FileSizes {
 
 #[derive(Debug, Deserialize)]
 pub struct Actions {
-    pub writes: u8,
-    pub reads: u8,
-    pub deletes: u8,
+    pub writes: usize,
+    pub reads: usize,
+    pub deletes: usize,
 }
 
 impl Default for Actions {

--- a/stresstest/src/main.rs
+++ b/stresstest/src/main.rs
@@ -50,6 +50,7 @@ async fn main() -> anyhow::Result<()> {
         .map(|w| {
             Workload::builder(w.name)
                 .concurrency(w.concurrency)
+                .mode(w.mode)
                 .size_distribution(w.file_sizes.p50.0, w.file_sizes.p99.0)
                 .action_weights(w.actions.writes, w.actions.reads, w.actions.deletes)
                 .build()

--- a/stresstest/src/workload.rs
+++ b/stresstest/src/workload.rs
@@ -178,28 +178,28 @@ impl Workload {
         let elapsed = self.start_time.get_or_insert_with(Instant::now).elapsed();
 
         // Prioritize writes to create readback.
-        if (self.totals.writes as f64) < (elapsed.as_secs_f64() * (write_throughput as f64)) {
+        if (self.totals.writes as f64) < (elapsed.as_secs_f64() * write_throughput as f64) {
             self.totals.writes += 1;
             let seed = self.rng.next_u64();
             return Some(Action::Write(InternalId(seed), self.get_payload(seed)));
         }
 
-        if (self.totals.reads as f64) < elapsed.as_secs_f64() * (read_throughput as f64) {
-            if let Some((internal, external)) = self.sample_readback() {
-                self.totals.reads += 1;
-                return Some(Action::Read(
-                    internal,
-                    external,
-                    self.get_payload(internal.0),
-                ));
-            };
+        if (self.totals.reads as f64) < elapsed.as_secs_f64() * read_throughput as f64
+            && let Some((internal, external)) = self.sample_readback()
+        {
+            self.totals.reads += 1;
+            return Some(Action::Read(
+                internal,
+                external,
+                self.get_payload(internal.0),
+            ));
         }
 
-        if (self.totals.deletes as f64) < elapsed.as_secs_f64() * (delete_throughput as f64) {
-            if let Some((_internal, external)) = self.sample_readback() {
-                self.totals.deletes += 1;
-                return Some(Action::Delete(external));
-            };
+        if (self.totals.deletes as f64) < elapsed.as_secs_f64() * delete_throughput as f64
+            && let Some((_internal, external)) = self.sample_readback()
+        {
+            self.totals.deletes += 1;
+            return Some(Action::Delete(external));
         }
 
         None


### PR DESCRIPTION
Adds a second opt-in mode for stresstests to define constant throughput rather
than constant concurrency. This allows us to test the traffic patterns of our
use case across iterations of the server with different latency. Also, it allows
us to more effectively assess the latency of the service at specific throughput.

