### PR TITLE
Always assign Id from the server

### DIFF
--- a/stresstest/src/http.rs
+++ b/stresstest/src/http.rs
@@ -5,7 +5,7 @@ use objectstore_client::{Client, ClientBuilder, GetResult};
 use tokio::io::AsyncReadExt;
 use tokio_util::io::{ReaderStream, StreamReader};
 
-use crate::workload::{InternalId, Payload};
+use crate::workload::Payload;
 
 /// A remote implementation using HTTP to interact with objectstore.
 #[derive(Debug)]
@@ -25,13 +25,12 @@ impl HttpRemote {
         Self { client }
     }
 
-    pub(crate) async fn write(&self, id: InternalId, payload: Payload) -> String {
+    pub(crate) async fn write(&self, payload: Payload) -> String {
         let stream = ReaderStream::new(payload).boxed();
 
         self.client
-            .put(id.to_string().as_str())
+            .put_stream(stream)
             .compression(None)
-            .stream(stream)
             .send()
             .await
             .unwrap()

--- a/stresstest/src/stresstest.rs
+++ b/stresstest/src/stresstest.rs
@@ -152,7 +152,7 @@ async fn run_workload(
                     match action {
                         Action::Write(internal_id, payload) => {
                             let file_size = payload.len;
-                            let external_id = remote.write(internal_id, payload).await;
+                            let external_id = remote.write(payload).await;
                             workload.lock().unwrap().push_file(internal_id, external_id);
                             let mut metrics = metrics.lock().unwrap();
                             metrics.write_timing.add(start.elapsed().as_secs_f64());


### PR DESCRIPTION
This changes the Client implementation so that object Ids are always assigned and returned from the Server.

We would like to support multiple storage backends, and encode the used backend into the object id. For that to work, the Id need to be controlled by the server/service.

As a driveby change, this also simplifies the `PutBuilder` code a bit.