### PR TITLE
ci(gha): Build release binary natively and switch to distroless image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
           SHA_TAG: ${{ github.sha }}
         run: |
           for PLATFORM in amd64 arm64; do
-            docker load --input /tmp/objectstore-$PLATFORM.tar
+            docker load --input /tmp/objectstore-$PLATFORM
             docker tag $PLATFORM $REGISTRY:$SHA_TAG-$PLATFORM
             docker push $REGISTRY:$SHA_TAG-$PLATFORM
           done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
       - release/**
 
   # NB: Do not build on pull requests by default. Uncomment temporarily to test changes.
-  # pull_request:
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,10 @@ on:
   # NB: Do not build on pull requests by default. Uncomment temporarily to test changes.
   pull_request:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     name: Build ${{ matrix.platform }}
@@ -69,10 +73,6 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     needs: [build]
-
-    permissions:
-      contents: read
-      packages: write
 
     # Intentionally never publish on pull requests
     # if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,9 @@ jobs:
           cargo build --release --target=${{ matrix.target }} --bin objectstore
           cp target/${{ matrix.target }}/release/objectstore ./objectstore
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build Image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,7 @@ jobs:
         with:
           pattern: objectstore-*
           path: /tmp
+          merge-multiple: true
 
       - name: Push to GitHub Container Registry
         env:
@@ -96,7 +97,7 @@ jobs:
           SHA_TAG: ${{ github.sha }}
         run: |
           for PLATFORM in amd64 arm64; do
-            docker load --input /tmp/objectstore-$PLATFORM
+            docker load --input /tmp/objectstore-$PLATFORM.tar
             docker tag $PLATFORM $REGISTRY:$SHA_TAG-$PLATFORM
             docker push $REGISTRY:$SHA_TAG-$PLATFORM
           done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
 
+    permissions:
+      contents: read
+      packages: write
+
     # Intentionally never publish on pull requests
     # if: ${{ github.event_name != 'pull_request' }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
       - release/**
 
   # NB: Do not build on pull requests by default. Uncomment temporarily to test changes.
-  pull_request:
+  # pull_request:
 
 permissions:
   contents: read
@@ -75,7 +75,7 @@ jobs:
     needs: [build]
 
     # Intentionally never publish on pull requests
-    # if: ${{ github.event_name != 'pull_request' }}
+    if: ${{ github.event_name != 'pull_request' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Docker
+name: Build
 
 on:
   push:
@@ -19,21 +19,36 @@ jobs:
         include:
           - os: ubuntu-24.04
             platform: amd64
+            target: x86_64-unknown-linux-gnu
           - os: ubuntu-24.04-arm
             platform: arm64
+            target: aarch64-unknown-linux-gnu
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Install Rust Toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --target ${{ matrix.target }} --no-self-update
 
-      - name: Build
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          key: ${{ github.job }}
+
+      - name: Build Binary
+        run: |
+          cargo build --release --target=${{ matrix.target }} --bin objectstore
+          cp target/${{ matrix.target }}/release/objectstore ./objectstore
+
+      - name: Build Image
         uses: docker/build-push-action@v6
         with:
           context: .
-          cache-from: ghcr.io/getsentry/objectstore:latest
-          cache-to: type=inline
           platforms: linux/${{ matrix.platform }}
           tags: ${{ matrix.platform }}
           outputs: type=docker,dest=/tmp/objectstore-${{ matrix.platform }}.tar
@@ -60,17 +75,11 @@ jobs:
         env:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Download amd64 Image
         uses: actions/download-artifact@v4
         with:
           name: objectstore-amd64
           path: /tmp
-
-      - name: Load amd64 Image
-        run: docker load --input /tmp/objectstore-amd64.tar
 
       - name: Download arm64 Image
         uses: actions/download-artifact@v4
@@ -78,27 +87,20 @@ jobs:
           name: objectstore-arm64
           path: /tmp
 
-      - name: Load arm64 Image
-        run: docker load --input /tmp/objectstore-arm64.tar
-
       - name: Push to GitHub Container Registry
+        env:
+          REGISTRY: ghcr.io/getsentry/objectstore
+          SHA_TAG: ${{ github.sha }}
         run: |
-          docker tag amd64 ghcr.io/getsentry/objectstore:${{ github.sha }}-amd64
-          docker push ghcr.io/getsentry/objectstore:${{ github.sha }}-amd64
+          for PLATFORM in amd64 arm64; do
+            docker load --input /tmp/objectstore-$PLATFORM.tar
+            docker tag $PLATFORM $REGISTRY:$SHA_TAG-$PLATFORM
+            docker push $REGISTRY:$SHA_TAG-$PLATFORM
+          done
 
-          docker tag arm64 ghcr.io/getsentry/objectstore:${{ github.sha }}-arm64
-          docker push ghcr.io/getsentry/objectstore:${{ github.sha }}-arm64
-
-          docker manifest create \
-            ghcr.io/getsentry/objectstore:${{ github.sha }} \
-            --amend ghcr.io/getsentry/objectstore:${{ github.sha }}-amd64 \
-            --amend ghcr.io/getsentry/objectstore:${{ github.sha }}-arm64
-
-          docker manifest push ghcr.io/getsentry/objectstore:${{ github.sha }}
-
-          docker manifest create \
-            ghcr.io/getsentry/objectstore:latest \
-            --amend ghcr.io/getsentry/objectstore:${{ github.sha }}-amd64 \
-            --amend ghcr.io/getsentry/objectstore:${{ github.sha }}-arm64
-
-          docker manifest push ghcr.io/getsentry/objectstore:latest
+          for TAG in $SHA_TAG latest; do
+            docker manifest create $REGISTRY:$TAG \
+              --amend $REGISTRY:$SHA_TAG-amd64 \
+              --amend $REGISTRY:$SHA_TAG-arm64
+            docker manifest push $REGISTRY:$TAG
+          done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,9 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Ensure a clean build on release, use caches when building main.
       - uses: swatinem/rust-cache@v2
+        if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
         with:
           key: ${{ github.job }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
     needs: [build]
 
     # Intentionally never publish on pull requests
-    if: ${{ github.event_name != 'pull_request' }}
+    # if: ${{ github.event_name != 'pull_request' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -80,16 +80,10 @@ jobs:
         env:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download amd64 Image
-        uses: actions/download-artifact@v4
+      - name: Download Images
+        uses: actions/download-artifact@v5
         with:
-          name: objectstore-amd64
-          path: /tmp
-
-      - name: Download arm64 Image
-        uses: actions/download-artifact@v4
-        with:
-          name: objectstore-arm64
+          pattern: objectstore-*
           path: /tmp
 
       - name: Push to GitHub Container Registry

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,44 +1,10 @@
-FROM rust:slim-bookworm AS build-chef
-
-WORKDIR /work
-RUN cargo install cargo-chef --locked
-
-FROM build-chef AS build-planner
-
-COPY . .
-RUN cargo chef prepare --recipe-path recipe.json --bin objectstore
-
-FROM build-chef AS build-server
-
-ARG CARGO_FEATURES=""
-ENV CARGO_FEATURES=${CARGO_FEATURES}
-
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev libssl-dev pkg-config \
-    && rm -rf /var/lib/apt/lists/*
-
-COPY --from=build-planner /work/recipe.json recipe.json
-
-RUN cargo chef cook --release --features=${CARGO_FEATURES} --recipe-path recipe.json
-
-COPY . .
-
-# NOTE: Simplified build that leaves debug info in the binary. As the binary grows, we will want to
-# move this out and instead upload it directly to the registry and Sentry.
-RUN cargo build --release --features=${CARGO_FEATURES} --bin objectstore
-
-FROM debian:bookworm-slim
-
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+FROM gcr.io/distroless/cc-debian12
 
 ENV FSS_PATH="/data"
+
+# Copy the pre-built binary
+COPY objectstore /bin/objectstore
+
 VOLUME ["/data"]
-
-COPY --from=build-server /work/target/release/objectstore /bin
-
 ENTRYPOINT ["/bin/objectstore"]
 EXPOSE 8888


### PR DESCRIPTION
Switches to a much smaller and more lightweight distroless Docker base image. The amd64 and arm64 are built directly on the GHA runners and copied into the Docker image.