### PR TITLE
build: Disable debug in dev again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,17 @@ resolver = "3"
 members = ["objectstore-*", "stresstest"]
 default-members = ["objectstore-server"]
 
+[profile.dev]
+# Debug information slows down the build and increases caches in the
+# target folder, but we don't require stack traces in most cases.
+debug = false
+
+[profile.dev-debug]
+# A version of the dev profile with debug information enabled, for e.g. local
+# debugging.
+inherits = "dev"
+debug = true
+
 [profile.release]
 # In release, however, we do want full debug information to report
 # panic and error stack traces to Sentry.


### PR DESCRIPTION
This seems to have been removed unintentionally as a drive-by refactor. Brings
back our usual profile management that we also use in Relay and Symbolicator. 

By default, debug information is disabled in development to speed up the build
and reduce the target folder size. In a `dev-debug` profile or in `release`,
debug information is enabled.

