### PR TITLE
ref(types): Do not depend on reqwest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1876,8 +1876,8 @@ name = "objectstore-types"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "http 1.3.1",
  "humantime",
- "reqwest",
  "serde",
 ]
 

--- a/objectstore-types/Cargo.toml
+++ b/objectstore-types/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0.98"
 humantime = "2.2.0"
-reqwest = { version = "0.12.22", default-features = false }
+http = "1.3.1"
 serde = { version = "1.0.219", features = ["derive"] }

--- a/objectstore-types/src/lib.rs
+++ b/objectstore-types/src/lib.rs
@@ -11,8 +11,8 @@ use std::fmt;
 use std::str::FromStr;
 use std::time::{Duration, SystemTime};
 
+use http::header::{self, HeaderMap, HeaderName};
 use humantime::{format_duration, format_rfc3339_seconds, parse_duration};
-use reqwest::header::{self, HeaderMap, HeaderName};
 use serde::{Deserialize, Serialize};
 
 /// The custom HTTP header that contains the serialized [`ExpirationPolicy`].


### PR DESCRIPTION
The `objectstore-types` create depends on reqwest, while it only requires types
from `http` to represent headers.

To decoulple our types crate from the HTTP client, we change that dependency.

