### PR TITLE
fix(build): Downgrade build runner and use nonroot image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,11 @@ jobs:
           outputs: type=docker,dest=/tmp/objectstore-${{ matrix.platform }}.tar
           push: false
 
+      - name: Test Image
+        run: |
+          docker load --input /tmp/objectstore-${{ matrix.platform }}.tar
+          docker run --rm ${{ matrix.platform }} --help | grep -q '^Usage: objectstore'
+
       - name: Upload Image
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
       - release/**
 
   # NB: Do not build on pull requests by default. Uncomment temporarily to test changes.
-  # pull_request:
+  pull_request:
 
 permissions:
   contents: read
@@ -75,7 +75,7 @@ jobs:
     needs: [build]
 
     # Intentionally never publish on pull requests
-    if: ${{ github.event_name != 'pull_request' }}
+    # if: ${{ github.event_name != 'pull_request' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             platform: amd64
             target: x86_64-unknown-linux-gnu
-          - os: ubuntu-24.04-arm
+          - os: ubuntu-22.04-arm
             platform: arm64
             target: aarch64-unknown-linux-gnu
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
       - release/**
 
   # NB: Do not build on pull requests by default. Uncomment temporarily to test changes.
-  pull_request:
+  # pull_request:
 
 permissions:
   contents: read
@@ -80,7 +80,7 @@ jobs:
     needs: [build]
 
     # Intentionally never publish on pull requests
-    # if: ${{ github.event_name != 'pull_request' }}
+    if: ${{ github.event_name != 'pull_request' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/cc-debian12
+FROM gcr.io/distroless/cc-debian12:nonroot
 
 ENV FSS_PATH="/data"
 


### PR DESCRIPTION
The runner image was too new for objectstore to run on debian-12. This downgrades the runner and adds a smoketest to verify that the binary can run in the container.