### PR TITLE
fix: Support rustls on distroless

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1835,6 +1835,7 @@ dependencies = [
  "objectstore-service",
  "objectstore-types",
  "rand",
+ "rustls",
  "sentry",
  "serde",
  "serde_json",
@@ -2513,9 +2514,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2559,9 +2560,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/objectstore-server/Cargo.toml
+++ b/objectstore-server/Cargo.toml
@@ -15,6 +15,7 @@ jsonwebtoken = "9.3.1"
 objectstore-service = { path = "../objectstore-service" }
 objectstore-types = { path = "../objectstore-types" }
 rand = { version = "0.9.1" }
+rustls = { version = "0.23.31", default-features = false }
 sentry = { version = "0.41.0", features = [
     "tower-axum-matched-path",
     "tracing",

--- a/objectstore-server/src/main.rs
+++ b/objectstore-server/src/main.rs
@@ -54,6 +54,11 @@ fn initialize_tracing(config: &Config) {
 async fn main() -> Result<()> {
     let config = Config::from_env()?;
 
+    // Ensure a rustls crypto provider is installed, required on distroless.
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Failed to install rustls crypto provider");
+
     let _sentry_guard = maybe_initialize_sentry(&config);
     initialize_tracing(&config);
 


### PR DESCRIPTION
To support rustls on distroless, we have to install a crypto provider
explicitly. This is required for gcp_auth.

