### PR TITLE
ref(server): Improve logging

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -33,5 +33,6 @@ source .venv/bin/activate
 
 # Use with `devservices up objectstore --mode=full`
 export BIGTABLE_EMULATOR_HOST=localhost:8086
+export RUST_LOG=debug
 
 source_env_if_exists .envrc.private

--- a/objectstore-server/src/main.rs
+++ b/objectstore-server/src/main.rs
@@ -5,11 +5,13 @@
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
 
+use std::env;
+
 use anyhow::Result;
 use sentry::integrations::tracing as sentry_tracing;
 use tokio::signal::unix::SignalKind;
 use tracing::Level;
-use tracing_subscriber::fmt::format::FmtSpan;
+use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{EnvFilter, prelude::*};
 
 use crate::config::Config;
@@ -33,6 +35,8 @@ fn maybe_initialize_sentry(config: &Config) -> Option<sentry::ClientInitGuard> {
 }
 
 fn initialize_tracing(config: &Config) {
+    // Same as the default filter, except it converts warnings into events
+    // and also sends everything at or above INFO as logs instead of breadcrumbs.
     let sentry_layer = config.sentry_dsn.as_ref().map(|_| {
         sentry_tracing::layer().event_filter(|metadata| match *metadata.level() {
             Level::ERROR | Level::WARN => {
@@ -43,11 +47,41 @@ fn initialize_tracing(config: &Config) {
         })
     });
 
+    let (level, env_filter) = parse_rust_log();
+    let format = tracing_subscriber::fmt::layer()
+        .with_writer(std::io::stderr)
+        .with_target(true);
+
     tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer().with_span_events(FmtSpan::ENTER))
+        .with(format.with_filter(LevelFilter::from(level)))
         .with(sentry_layer)
-        .with(EnvFilter::from_default_env())
+        .with(env_filter)
         .init();
+}
+
+fn parse_rust_log() -> (Level, EnvFilter) {
+    // Try to parse RUST_LOG as a simple level filter and apply default levels internally.
+    // Otherwise, use it literally if the user knows which overrides they want to run.
+    let level = match env::var(EnvFilter::DEFAULT_ENV) {
+        Ok(value) => match value.parse::<Level>() {
+            Ok(level) => level,
+            Err(_) => return (Level::TRACE, EnvFilter::new(value)),
+        },
+        Err(_) => Level::INFO,
+    };
+
+    // This is the maximum verbosity that will be logged, we filter this down to `level`.
+    let env_filter = EnvFilter::new(
+        "INFO,\
+        tower_http=TRACE,\
+        trust_dns_proto=WARN,\
+        objectstore_server=TRACE,\
+        objectstore_service=TRACE,\
+        objectstore_types=TRACE,\
+        ",
+    );
+
+    (level, env_filter)
 }
 
 #[tokio::main]


### PR DESCRIPTION
We still support `RUST_LOG`, but objectstore now applies better defaults on its
own dependencies to reduce noise in logging.

By default, objectstore uses INFO as log level. In our own development
environment we override this to DEBUG, so we have more visibility by default.
TRACE would be possible, too, but is quite verbose for a usual test run.

If the user configures complex `RUST_LOG` directives, we will still honor them
and apply them directly as env filter to the tracing library. If `RUST_LOG` is
set to a simple level, however, we apply custom logic:
 - Our own crates and `tower_http` will go up to TRACE, but no higher than the
   configured log level from `RUST_LOG`.
 - `trust_dns_proto` is known to be very spammy on INFO, so we mute it to `WARN`.
 - Everything else logs on `INFO`.

The Sentry SDK receives all logs independent of the configured filter.

Refs FS-114
