### PR TITLE
Add a second storage backend

### DIFF
--- a/objectstore-server/src/state.rs
+++ b/objectstore-server/src/state.rs
@@ -13,24 +13,29 @@ pub struct State {
 
 impl State {
     pub async fn new(config: Config) -> anyhow::Result<ServiceState> {
-        let storage_config = match &config.storage {
-            Storage::FileSystem { path } => StorageConfig::FileSystem { path },
-            Storage::S3Compatible { endpoint, bucket } => StorageConfig::S3Compatible {
-                endpoint: endpoint.as_deref(),
-                bucket,
-            },
-            Storage::BigTable {
-                project_id,
-                instance_name,
-                table_name,
-            } => StorageConfig::BigTable(BigTableConfig {
-                project_id: project_id.clone(),
-                instance_name: instance_name.clone(),
-                table_name: table_name.clone(),
-            }),
-        };
-        let service = StorageService::new(storage_config).await?;
+        let small_storage = map_storage_config(&config.small_storage);
+        let large_storage = map_storage_config(&config.large_storage);
+        let service = StorageService::new(small_storage, large_storage).await?;
 
         Ok(Arc::new(Self { config, service }))
+    }
+}
+
+fn map_storage_config(config: &'_ Storage) -> StorageConfig<'_> {
+    match config {
+        Storage::FileSystem { path } => StorageConfig::FileSystem { path },
+        Storage::S3Compatible { endpoint, bucket } => StorageConfig::S3Compatible {
+            endpoint: endpoint.as_deref(),
+            bucket,
+        },
+        Storage::BigTable {
+            project_id,
+            instance_name,
+            table_name,
+        } => StorageConfig::BigTable(BigTableConfig {
+            project_id: project_id.clone(),
+            instance_name: instance_name.clone(),
+            table_name: table_name.clone(),
+        }),
     }
 }

--- a/objectstore-service/src/backend/bigtable.rs
+++ b/objectstore-service/src/backend/bigtable.rs
@@ -38,7 +38,7 @@ const FAMILY_GC: &str = "fg";
 const FAMILY_MANUAL: &str = "fm";
 
 /// Configuration for the BigTable backend.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BigTableConfig {
     /// GCP project ID.
     pub project_id: String,
@@ -227,7 +227,7 @@ impl Backend for BigTableBackend {
 
         let mut payload = Vec::new();
         while let Some(chunk) = stream.try_next().await? {
-            payload.extend(&chunk);
+            payload.extend_from_slice(&chunk);
         }
 
         let mutations = [


### PR DESCRIPTION
This hardcodes two storage backends, one for small files, and one for large files. The threshold has been chosen arbitrarily as 50 KiB for now.