### PR TITLE
fix(devservices): Configure both backends in Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,10 @@ reason, we do **not** provide default configuration variables in `.envrc`.
 cargo run -- -c path/to/config.yml
 
 # Option 2: Environment variables
-export FSS_STORAGE__TYPE=filesystem
-export FSS_STORAGE__PATH=data
+export FSS_HIGH_VOLUME_STORAGE__TYPE=filesystem
+export FSS_HIGH_VOLUME_STORAGE__PATH=data
+export FSS_LONG_TERM_STORAGE__TYPE=filesystem
+export FSS_LONG_TERM_STORAGE__PATH=data
 cargo run
 ```
 

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -20,8 +20,10 @@ services:
   objectstore:
     image: ghcr.io/getsentry/objectstore:latest
     environment:
-      FSS_STORAGE__TYPE: "filesystem"
-      FSS_STORAGE__PATH: "/data"
+      FSS_HIGH_VOLUME_STORAGE__TYPE: "filesystem"
+      FSS_HIGH_VOLUME_STORAGE__PATH: "/data"
+      FSS_LONG_TERM_STORAGE__TYPE: "filesystem"
+      FSS_LONG_TERM_STORAGE__PATH: "/data"
       RUST_LOG: "debug"
     ports:
       - 127.0.0.1:8888:8888


### PR DESCRIPTION
Follow-up to #78, updating the configuration for the objecstore Docker container
used for devservices, for example in Sentry. Configures both the high-volume and
long-term storage backends. Without this definition, the mounted folder will not
match and writes will fail.

Also updates the README.

