### PR TITLE
fix(stresstest): Remove config for JWT token

### DIFF
--- a/objectstore-server/src/config.rs
+++ b/objectstore-server/src/config.rs
@@ -39,9 +39,6 @@ pub struct Config {
     pub high_volume_storage: Storage,
     pub long_term_storage: Storage,
 
-    // authentication config
-    pub jwt_secret: String,
-
     // others
     pub sentry_dsn: Option<String>,
     pub datadog_key: Option<String>,
@@ -59,8 +56,6 @@ impl Default for Config {
             long_term_storage: Storage::FileSystem {
                 path: PathBuf::from("data"),
             },
-
-            jwt_secret: String::new(),
 
             sentry_dsn: None,
             datadog_key: None,


### PR DESCRIPTION
Follow-up to #83, which removed JWT authentication. This also removes the config
from the stresstest binary.

