### PR TITLE
ref(stresstest): Distribute workloads across usecases and orgs

### DIFF
--- a/stresstest/example.yaml
+++ b/stresstest/example.yaml
@@ -5,6 +5,7 @@ duration: 5s
 workloads:
   - name: attachments
     mode: throughput
+    organizations: 1000
     file_sizes:
       p50: 50 KiB
       p99: 200 KiB

--- a/stresstest/src/config.rs
+++ b/stresstest/src/config.rs
@@ -19,11 +19,17 @@ pub struct Workload {
     pub name: String,
     #[serde(default)]
     pub concurrency: usize,
+    #[serde(default = "default_organizations")]
+    pub organizations: u64,
     #[serde(default)]
     pub mode: WorkloadMode,
     pub file_sizes: FileSizes,
     #[serde(default)]
     pub actions: Actions,
+}
+
+fn default_organizations() -> u64 {
+    1
 }
 
 #[derive(Debug, Deserialize)]

--- a/stresstest/src/main.rs
+++ b/stresstest/src/main.rs
@@ -50,6 +50,7 @@ async fn main() -> anyhow::Result<()> {
         .map(|w| {
             Workload::builder(w.name)
                 .concurrency(w.concurrency)
+                .organizations(w.organizations)
                 .mode(w.mode)
                 .size_distribution(w.file_sizes.p50.0, w.file_sizes.p99.0)
                 .action_weights(w.actions.writes, w.actions.reads, w.actions.deletes)


### PR DESCRIPTION
Makes the stresstest more realistic by writing multiple usecases and scopes.
The name of each concurrent workload is used as usecase, which also mimics
production behavior more closely. Also, each workload can specify a number of
organizations (defaulting to 1), which is used as scope.

Internally, we create a project-level scope, since this is what the real
usecases will also be doing. We reuse the org ID as project ID.

