### PR TITLE
fix: Add Secret newtype to avoid config secrets in logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1869,6 +1869,7 @@ dependencies = [
  "objectstore-types",
  "rand",
  "rustls",
+ "secrecy",
  "sentry",
  "serde",
  "serde_json",
@@ -2627,6 +2628,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "serde",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"

--- a/objectstore-server/Cargo.toml
+++ b/objectstore-server/Cargo.toml
@@ -21,6 +21,7 @@ sentry = { version = "0.41.0", features = [
     "tracing",
     "logs",
 ] }
+secrecy = { version = "0.10.3", features = ["serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }


### PR DESCRIPTION
adds a `Secret` newtype around `String` which:
- does not implement `Display`
- writes `"[redacted]"` in its `Debug` implementation
- allows access to the underlying secret as a `&str` via `secret.access()`

we already do `debug!(?config)` and inevitably we will add things like `debug!(?request.headers); // Temporary log to debug #1234`. use this type when you have the opportunity for values you recognize are sensitive so that logging like this doesn't cause an incident

the sentry dsn and datadog key are not "defcon 0" secrets but they are definitely non-public and we will probably have more sensitive examples in the future