### PR TITLE
ref: Retry high-volume PUT failures

### DIFF
--- a/objectstore-service/src/backend/bigtable.rs
+++ b/objectstore-service/src/backend/bigtable.rs
@@ -203,6 +203,10 @@ impl BigTableBackend {
 
 #[async_trait::async_trait]
 impl Backend for BigTableBackend {
+    fn name(&self) -> &'static str {
+        "bigtable"
+    }
+
     async fn put_object(
         &self,
         path: &ObjectPath,

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -262,6 +262,10 @@ impl fmt::Debug for GcsBackend {
 
 #[async_trait::async_trait]
 impl Backend for GcsBackend {
+    fn name(&self) -> &'static str {
+        "gcs"
+    }
+
     async fn put_object(
         &self,
         path: &ObjectPath,

--- a/objectstore-service/src/backend/local_fs.rs
+++ b/objectstore-service/src/backend/local_fs.rs
@@ -28,6 +28,10 @@ impl LocalFsBackend {
 
 #[async_trait::async_trait]
 impl Backend for LocalFsBackend {
+    fn name(&self) -> &'static str {
+        "local-fs"
+    }
+
     async fn put_object(
         &self,
         path: &ObjectPath,

--- a/objectstore-service/src/backend/mod.rs
+++ b/objectstore-service/src/backend/mod.rs
@@ -22,6 +22,9 @@ pub type BackendStream = BoxStream<'static, io::Result<Bytes>>;
 
 #[async_trait::async_trait]
 pub trait Backend: Debug + Send + Sync + 'static {
+    /// The backend name, used for diagnostics.
+    fn name(&self) -> &'static str;
+
     async fn put_object(
         &self,
         path: &ObjectPath,

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -126,6 +126,10 @@ impl S3CompatibleBackend<NoToken> {
 
 #[async_trait::async_trait]
 impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
+    fn name(&self) -> &'static str {
+        "s3-compatible"
+    }
+
     async fn put_object(
         &self,
         path: &ObjectPath,

--- a/objectstore-service/src/path.rs
+++ b/objectstore-service/src/path.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Display};
 /// The fully scoped path of an object.
 ///
 /// This consists of a usecase, the scope, and the user-defined object key.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ObjectPath {
     /// The usecase, or "product" this object belongs to.
     ///


### PR DESCRIPTION
This adds a retry loop around PUT failures of the "high-volume" backend, which we can do because we are buffering the whole payload in memory and can thus trivially clone it.

The long-term backend however cannot be retried, as it is based on streaming uploads, which we cannot rewind.

As a driveby change, this also introduces a `name` to the generic backends, which we emit as a separate metrics tag now.