### PR TITLE
fix(docker): Permissions in data volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/cc-debian12:debug-nonroot
+FROM gcr.io/distroless/cc-debian12:nonroot
 
 ARG BINARY=objectstore
 COPY ${BINARY} /bin/entrypoint


### PR DESCRIPTION
A docker volume is usually created with root permissions, so `objectstore`
running as `nonroot` did not have enough permissions to create files in the data
volume. This also happens in our devservices setup, where we mount a volume at
`/data`.

To fix this, we first create a folder with appropriate permissions. When
mounting the empty volume for the first time, docker will inherit the folder's
group and user.

Since there is no `mkdir` in the distroless container, we use `COPY` from the
empty home folder in the distroless base image to create the folder.

