### PR TITLE
feat: Add a healthcheck endpoint, moving existing routes to `v1/`

### DIFF
--- a/objectstore-client/src/client.rs
+++ b/objectstore-client/src/client.rs
@@ -140,7 +140,7 @@ impl Client {
 
     /// Deletes the object with the given `id`.
     pub async fn delete(&self, id: &str) -> anyhow::Result<()> {
-        let delete_url = format!("{}/{id}", self.service_url);
+        let delete_url = format!("{}/v1/{id}", self.service_url);
 
         let _response = self
             .request(reqwest::Method::DELETE, delete_url)?

--- a/objectstore-client/src/get.rs
+++ b/objectstore-client/src/get.rs
@@ -58,7 +58,7 @@ impl GetBuilder<'_> {
 
     /// Sends the `GET` request.
     pub async fn send(self) -> anyhow::Result<Option<GetResult>> {
-        let get_url = format!("{}/{}", self.client.service_url, self.id);
+        let get_url = format!("{}/v1/{}", self.client.service_url, self.id);
 
         let response = self
             .client

--- a/objectstore-client/src/put.rs
+++ b/objectstore-client/src/put.rs
@@ -112,9 +112,8 @@ pub struct PutResponse {
 impl PutBuilder<'_> {
     /// Sends the built PUT request to the upstream service.
     pub async fn send(self) -> anyhow::Result<PutResponse> {
-        let mut builder = self
-            .client
-            .request(reqwest::Method::PUT, self.client.service_url.as_ref())?;
+        let put_url = format!("{}/v1/", self.client.service_url);
+        let mut builder = self.client.request(reqwest::Method::PUT, put_url)?;
 
         let body = match (self.metadata.compression, self.body) {
             (Some(Compression::Zstd), PutBody::Buffer(bytes)) => {

--- a/objectstore-client/src/tests.rs
+++ b/objectstore-client/src/tests.rs
@@ -124,8 +124,8 @@ impl TestServer {
         }
 
         let router = Router::new()
-            .route("/", routing::put(put))
-            .route("/{*key}", routing::get(get).delete(delete))
+            .route("/v1/", routing::put(put))
+            .route("/v1/{*key}", routing::get(get).delete(delete))
             .with_state(state);
         Self::with_router(router)
     }


### PR DESCRIPTION
ref FS-154

this only adds the most basic healthcheck, as we don’t have a concept of "readiness" yet.