### PR TITLE
chore: add basic debug logs and adjust span log levels

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -31,7 +31,4 @@ fi
 # Activate the virtual environment
 source .venv/bin/activate
 
-# Use with `devservices up objectstore --mode=full`
-export RUST_LOG=debug
-
 source_env_if_exists .envrc.private

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1910,6 +1910,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tonic",
+ "tracing",
  "uuid",
  "watto",
  "zstd",

--- a/objectstore-server/src/http.rs
+++ b/objectstore-server/src/http.rs
@@ -110,7 +110,7 @@ struct PutBlobResponse {
     key: String,
 }
 
-#[tracing::instrument(level = "trace", skip(state, body))]
+#[tracing::instrument(level = "info", skip(state, body))]
 async fn put_object_nokey(
     State(state): State<ServiceState>,
     Query(params): Query<ContextParams>,
@@ -132,7 +132,7 @@ async fn put_object_nokey(
     }))
 }
 
-#[tracing::instrument(level = "trace", skip(state, body))]
+#[tracing::instrument(level = "info", skip(state, body))]
 async fn put_object(
     State(state): State<ServiceState>,
     Query(params): Query<ContextParams>,
@@ -155,7 +155,7 @@ async fn put_object(
     }))
 }
 
-#[tracing::instrument(level = "trace", skip(state))]
+#[tracing::instrument(level = "info", skip(state))]
 async fn get_object(
     State(state): State<ServiceState>,
     Query(params): Query<ContextParams>,
@@ -175,7 +175,7 @@ async fn get_object(
     Ok((headers, Body::from_stream(stream)).into_response())
 }
 
-#[tracing::instrument(level = "trace", skip(state))]
+#[tracing::instrument(level = "info", skip(state))]
 async fn delete_object(
     State(state): State<ServiceState>,
     Query(params): Query<ContextParams>,

--- a/objectstore-server/src/main.rs
+++ b/objectstore-server/src/main.rs
@@ -22,7 +22,9 @@ fn main() -> Result<()> {
     let _runtime_guard = runtime.enter();
 
     let config = Config::from_env()?;
-    tracing::debug!(?config, "Starting service");
+    initialize_tracing(&config);
+    tracing::info!("Starting service");
+    tracing::debug!(?config);
 
     // Ensure a rustls crypto provider is installed, required on distroless.
     rustls::crypto::ring::default_provider()
@@ -31,7 +33,6 @@ fn main() -> Result<()> {
 
     let _sentry_guard = maybe_initialize_sentry(&config);
     let metrics_guard = maybe_initialize_metrics(&config)?;
-    initialize_tracing(&config);
 
     runtime.block_on(async move {
         let state = State::new(config).await?;

--- a/objectstore-service/Cargo.toml
+++ b/objectstore-service/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tonic = { workspace = true }
+tracing = { workspace = true }
 uuid = { workspace = true, features = ["v7"] }
 watto = "0.2.0"
 zstd = "0.13.3"


### PR DESCRIPTION
- sets our spans to `info` level so they will be sent to sentry
- cleans up our `EnvFilter` usage. we don't use the dns crate that was referenced before, we had the wrong name for one of our targets, and with our spans set to `info` we can disable the noise from `tower_http`.
  - if we want to re-add the capability to put a level filter specifically on printing, IMO that should be a separate env var. i think it is weird that `RUST_LOG=debug` means `RUST_LOG=debug` for the console and `RUST_LOG=INFO,objectstore=TRACE...` for spans.
- adds a few spans and a bunch of `debug!()`s to see a very basic "story" when uploads pass through

the "logs" tab in sentry does not get any of the span context surrounding the log so it is not very useful. i will look into whether anything special has to be done for structured logging to work well in GCP.

also will do a pass for metrics i think we want. didn't get to it today