### PR TITLE
fix: Add missing import

### DIFF
--- a/objectstore-server/src/http.rs
+++ b/objectstore-server/src/http.rs
@@ -7,7 +7,7 @@ use axum::body::Body;
 use axum::extract::{Path, Query, Request, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
-use axum::routing::put;
+use axum::routing::{get, put};
 use axum::{Json, Router};
 use futures_util::{StreamExt, TryStreamExt};
 use objectstore_service::ObjectPath;


### PR DESCRIPTION
This was caused by a merge conflict. We should probably enable a merge queue to make sure conflicting PRs that are green individually do not cause further problems.