### PR TITLE
ci: enable ci workflows to run on merge_group trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
       - release/**
 
   pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - release/**
 
   pull_request:
+  merge_group:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
enabling merge queues before doing this means it will wait forever for required workflows that are never triggered