### PR TITLE
feat: latency metric for GET/DELETE, size metric for GET requests

### DIFF
--- a/objectstore-service/src/backend/bigtable.rs
+++ b/objectstore-service/src/backend/bigtable.rs
@@ -358,6 +358,7 @@ impl Backend for BigTableBackend {
 
         // TODO: Inject the access time from the request.
         let access_time = SystemTime::now();
+        metadata.size = Some(value.len());
 
         // Filter already expired objects but leave them to garbage collection
         if metadata.expiration_policy.is_timeout() && expire_at.is_some_and(|ts| ts < access_time) {
@@ -461,6 +462,7 @@ mod tests {
             expiration_policy: ExpirationPolicy::Manual,
             compression: None,
             custom: BTreeMap::from_iter([("hello".into(), "world".into())]),
+            size: None,
         };
 
         backend
@@ -507,6 +509,7 @@ mod tests {
             expiration_policy: ExpirationPolicy::Manual,
             compression: None,
             custom: BTreeMap::from_iter([("invalid".into(), "invalid".into())]),
+            size: None,
         };
 
         backend
@@ -517,6 +520,7 @@ mod tests {
             expiration_policy: ExpirationPolicy::Manual,
             compression: None,
             custom: BTreeMap::from_iter([("hello".into(), "world".into())]),
+            size: None,
         };
 
         backend
@@ -542,6 +546,7 @@ mod tests {
             expiration_policy: ExpirationPolicy::Manual,
             compression: None,
             custom: Default::default(),
+            size: None,
         };
 
         backend
@@ -568,6 +573,7 @@ mod tests {
             expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_secs(0)),
             compression: None,
             custom: Default::default(),
+            size: None,
         };
 
         backend
@@ -592,6 +598,7 @@ mod tests {
             expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_secs(0)),
             compression: None,
             custom: Default::default(),
+            size: None,
         };
 
         backend

--- a/objectstore-service/src/backend/local_fs.rs
+++ b/objectstore-service/src/backend/local_fs.rs
@@ -83,6 +83,7 @@ impl Backend for LocalFsBackend {
 
         let mut reader = BufReader::new(file);
         let mut metadata_buf = vec![];
+        // TODO populate size in our metadata
         let metadata = loop {
             let reader_buf = reader.fill_buf().await?;
             let buf = if metadata_buf.is_empty() {
@@ -158,6 +159,7 @@ mod tests {
             expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_secs(3600)),
             compression: Some(Compression::Zstd),
             custom: [("foo".into(), "bar".into())].into(),
+            size: None,
         };
         backend
             .put_object(&key, &metadata, make_stream(b"oh hai!"))

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -166,6 +166,7 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
             .context("failed to get object")?;
 
         let headers = response.headers();
+        // TODO: Populate size in metadata
         let metadata = Metadata::from_headers(headers, GCS_CUSTOM_PREFIX)?;
 
         // TODO: Schedule into background persistently so this doesn't get lost on restarts

--- a/objectstore-types/src/lib.rs
+++ b/objectstore-types/src/lib.rs
@@ -147,6 +147,9 @@ pub struct Metadata {
 
     /// Some arbitrary user-provided metadata.
     pub custom: BTreeMap<String, String>,
+
+    /// Size of the data in bytes, if known.
+    pub size: Option<usize>,
 }
 
 impl Metadata {


### PR DESCRIPTION
only implements these metrics in GCS/Bigtable, not local_fs or s3_compatible.

regarding the size metric in GET requests: GCS will calculate the size for us and populate it in the metadata response. Bigtable doesn't, but we load entire Bigtable objects into memory so we compute the size and set it in the GET handler. alternatively, we could write the size into the metadata at PUT time so it will be deserialized automatically at GET time, but the trait interface takes `&Metadata` and that would have to change.

regarding deletes: if we need to speed those up, we should either make the second backend attempt contingent on a `NOT_FOUND` from the first attempt or run both attempts concurrently. currently you must run both in sequence.

also, i notice the retry logic in the bigtable impl does not early-exit for `NOT_FOUND`. we can probably decrease GET latency for objects stored in GCS if we change that.