### PR TITLE
feat: hook objectstore logs up to gcp cloud logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "actix-codec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1881,6 +1891,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-stackdriver",
  "tracing-subscriber",
  "uuid",
 ]
@@ -3477,6 +3488,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-stackdriver"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80048836e000e1f058562f01d69cc46f476955bf389c0dc2d2d7edb98ca63ac1"
+dependencies = [
+ "Inflector",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "time",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3486,12 +3522,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec 1.15.1",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/objectstore-server/Cargo.toml
+++ b/objectstore-server/Cargo.toml
@@ -32,6 +32,7 @@ tower-http = { version = "0.6.6", default-features = false, features = [
     "trace",
 ] }
 tracing = { workspace = true }
+tracing-stackdriver = "0.10.0"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 uuid = { workspace = true, features = ["v7"] }
 

--- a/objectstore-server/src/config.rs
+++ b/objectstore-server/src/config.rs
@@ -73,6 +73,14 @@ pub struct Sentry {
     pub traces_sample_rate: Option<f32>,
 }
 
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LogSink {
+    #[default]
+    Term,
+    CloudLogging,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Config {
     // server addr config
@@ -86,6 +94,7 @@ pub struct Config {
     pub sentry: Option<Sentry>,
     pub datadog_key: Option<SecretBox<ConfigSecret>>,
     pub metric_tags: BTreeMap<String, String>,
+    pub log_sink: LogSink,
 }
 
 impl Default for Config {
@@ -103,6 +112,7 @@ impl Default for Config {
             sentry: None,
             datadog_key: None,
             metric_tags: Default::default(),
+            log_sink: Default::default(),
         }
     }
 }


### PR DESCRIPTION
set the `log_sink` config to `cloudlogging` to use a json formatter for convenient structured display in GCP Logs Explorer rather than text spew for humans to look at

the logs themselves still need improvement though

<img width="1138" height="410" alt="Screenshot 2025-09-25 at 1 25 48 PM" src="https://github.com/user-attachments/assets/3614f616-5907-4fae-81b4-3689dd05908b" />