### PR TITLE
build: Exclusively build on merge_group and not main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,8 +79,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
 
-    # Intentionally never publish on pull requests
-    if: ${{ github.event_name != 'pull_request' }}
+    # Intentionally never publish on pull requests or merge queue
+    if: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ name: Build
 on:
   push:
     branches:
-      - main
       - release/**
 
   pull_request:
@@ -79,8 +78,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
 
-    # Intentionally never publish on pull requests or merge queue
-    if: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
+    # Intentionally never publish on pull requests
+    if: ${{ github.event_name != 'pull_request' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   push:
     branches:
-      - main
       - release/**
 
   pull_request:


### PR DESCRIPTION
Since we enabled merge queues, every merged PR was built & pushed twice. Since the merge group commits land directly in the main branch, we can skip building there. 

This assumes that we will not have workflows bypassing the merge queue. If we add such workflows in the future, we can revise.