### PR TITLE
fix(observability): Introduce configurable log formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,6 +597,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e47641d3deaf41fb1538ac1f54735925e275eaf3bf4d55c81b137fba797e5cbb"
 
 [[package]]
+name = "console"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,6 +802,12 @@ dependencies = [
  "tokio",
  "tokio-util",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1863,6 +1882,7 @@ dependencies = [
  "argh",
  "axum",
  "axum-extra",
+ "console",
  "elegant-departure",
  "figment",
  "futures-util",
@@ -1876,6 +1896,7 @@ dependencies = [
  "sentry",
  "serde",
  "serde_json",
+ "serde_with",
  "stresstest",
  "tempfile",
  "tokio",
@@ -3479,6 +3500,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3488,12 +3519,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec 1.15.1",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -3567,6 +3601,12 @@ name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "unicode-xid"

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -26,7 +26,7 @@ services:
       FSS_HIGH_VOLUME_STORAGE__PATH: "/data"
       FSS_LONG_TERM_STORAGE__TYPE: "filesystem"
       FSS_LONG_TERM_STORAGE__PATH: "/data"
-      RUST_LOG: "debug"
+      FSS_LOGGING__LEVEL: "debug"
     ports:
       - 127.0.0.1:8888:8888
     volumes:

--- a/objectstore-server/Cargo.toml
+++ b/objectstore-server/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = { workspace = true }
 argh = "0.1.13"
 axum = "0.8.4"
 axum-extra = "0.10.1"
+console = "0.16.1"
 elegant-departure = { version = "0.3.2", features = ["tokio"] }
 figment = { version = "0.10.19", features = ["env", "test", "yaml"] }
 futures-util = { workspace = true }
@@ -24,6 +25,7 @@ sentry = { workspace = true, features = [
 secrecy = { version = "0.10.3", features = ["serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_with = "3.14.1"
 tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true }
 tower = { version = "0.5.2" }
@@ -32,7 +34,7 @@ tower-http = { version = "0.6.6", default-features = false, features = [
     "trace",
 ] }
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }
 uuid = { workspace = true, features = ["v7"] }
 
 [dev-dependencies]

--- a/objectstore-server/src/http.rs
+++ b/objectstore-server/src/http.rs
@@ -111,7 +111,7 @@ struct PutBlobResponse {
     key: String,
 }
 
-#[tracing::instrument(level = "info", skip(state, body))]
+#[tracing::instrument(level = "trace", skip(state, body))]
 async fn put_object_nokey(
     State(state): State<ServiceState>,
     Query(params): Query<ContextParams>,
@@ -133,7 +133,7 @@ async fn put_object_nokey(
     }))
 }
 
-#[tracing::instrument(level = "info", skip(state, body))]
+#[tracing::instrument(level = "trace", skip(state, body))]
 async fn put_object(
     State(state): State<ServiceState>,
     Query(params): Query<ContextParams>,
@@ -156,7 +156,7 @@ async fn put_object(
     }))
 }
 
-#[tracing::instrument(level = "info", skip(state))]
+#[tracing::instrument(level = "trace", skip(state))]
 async fn get_object(
     State(state): State<ServiceState>,
     Query(params): Query<ContextParams>,
@@ -176,7 +176,7 @@ async fn get_object(
     Ok((headers, Body::from_stream(stream)).into_response())
 }
 
-#[tracing::instrument(level = "info", skip(state))]
+#[tracing::instrument(level = "trace", skip(state))]
 async fn delete_object(
     State(state): State<ServiceState>,
     Query(params): Query<ContextParams>,

--- a/objectstore-server/tests/stresstest.rs
+++ b/objectstore-server/tests/stresstest.rs
@@ -39,7 +39,7 @@ async fn test_basic() {
             "FSS_long_term_storage__PATH",
             tempdir.path().display().to_string(),
         )
-        .env("RUST_LOG", "warn");
+        .env("FSS_LOGGING__LEVEL", "warn");
     if let Ok(datadog_key) = std::env::var("DD_API_KEY") {
         cmd.env("FSS_datadog_key", datadog_key);
     }

--- a/objectstore-service/src/backend/bigtable.rs
+++ b/objectstore-service/src/backend/bigtable.rs
@@ -272,7 +272,7 @@ impl Backend for BigTableBackend {
         "bigtable"
     }
 
-    #[tracing::instrument(level = "info", fields(backend = self.name()), skip_all)]
+    #[tracing::instrument(level = "trace", fields(backend = self.name()), skip_all)]
     async fn put_object(
         &self,
         path: &ObjectPath,
@@ -291,7 +291,7 @@ impl Backend for BigTableBackend {
         Ok(())
     }
 
-    #[tracing::instrument(level = "info", fields(backend = self.name()), skip_all)]
+    #[tracing::instrument(level = "trace", fields(backend = self.name()), skip_all)]
     async fn get_object(&self, path: &ObjectPath) -> Result<Option<(Metadata, BackendStream)>> {
         tracing::debug!("Reading from Bigtable backend");
         let path = path.to_string().into_bytes();
@@ -379,7 +379,7 @@ impl Backend for BigTableBackend {
         Ok(Some((metadata, stream)))
     }
 
-    #[tracing::instrument(level = "info", fields(backend = self.name()), skip_all)]
+    #[tracing::instrument(level = "trace", fields(backend = self.name()), skip_all)]
     async fn delete_object(&self, path: &ObjectPath) -> Result<()> {
         tracing::debug!("Deleting from Bigtable backend");
         let path = path.to_string().into_bytes();

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -278,7 +278,7 @@ impl Backend for GcsBackend {
         "gcs"
     }
 
-    #[tracing::instrument(level = "info", fields(backend = self.name()), skip_all)]
+    #[tracing::instrument(level = "trace", fields(backend = self.name()), skip_all)]
     async fn put_object(
         &self,
         path: &ObjectPath,
@@ -319,7 +319,7 @@ impl Backend for GcsBackend {
         Ok(())
     }
 
-    #[tracing::instrument(level = "info", fields(backend = self.name()), skip_all)]
+    #[tracing::instrument(level = "trace", fields(backend = self.name()), skip_all)]
     async fn get_object(&self, path: &ObjectPath) -> Result<Option<(Metadata, BackendStream)>> {
         tracing::debug!("Reading from GCS backend");
         let object_url = self.object_url(path)?;
@@ -384,7 +384,7 @@ impl Backend for GcsBackend {
         Ok(Some((metadata, stream)))
     }
 
-    #[tracing::instrument(level = "info", fields(backend = self.name()), skip_all)]
+    #[tracing::instrument(level = "trace", fields(backend = self.name()), skip_all)]
     async fn delete_object(&self, path: &ObjectPath) -> Result<()> {
         tracing::debug!("Deleting from GCS backend");
         let response = self

--- a/objectstore-service/src/backend/local_fs.rs
+++ b/objectstore-service/src/backend/local_fs.rs
@@ -32,7 +32,7 @@ impl Backend for LocalFsBackend {
         "local-fs"
     }
 
-    #[tracing::instrument(level = "info", fields(backend = self.name()), skip_all)]
+    #[tracing::instrument(level = "trace", fields(backend = self.name()), skip_all)]
     async fn put_object(
         &self,
         path: &ObjectPath,
@@ -65,7 +65,7 @@ impl Backend for LocalFsBackend {
     }
 
     // TODO: Return `Ok(None)` if object is found but past expiry
-    #[tracing::instrument(level = "info", fields(backend = self.name()), skip_all)]
+    #[tracing::instrument(level = "trace", fields(backend = self.name()), skip_all)]
     async fn get_object(
         &self,
         path: &ObjectPath,
@@ -117,7 +117,7 @@ impl Backend for LocalFsBackend {
         Ok(Some((metadata, stream.boxed())))
     }
 
-    #[tracing::instrument(level = "info", fields(backend = self.name()), skip_all)]
+    #[tracing::instrument(level = "trace", fields(backend = self.name()), skip_all)]
     async fn delete_object(&self, path: &ObjectPath) -> anyhow::Result<()> {
         tracing::debug!("Deleting from local_fs backend");
         let path = self.path.join(path.to_string());

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -130,7 +130,7 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
         "s3-compatible"
     }
 
-    #[tracing::instrument(level = "info", fields(backend = self.name()), skip_all)]
+    #[tracing::instrument(level = "trace", fields(backend = self.name()), skip_all)]
     async fn put_object(
         &self,
         path: &ObjectPath,
@@ -150,7 +150,7 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
         Ok(())
     }
 
-    #[tracing::instrument(level = "info", fields(backend = self.name()), skip_all)]
+    #[tracing::instrument(level = "trace", fields(backend = self.name()), skip_all)]
     async fn get_object(&self, path: &ObjectPath) -> Result<Option<(Metadata, BackendStream)>> {
         tracing::debug!("Reading from s3_compatible backend");
         let object_url = self.object_url(path);
@@ -192,7 +192,7 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
         Ok(Some((metadata, stream.boxed())))
     }
 
-    #[tracing::instrument(level = "info", fields(backend = self.name()), skip_all)]
+    #[tracing::instrument(level = "trace", fields(backend = self.name()), skip_all)]
     async fn delete_object(&self, path: &ObjectPath) -> Result<()> {
         tracing::debug!("Deleting from s3_compatible backend");
         let response = self


### PR DESCRIPTION
Introduces configurable log formats very similar to how Relay handles it. The
default is "auto", which infers the right format from the TTY. On attended
sessions, the default format is "pretty" with colors, otherwise a plain text
version. For production, there's a JSON format option.

Also switches back all tracing instruments to `trace` level, as they are way too
verbose for either INFO or DEBUG level. Especially on INFO, we would cause
significant cost on cloud logs.

