### PR TITLE
ref: Slightly improve error logging

### DIFF
--- a/objectstore-server/src/http.rs
+++ b/objectstore-server/src/http.rs
@@ -216,7 +216,7 @@ mod error {
 
                     // TODO: Support more nuanced return codes for validation errors etc. See
                     // Relay's ApiErrorResponse and BadStoreRequest as examples.
-                    (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response()
+                    StatusCode::INTERNAL_SERVER_ERROR.into_response()
                 }
                 AnyhowResponse::Response(response) => response,
             }


### PR DESCRIPTION
This completely removes error logging from within the `BigTableBackend`. Previously, we were logging the same error **3** times: explicitly using Sentry, using using `tracing`, and then on the very outside in the HTTP handler when returning the error to the caller.

Without the inner error handling, we log the error only once now, in the HTTP handler. That HTTP handler also does not leak error details anymore.

Apart from that, this now also adds the bigtable mutate action to metrics and the error context.