### PR TITLE
ref: Add useful things to the Sentry Scope

### DIFF
--- a/objectstore-service/src/backend/bigtable.rs
+++ b/objectstore-service/src/backend/bigtable.rs
@@ -274,7 +274,7 @@ impl Backend for BigTableBackend {
         "bigtable"
     }
 
-    #[tracing::instrument(level = "trace", fields(backend = self.name()), skip_all)]
+    #[tracing::instrument(level = "trace", fields(?path), skip_all)]
     async fn put_object(
         &self,
         path: &ObjectPath,
@@ -293,7 +293,7 @@ impl Backend for BigTableBackend {
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", fields(backend = self.name()), skip_all)]
+    #[tracing::instrument(level = "trace", fields(?path), skip_all)]
     async fn get_object(&self, path: &ObjectPath) -> Result<Option<(Metadata, BackendStream)>> {
         tracing::debug!("Reading from Bigtable backend");
         let path = path.to_string().into_bytes();
@@ -377,7 +377,7 @@ impl Backend for BigTableBackend {
         Ok(Some((metadata, stream)))
     }
 
-    #[tracing::instrument(level = "trace", fields(backend = self.name()), skip_all)]
+    #[tracing::instrument(level = "trace", fields(?path), skip_all)]
     async fn delete_object(&self, path: &ObjectPath) -> Result<()> {
         tracing::debug!("Deleting from Bigtable backend");
         let path = path.to_string().into_bytes();

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -278,7 +278,7 @@ impl Backend for GcsBackend {
         "gcs"
     }
 
-    #[tracing::instrument(level = "trace", fields(backend = self.name()), skip_all)]
+    #[tracing::instrument(level = "trace", fields(?path), skip_all)]
     async fn put_object(
         &self,
         path: &ObjectPath,
@@ -319,7 +319,7 @@ impl Backend for GcsBackend {
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", fields(backend = self.name()), skip_all)]
+    #[tracing::instrument(level = "trace", fields(?path), skip_all)]
     async fn get_object(&self, path: &ObjectPath) -> Result<Option<(Metadata, BackendStream)>> {
         tracing::debug!("Reading from GCS backend");
         let object_url = self.object_url(path)?;
@@ -384,7 +384,7 @@ impl Backend for GcsBackend {
         Ok(Some((metadata, stream)))
     }
 
-    #[tracing::instrument(level = "trace", fields(backend = self.name()), skip_all)]
+    #[tracing::instrument(level = "trace", fields(?path), skip_all)]
     async fn delete_object(&self, path: &ObjectPath) -> Result<()> {
         tracing::debug!("Deleting from GCS backend");
         let response = self

--- a/objectstore-service/src/backend/local_fs.rs
+++ b/objectstore-service/src/backend/local_fs.rs
@@ -32,7 +32,7 @@ impl Backend for LocalFsBackend {
         "local-fs"
     }
 
-    #[tracing::instrument(level = "trace", fields(backend = self.name()), skip_all)]
+    #[tracing::instrument(level = "trace", fields(?path), skip_all)]
     async fn put_object(
         &self,
         path: &ObjectPath,
@@ -65,7 +65,7 @@ impl Backend for LocalFsBackend {
     }
 
     // TODO: Return `Ok(None)` if object is found but past expiry
-    #[tracing::instrument(level = "trace", fields(backend = self.name()), skip_all)]
+    #[tracing::instrument(level = "trace", fields(?path), skip_all)]
     async fn get_object(
         &self,
         path: &ObjectPath,
@@ -117,7 +117,7 @@ impl Backend for LocalFsBackend {
         Ok(Some((metadata, stream.boxed())))
     }
 
-    #[tracing::instrument(level = "trace", fields(backend = self.name()), skip_all)]
+    #[tracing::instrument(level = "trace", fields(?path), skip_all)]
     async fn delete_object(&self, path: &ObjectPath) -> anyhow::Result<()> {
         tracing::debug!("Deleting from local_fs backend");
         let path = self.path.join(path.to_string());

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -130,7 +130,7 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
         "s3-compatible"
     }
 
-    #[tracing::instrument(level = "trace", fields(backend = self.name()), skip_all)]
+    #[tracing::instrument(level = "trace", fields(?path), skip_all)]
     async fn put_object(
         &self,
         path: &ObjectPath,
@@ -150,7 +150,7 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", fields(backend = self.name()), skip_all)]
+    #[tracing::instrument(level = "trace", fields(?path), skip_all)]
     async fn get_object(&self, path: &ObjectPath) -> Result<Option<(Metadata, BackendStream)>> {
         tracing::debug!("Reading from s3_compatible backend");
         let object_url = self.object_url(path);
@@ -192,7 +192,7 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
         Ok(Some((metadata, stream.boxed())))
     }
 
-    #[tracing::instrument(level = "trace", fields(backend = self.name()), skip_all)]
+    #[tracing::instrument(level = "trace", fields(?path), skip_all)]
     async fn delete_object(&self, path: &ObjectPath) -> Result<()> {
         tracing::debug!("Deleting from s3_compatible backend");
         let response = self


### PR DESCRIPTION
Adds `usecase`, and object `scope`/`key` to the sentry scope as tags and extras respectively. Also replaces the explicit bigtable `backend` field with the more useful object `path`. The `backend` is implicit in the fully qualified fn name.