### PR TITLE
ci: Disable merge queues again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,10 @@ name: Build
 on:
   push:
     branches:
+      - main
       - release/**
 
   pull_request:
-  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches:
+      - main
       - release/**
 
   pull_request:
-  merge_group:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
There are too many edge cases that we cannot make work with merge queues
properly. For this reqson, we will disable them for the time being.

