### PR TITLE
ref(stresstest): Add progress bars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,6 +1492,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2092,6 +2105,12 @@ dependencies = [
  "serde",
  "time",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "potential_utf"
@@ -3032,6 +3051,7 @@ dependencies = [
  "futures",
  "futures-util",
  "humantime-serde",
+ "indicatif",
  "objectstore-client",
  "rand",
  "rand_distr",
@@ -3552,6 +3572,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3782,6 +3808,16 @@ name = "web-sys"
 version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/stresstest/Cargo.toml
+++ b/stresstest/Cargo.toml
@@ -11,6 +11,7 @@ bytesize = { version = "2.0.1", features = ["serde"] }
 futures = { workspace = true }
 futures-util = { workspace = true }
 humantime-serde = { workspace = true }
+indicatif = "0.18.0"
 objectstore-client = { workspace = true }
 rand = { workspace = true, features = ["small_rng"] }
 rand_distr = "0.5.1"

--- a/stresstest/src/workload.rs
+++ b/stresstest/src/workload.rs
@@ -256,9 +256,9 @@ impl Workload {
         self.existing_files.push((internal, external))
     }
 
-    pub(crate) fn external_files(&mut self) -> impl Iterator<Item = ExternalId> + use<> {
-        std::mem::take(&mut self.existing_files)
-            .into_iter()
+    pub(crate) fn external_files(&self) -> impl Iterator<Item = &ExternalId> {
+        self.existing_files
+            .iter()
             .map(|(_internal, external)| external)
     }
 }


### PR DESCRIPTION
Stresstests can run for a long time, and especially with BigTable the cleanup
section has been intransparent. This adds an interactive progress bar which we
can use to observe progress.

We can improve this progress bar at a later time to render live stats during the
test.

