### PR TITLE
Comprehensive consistency test suite for TieredStorage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,6 +455,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2588,6 +2603,7 @@ dependencies = [
  "humantime-serde",
  "objectstore-metrics",
  "objectstore-types",
+ "proptest",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -2952,6 +2968,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3084,6 +3119,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -3239,6 +3280,15 @@ checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand 0.9.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3585,6 +3635,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -4656,6 +4718,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4795,6 +4863,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/objectstore-service/Cargo.toml
+++ b/objectstore-service/Cargo.toml
@@ -38,6 +38,7 @@ uuid = { workspace = true, features = ["v7"] }
 
 [dev-dependencies]
 futures = { workspace = true }
+proptest = "1.6"
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 tokio-stream = { workspace = true }

--- a/objectstore-service/src/tiered.rs
+++ b/objectstore-service/src/tiered.rs
@@ -1743,4 +1743,332 @@ mod tests {
             }
         }
     }
+
+    // ==========================================
+    // Concurrent chaos fuzz testing
+    // ==========================================
+
+    mod chaos_fuzz {
+        use std::collections::HashMap;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        use objectstore_types::metadata::Metadata;
+        use objectstore_types::scope::{Scope, Scopes};
+
+        use super::*;
+
+        const KEY_NAMES: &[&str] = &["key-a", "key-b", "key-c"];
+        const LARGE_SIZE: usize = super::BACKEND_SIZE_THRESHOLD + 1024;
+
+        fn make_context() -> ObjectContext {
+            ObjectContext {
+                usecase: "chaos".into(),
+                scopes: Scopes::from_iter([Scope::create("test", "chaos").unwrap()]),
+            }
+        }
+
+        // -- ChaosConfig + ChaosBackend --
+
+        #[derive(Debug, Clone)]
+        struct ChaosConfig {
+            put_error_pct: u8,
+            get_error_pct: u8,
+            get_metadata_error_pct: u8,
+            delete_error_pct: u8,
+        }
+
+        #[derive(Debug)]
+        struct ChaosBackend {
+            inner: InMemoryBackend,
+            config: ChaosConfig,
+            call_counter: AtomicU64,
+        }
+
+        impl ChaosBackend {
+            fn new(inner: InMemoryBackend, config: ChaosConfig) -> Self {
+                Self {
+                    inner,
+                    config,
+                    call_counter: AtomicU64::new(0),
+                }
+            }
+
+            fn should_fail(&self, error_pct: u8) -> bool {
+                if error_pct == 0 {
+                    return false;
+                }
+                let count = self.call_counter.fetch_add(1, Ordering::Relaxed);
+                let roll = (count.wrapping_mul(6_364_136_223_846_793_005)) % 100;
+                roll < error_pct as u64
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl crate::backend::common::Backend for ChaosBackend {
+            fn name(&self) -> &'static str {
+                "chaos"
+            }
+
+            async fn put_object(
+                &self,
+                id: &ObjectId,
+                metadata: &Metadata,
+                stream: PayloadStream,
+            ) -> crate::error::Result<()> {
+                if self.should_fail(self.config.put_error_pct) {
+                    return Err(simulated_error("chaos: put_object"));
+                }
+                // Yield before the actual write to create interleaving
+                // windows between the multi-step TieredStorage operations.
+                tokio::task::yield_now().await;
+                self.inner.put_object(id, metadata, stream).await
+            }
+
+            async fn get_object(
+                &self,
+                id: &ObjectId,
+            ) -> crate::error::Result<Option<(Metadata, PayloadStream)>> {
+                if self.should_fail(self.config.get_error_pct) {
+                    return Err(simulated_error("chaos: get_object"));
+                }
+                tokio::task::yield_now().await;
+                self.inner.get_object(id).await
+            }
+
+            async fn get_metadata(&self, id: &ObjectId) -> crate::error::Result<Option<Metadata>> {
+                if self.should_fail(self.config.get_metadata_error_pct) {
+                    return Err(simulated_error("chaos: get_metadata"));
+                }
+                tokio::task::yield_now().await;
+                self.inner.get_metadata(id).await
+            }
+
+            async fn delete_object(&self, id: &ObjectId) -> crate::error::Result<()> {
+                if self.should_fail(self.config.delete_error_pct) {
+                    return Err(simulated_error("chaos: delete_object"));
+                }
+                tokio::task::yield_now().await;
+                self.inner.delete_object(id).await
+            }
+        }
+
+        /// Which write operation to perform concurrently.
+        #[derive(Clone, Copy)]
+        enum WriteOp {
+            InsertSmall,
+            InsertLarge,
+            Delete,
+        }
+
+        /// Runs `rounds` independent rounds, each spawning concurrent writes
+        /// to the *same* key, and returns a tally of invariant violations.
+        ///
+        /// All ops target a single key to maximize the chance of interleaving
+        /// between the multi-step backend calls inside `TieredStorage`.
+        async fn run_chaos_rounds(
+            rounds: usize,
+            ops: &[WriteOp],
+            hv_config: ChaosConfig,
+            lt_config: ChaosConfig,
+        ) -> HashMap<&'static str, u32> {
+            let mut violations: HashMap<&'static str, u32> = HashMap::new();
+            let key = KEY_NAMES[0];
+
+            for _ in 0..rounds {
+                let hv = InMemoryBackend::new("chaos-hv");
+                let lt = InMemoryBackend::new("chaos-lt");
+
+                let storage = Arc::new(TieredStorage {
+                    high_volume_backend: Box::new(ChaosBackend::new(hv.clone(), hv_config.clone())),
+                    long_term_backend: Box::new(ChaosBackend::new(lt.clone(), lt_config.clone())),
+                });
+
+                let context = make_context();
+
+                let handles: Vec<_> = ops
+                    .iter()
+                    .map(|&op| {
+                        let storage = Arc::clone(&storage);
+                        let ctx = context.clone();
+                        tokio::spawn(async move {
+                            match op {
+                                WriteOp::InsertSmall => {
+                                    let _ = storage
+                                        .insert_object(
+                                            ctx,
+                                            Some(key.into()),
+                                            &Default::default(),
+                                            make_stream(SMALL),
+                                        )
+                                        .await;
+                                }
+                                WriteOp::InsertLarge => {
+                                    let payload = vec![0xBB; LARGE_SIZE];
+                                    let _ = storage
+                                        .insert_object(
+                                            ctx,
+                                            Some(key.into()),
+                                            &Default::default(),
+                                            make_stream(&payload),
+                                        )
+                                        .await;
+                                }
+                                WriteOp::Delete => {
+                                    let id = ObjectId::new(ctx, key.into());
+                                    let _ = storage.delete_object(&id).await;
+                                }
+                            }
+                        })
+                    })
+                    .collect();
+
+                let results = futures_util::future::join_all(handles).await;
+                for (i, result) in results.iter().enumerate() {
+                    assert!(
+                        result.is_ok(),
+                        "Task {i} panicked: {:?}",
+                        result.as_ref().unwrap_err()
+                    );
+                }
+
+                let id = ObjectId::new(context, key.into());
+                if let Err(msg) = check_invariants(&hv, &lt, &id) {
+                    let label = if msg.contains("OrphanLT") {
+                        "OrphanLT"
+                    } else if msg.contains("DualData") {
+                        "DualData"
+                    } else {
+                        "Unknown"
+                    };
+                    *violations.entry(label).or_default() += 1;
+                }
+            }
+
+            violations
+        }
+
+        /// No-error config: yield points only, no injected failures.
+        fn no_error_config() -> ChaosConfig {
+            ChaosConfig {
+                put_error_pct: 0,
+                get_error_pct: 0,
+                get_metadata_error_pct: 0,
+                delete_error_pct: 0,
+            }
+        }
+
+        const ROUNDS: usize = 2000;
+
+        /// Concurrent insert(large) + insert(small) on the same key.
+        ///
+        /// The race window: A peeks and picks LongTerm, B peeks and picks
+        /// HighVolume. B checks HV metadata (no tombstone yet). A writes LT
+        /// + tombstone to HV. B overwrites HV with small data, destroying
+        /// the tombstone → DualData.
+        ///
+        /// TODO(consistency): Prevent via per-key serialization or conditional
+        /// writes. Flip to `assert!(!violations.contains_key(...))` when fixed.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn concurrent_insert_large_insert_small() {
+            use WriteOp::*;
+            let violations = run_chaos_rounds(
+                ROUNDS,
+                &[
+                    InsertLarge,
+                    InsertSmall,
+                    InsertLarge,
+                    InsertSmall,
+                    InsertLarge,
+                    InsertSmall,
+                ],
+                no_error_config(),
+                no_error_config(),
+            )
+            .await;
+
+            println!("insert_large+insert_small: {violations:?}");
+            assert!(
+                violations.contains_key("DualData") || violations.contains_key("OrphanLT"),
+                "Expected consistency violations from concurrent large+small insert"
+            );
+        }
+
+        /// Concurrent insert(small) + delete on a key that starts in Large
+        /// state (pre-seeded by a preceding insert(large)).
+        ///
+        /// The race window: delete sees the tombstone and deletes LT data.
+        /// Meanwhile insert checks HV metadata, sees the tombstone, and
+        /// routes to LT. Delete then removes the HV tombstone. Result:
+        /// new data in LT with nothing in HV → OrphanLT.
+        ///
+        /// TODO(consistency): Prevent via per-key serialization or conditional
+        /// writes. Flip to `assert!(!violations.contains_key(...))` when fixed.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn concurrent_insert_delete_from_large_state() {
+            use WriteOp::*;
+            let violations = run_chaos_rounds(
+                ROUNDS,
+                // First op seeds Large state; remaining ops race.
+                &[InsertLarge, InsertSmall, Delete, InsertSmall, Delete],
+                no_error_config(),
+                no_error_config(),
+            )
+            .await;
+
+            println!("insert+delete from large: {violations:?}");
+            assert!(
+                violations.contains_key("OrphanLT") || violations.contains_key("DualData"),
+                "Expected consistency violations from concurrent insert+delete"
+            );
+        }
+
+        /// Concurrent large inserts with targeted error injection to trigger
+        /// the double-failure cleanup path.
+        ///
+        /// The HV put (tombstone write) sometimes fails. When it does, the
+        /// cleanup tries to delete the already-written LT data — but that
+        /// also sometimes fails → OrphanLT.
+        ///
+        /// TODO(consistency): Fix insert cleanup to handle double failure.
+        /// Flip to `assert!(!violations.contains_key(...))` when fixed.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn concurrent_inserts_with_tombstone_write_errors() {
+            use WriteOp::*;
+            // HV: put errors (tombstone write fails), no other errors.
+            let hv_config = ChaosConfig {
+                put_error_pct: 25,
+                get_error_pct: 0,
+                get_metadata_error_pct: 0,
+                delete_error_pct: 0,
+            };
+            // LT: delete errors (cleanup fails), no other errors.
+            let lt_config = ChaosConfig {
+                put_error_pct: 0,
+                get_error_pct: 0,
+                get_metadata_error_pct: 0,
+                delete_error_pct: 25,
+            };
+            let violations = run_chaos_rounds(
+                ROUNDS,
+                &[
+                    InsertLarge,
+                    InsertSmall,
+                    InsertLarge,
+                    InsertSmall,
+                    InsertLarge,
+                    InsertSmall,
+                ],
+                hv_config,
+                lt_config,
+            )
+            .await;
+
+            println!("inserts with tombstone errors: {violations:?}");
+            assert!(
+                violations.contains_key("OrphanLT") || violations.contains_key("DualData"),
+                "Expected consistency violations from tombstone write + cleanup failures"
+            );
+        }
+    }
 }

--- a/objectstore-service/src/tiered.rs
+++ b/objectstore-service/src/tiered.rs
@@ -269,7 +269,6 @@ mod tests {
     use tokio::sync::Notify;
 
     use super::*;
-    use crate::backend::common::BoxedBackend;
     use crate::backend::in_memory::InMemoryBackend;
     use crate::error::Error;
     use crate::stream::make_stream;
@@ -281,14 +280,49 @@ mod tests {
         }
     }
 
+    const SMALL: &[u8] = &[0xAA; 100];
+    const LARGE_SIZE: usize = 2 * 1024 * 1024;
+
+    fn large_payload() -> Vec<u8> {
+        vec![0xBB; LARGE_SIZE]
+    }
+
+    fn make_tiered_from(hv: &InMemoryBackend, lt: &InMemoryBackend) -> TieredStorage {
+        TieredStorage {
+            high_volume_backend: Box::new(hv.clone()),
+            long_term_backend: Box::new(lt.clone()),
+        }
+    }
+
     fn make_tiered_storage() -> (TieredStorage, InMemoryBackend, InMemoryBackend) {
         let hv = InMemoryBackend::new("in-memory-hv");
         let lt = InMemoryBackend::new("in-memory-lt");
-        let storage = TieredStorage {
-            high_volume_backend: Box::new(hv.clone()),
-            long_term_backend: Box::new(lt.clone()),
-        };
-        (storage, hv, lt)
+        (make_tiered_from(&hv, &lt), hv, lt)
+    }
+
+    async fn insert_small(storage: &TieredStorage, key: &str) -> ObjectId {
+        storage
+            .insert_object(
+                make_context(),
+                Some(key.into()),
+                &Default::default(),
+                make_stream(SMALL),
+            )
+            .await
+            .unwrap()
+    }
+
+    async fn insert_large(storage: &TieredStorage, key: &str) -> ObjectId {
+        let payload = large_payload();
+        storage
+            .insert_object(
+                make_context(),
+                Some(key.into()),
+                &Default::default(),
+                make_stream(&payload),
+            )
+            .await
+            .unwrap()
     }
 
     fn simulated_error(msg: &str) -> Error {
@@ -312,6 +346,27 @@ mod tests {
     // `assert_consistent` wraps it and additionally verifies OrphanTombstone
     // reads return None.
 
+    /// Core invariant check on the three booleans that characterize tiered state.
+    fn check_invariants_core(
+        hv_present: bool,
+        hv_tombstone: bool,
+        lt_present: bool,
+        key: &str,
+    ) -> std::result::Result<(), String> {
+        match (hv_present, hv_tombstone, lt_present) {
+            (false, _, false) => Ok(()),    // Empty
+            (true, false, false) => Ok(()), // Small
+            (true, true, true) => Ok(()),   // Large
+            (true, true, false) => Ok(()),  // OrphanTombstone (async check in assert_consistent)
+            (false, _, true) => Err(format!(
+                "OrphanLT: data in LT for key {key:?} but nothing in HV"
+            )),
+            (true, false, true) => Err(format!(
+                "DualData: non-tombstone in HV AND data in LT for key {key:?}"
+            )),
+        }
+    }
+
     /// Checks the three consistency invariants. Returns `Err(msg)` on violation.
     fn check_invariants(
         hv: &InMemoryBackend,
@@ -319,26 +374,10 @@ mod tests {
         id: &ObjectId,
     ) -> std::result::Result<(), String> {
         let hv_entry = hv.get_stored(id);
-        let lt_entry = lt.get_stored(id);
-
         let hv_present = hv_entry.is_some();
         let hv_tombstone = hv_entry.as_ref().is_some_and(|(m, _)| m.is_tombstone());
-        let lt_present = lt_entry.is_some();
-
-        match (hv_present, hv_tombstone, lt_present) {
-            (false, _, false) => Ok(()),    // Empty
-            (true, false, false) => Ok(()), // Small
-            (true, true, true) => Ok(()),   // Large
-            (true, true, false) => Ok(()),  // OrphanTombstone (async check in assert_consistent)
-            (false, _, true) => Err(format!(
-                "OrphanLT: data in LT for key {:?} but nothing in HV",
-                id.key()
-            )),
-            (true, false, true) => Err(format!(
-                "DualData: non-tombstone in HV AND data in LT for key {:?}",
-                id.key()
-            )),
-        }
+        let lt_present = lt.get_stored(id).is_some();
+        check_invariants_core(hv_present, hv_tombstone, lt_present, id.key())
     }
 
     /// Panics if invariants are violated. For OrphanTombstone, additionally
@@ -379,6 +418,13 @@ mod tests {
         Get,
         GetMetadata,
         Delete,
+    }
+
+    /// Which side of the tiered storage should fail.
+    #[derive(Debug, Clone, Copy)]
+    enum FailSide {
+        Hv,
+        Lt,
     }
 
     /// A backend that delegates to an inner `InMemoryBackend` but fails on a
@@ -432,6 +478,24 @@ mod tests {
                 return Err(simulated_error("selective-fail: delete_object"));
             }
             self.inner.delete_object(id).await
+        }
+    }
+
+    fn make_failing_storage(
+        hv: &InMemoryBackend,
+        lt: &InMemoryBackend,
+        fail_side: FailSide,
+        fail_on: FailOn,
+    ) -> TieredStorage {
+        match fail_side {
+            FailSide::Hv => TieredStorage {
+                high_volume_backend: Box::new(SelectiveFailBackend::new(hv.clone(), fail_on)),
+                long_term_backend: Box::new(lt.clone()),
+            },
+            FailSide::Lt => TieredStorage {
+                high_volume_backend: Box::new(hv.clone()),
+                long_term_backend: Box::new(SelectiveFailBackend::new(lt.clone(), fail_on)),
+            },
         }
     }
 
@@ -539,17 +603,7 @@ mod tests {
     #[tokio::test]
     async fn small_object_goes_to_high_volume() {
         let (storage, hv, lt) = make_tiered_storage();
-        let payload = vec![0u8; 100]; // 100 bytes, well under 1 MiB
-
-        let id = storage
-            .insert_object(
-                make_context(),
-                Some("small".into()),
-                &Default::default(),
-                make_stream(&payload),
-            )
-            .await
-            .unwrap();
+        let id = insert_small(&storage, "small").await;
 
         assert!(hv.contains(&id), "expected in high-volume");
         assert!(!lt.contains(&id), "leaked to long-term");
@@ -559,21 +613,11 @@ mod tests {
     #[tokio::test]
     async fn large_object_goes_to_long_term_with_tombstone() {
         let (storage, hv, lt) = make_tiered_storage();
-        let payload = vec![0xABu8; 2 * 1024 * 1024]; // 2 MiB, over threshold
-
-        let id = storage
-            .insert_object(
-                make_context(),
-                Some("large".into()),
-                &Default::default(),
-                make_stream(&payload),
-            )
-            .await
-            .unwrap();
+        let id = insert_large(&storage, "large").await;
 
         // Real payload should be in long-term
         let (lt_meta, lt_bytes) = lt.get_stored(&id).unwrap();
-        assert_eq!(lt_bytes.len(), payload.len());
+        assert_eq!(lt_bytes.len(), LARGE_SIZE);
         assert!(!lt_meta.is_tombstone());
 
         // A redirect tombstone should exist in high-volume
@@ -588,37 +632,18 @@ mod tests {
         let (storage, hv, lt) = make_tiered_storage();
 
         // First: insert a large object -> creates tombstone in hv, payload in lt
-        let large_payload = vec![0xABu8; 2 * 1024 * 1024];
-        let id = storage
-            .insert_object(
-                make_context(),
-                Some("reinsert-key".into()),
-                &Default::default(),
-                make_stream(&large_payload),
-            )
-            .await
-            .unwrap();
-
+        let id = insert_large(&storage, "reinsert-key").await;
         let (hv_meta, _) = hv.get_stored(&id).unwrap();
         assert!(hv_meta.is_tombstone());
 
         // Now re-insert a SMALL payload with the same key. The service should
         // detect the existing tombstone and route to long-term anyway.
-        let small_payload = vec![0xCDu8; 100]; // well under 1 MiB threshold
-        storage
-            .insert_object(
-                make_context(),
-                Some("reinsert-key".into()),
-                &Default::default(),
-                make_stream(&small_payload),
-            )
-            .await
-            .unwrap();
+        insert_small(&storage, "reinsert-key").await;
 
         // The small object should be in long-term (not high-volume)
         let (lt_meta, lt_bytes) = lt.get_stored(&id).unwrap();
         assert!(!lt_meta.is_tombstone());
-        assert_eq!(lt_bytes.len(), small_payload.len());
+        assert_eq!(lt_bytes.len(), SMALL.len());
 
         // The tombstone in hv should still be present
         let (hv_meta, _) = hv.get_stored(&id).unwrap();
@@ -637,7 +662,7 @@ mod tests {
             origin: Some("10.0.0.1".into()),
             ..Default::default()
         };
-        let payload = vec![0u8; 2 * 1024 * 1024]; // force long-term
+        let payload = large_payload();
 
         let id = storage
             .insert_object(
@@ -666,7 +691,7 @@ mod tests {
     #[tokio::test]
     async fn reads_follow_tombstone_redirect() {
         let (storage, _hv, _lt) = make_tiered_storage();
-        let payload = vec![0xCDu8; 2 * 1024 * 1024]; // 2 MiB
+        let payload = large_payload();
 
         let metadata_in = Metadata {
             content_type: "image/png".into(),
@@ -685,7 +710,7 @@ mod tests {
         // get_object should transparently follow the tombstone
         let (metadata, stream) = storage.get_object(&id).await.unwrap().unwrap();
         let body: BytesMut = stream.try_collect().await.unwrap();
-        assert_eq!(body.len(), payload.len());
+        assert_eq!(body.len(), LARGE_SIZE);
         assert!(!metadata.is_tombstone());
 
         // get_metadata should also follow the tombstone
@@ -697,17 +722,7 @@ mod tests {
     #[tokio::test]
     async fn delete_cleans_up_both_backends() {
         let (storage, hv, lt) = make_tiered_storage();
-        let payload = vec![0u8; 2 * 1024 * 1024]; // 2 MiB
-
-        let id = storage
-            .insert_object(
-                make_context(),
-                Some("delete-both".into()),
-                &Default::default(),
-                make_stream(&payload),
-            )
-            .await
-            .unwrap();
+        let id = insert_large(&storage, "delete-both").await;
 
         storage.delete_object(&id).await.unwrap();
 
@@ -719,17 +734,7 @@ mod tests {
     #[tokio::test]
     async fn orphan_tombstone_returns_none() {
         let (storage, hv, lt) = make_tiered_storage();
-        let payload = vec![0xCDu8; 2 * 1024 * 1024]; // 2 MiB
-
-        let id = storage
-            .insert_object(
-                make_context(),
-                Some("orphan-tombstone".into()),
-                &Default::default(),
-                make_stream(&payload),
-            )
-            .await
-            .unwrap();
+        let id = insert_large(&storage, "orphan-tombstone").await;
 
         // Remove the long-term object, leaving an orphan tombstone in hv
         lt.remove(&id);
@@ -780,72 +785,34 @@ mod tests {
     #[tokio::test]
     async fn overwrite_small_with_large_no_prior_tombstone() {
         let (storage, hv, lt) = make_tiered_storage();
-        let small_payload = vec![0xAAu8; 100];
-        let large_payload = vec![0xBBu8; 2 * 1024 * 1024];
-
-        let id = storage
-            .insert_object(
-                make_context(),
-                Some("overwrite-key".into()),
-                &Default::default(),
-                make_stream(&small_payload),
-            )
-            .await
-            .unwrap();
+        let id = insert_small(&storage, "overwrite-key").await;
 
         let (hv_meta, hv_bytes) = hv.get_stored(&id).unwrap();
         assert!(!hv_meta.is_tombstone());
-        assert_eq!(hv_bytes.len(), small_payload.len());
+        assert_eq!(hv_bytes.len(), SMALL.len());
         assert!(!lt.contains(&id));
 
-        storage
-            .insert_object(
-                make_context(),
-                Some("overwrite-key".into()),
-                &Default::default(),
-                make_stream(&large_payload),
-            )
-            .await
-            .unwrap();
+        insert_large(&storage, "overwrite-key").await;
 
         let (hv_meta, _) = hv.get_stored(&id).unwrap();
         assert!(hv_meta.is_tombstone());
         let (lt_meta, lt_bytes) = lt.get_stored(&id).unwrap();
         assert!(!lt_meta.is_tombstone());
-        assert_eq!(lt_bytes.len(), large_payload.len());
+        assert_eq!(lt_bytes.len(), LARGE_SIZE);
         assert_consistent(&storage, &hv, &lt, &id).await;
     }
 
     #[tokio::test]
     async fn overwrite_large_with_small_after_delete() {
         let (storage, hv, lt) = make_tiered_storage();
-        let large_payload = vec![0xAAu8; 2 * 1024 * 1024];
-        let small_payload = vec![0xBBu8; 100];
-
-        let id = storage
-            .insert_object(
-                make_context(),
-                Some("reinsert-small".into()),
-                &Default::default(),
-                make_stream(&large_payload),
-            )
-            .await
-            .unwrap();
+        let id = insert_large(&storage, "reinsert-small").await;
         storage.delete_object(&id).await.unwrap();
 
-        storage
-            .insert_object(
-                make_context(),
-                Some("reinsert-small".into()),
-                &Default::default(),
-                make_stream(&small_payload),
-            )
-            .await
-            .unwrap();
+        insert_small(&storage, "reinsert-small").await;
 
         let (hv_meta, hv_bytes) = hv.get_stored(&id).unwrap();
         assert!(!hv_meta.is_tombstone());
-        assert_eq!(hv_bytes.len(), small_payload.len());
+        assert_eq!(hv_bytes.len(), SMALL.len());
         assert!(!lt.contains(&id));
         assert_consistent(&storage, &hv, &lt, &id).await;
     }
@@ -853,15 +820,7 @@ mod tests {
     #[tokio::test]
     async fn delete_small_only_object() {
         let (storage, hv, lt) = make_tiered_storage();
-        let id = storage
-            .insert_object(
-                make_context(),
-                Some("delete-small".into()),
-                &Default::default(),
-                make_stream(&vec![0xCCu8; 512]),
-            )
-            .await
-            .unwrap();
+        let id = insert_small(&storage, "delete-small").await;
 
         storage.delete_object(&id).await.unwrap();
 
@@ -919,15 +878,11 @@ mod tests {
     /// an unreachable orphan in long-term storage.
     #[tokio::test]
     async fn no_orphan_when_tombstone_write_fails() {
-        let lt = InMemoryBackend::new("lt");
         let hv = InMemoryBackend::new("hv");
-        let hv_fail: BoxedBackend = Box::new(SelectiveFailBackend::new(hv, FailOn::Put));
-        let storage = TieredStorage {
-            high_volume_backend: hv_fail,
-            long_term_backend: Box::new(lt.clone()),
-        };
+        let lt = InMemoryBackend::new("lt");
+        let storage = make_failing_storage(&hv, &lt, FailSide::Hv, FailOn::Put);
 
-        let payload = vec![0xABu8; 2 * 1024 * 1024]; // 2 MiB -> long-term path
+        let payload = large_payload();
         let result = storage
             .insert_object(
                 make_context(),
@@ -946,34 +901,21 @@ mod tests {
     #[tokio::test]
     async fn tombstone_preserved_when_long_term_delete_fails() {
         let hv = InMemoryBackend::new("hv");
-        let lt_inner = InMemoryBackend::new("lt");
-        let lt: BoxedBackend = Box::new(SelectiveFailBackend::new(lt_inner, FailOn::Delete));
-        let storage = TieredStorage {
-            high_volume_backend: Box::new(hv.clone()),
-            long_term_backend: lt,
-        };
+        let lt = InMemoryBackend::new("lt");
+        let setup = make_tiered_from(&hv, &lt);
+        let id = insert_large(&setup, "fail-delete").await;
 
-        let payload = vec![0xABu8; 2 * 1024 * 1024]; // 2 MiB -> goes to long-term
-        let id = storage
-            .insert_object(
-                make_context(),
-                Some("fail-delete".into()),
-                &Default::default(),
-                make_stream(&payload),
-            )
-            .await
-            .unwrap();
-
+        let storage = make_failing_storage(&hv, &lt, FailSide::Lt, FailOn::Delete);
         let result = storage.delete_object(&id).await;
         assert!(result.is_err());
 
         let (hv_meta, _) = hv.get_stored(&id).expect("tombstone removed");
         assert!(hv_meta.is_tombstone());
 
-        // The object should still be reachable through the service
-        let (metadata, stream) = storage.get_object(&id).await.unwrap().unwrap();
+        // The object should still be reachable through the setup storage
+        let (metadata, stream) = setup.get_object(&id).await.unwrap().unwrap();
         let body: BytesMut = stream.try_collect().await.unwrap();
-        assert_eq!(body.len(), payload.len());
+        assert_eq!(body.len(), LARGE_SIZE);
         assert!(!metadata.is_tombstone());
     }
 
@@ -985,44 +927,23 @@ mod tests {
     async fn insert_large_hv_metadata_check_fails() {
         let hv = InMemoryBackend::new("hv");
         let lt = InMemoryBackend::new("lt");
+        let setup = make_tiered_from(&hv, &lt);
+        let id = insert_large(&setup, "meta-fail").await;
+        assert_consistent(&setup, &hv, &lt, &id).await;
 
-        // Pre-populate a large object so there's a tombstone + LT data.
-        let pre_storage = TieredStorage {
-            high_volume_backend: Box::new(hv.clone()),
-            long_term_backend: Box::new(lt.clone()),
-        };
-        let payload = vec![0xAAu8; 2 * 1024 * 1024];
-        let id = pre_storage
+        let storage = make_failing_storage(&hv, &lt, FailSide::Hv, FailOn::GetMetadata);
+        let payload = large_payload();
+        let result = storage
             .insert_object(
                 make_context(),
                 Some("meta-fail".into()),
                 &Default::default(),
                 make_stream(&payload),
             )
-            .await
-            .unwrap();
-        assert_consistent(&pre_storage, &hv, &lt, &id).await;
-
-        // Now create a storage with HV that fails on get_metadata.
-        let hv_fail: BoxedBackend =
-            Box::new(SelectiveFailBackend::new(hv.clone(), FailOn::GetMetadata));
-        let storage = TieredStorage {
-            high_volume_backend: hv_fail,
-            long_term_backend: Box::new(lt.clone()),
-        };
-
-        let new_payload = vec![0xBBu8; 2 * 1024 * 1024];
-        let result = storage
-            .insert_object(
-                make_context(),
-                Some("meta-fail".into()),
-                &Default::default(),
-                make_stream(&new_payload),
-            )
             .await;
 
         assert!(result.is_err());
-        assert_consistent(&pre_storage, &hv, &lt, &id).await;
+        assert_consistent(&setup, &hv, &lt, &id).await;
     }
 
     /// LT.put_object fails before the tombstone write during large insert.
@@ -1031,13 +952,9 @@ mod tests {
     async fn insert_large_lt_put_fails() {
         let hv = InMemoryBackend::new("hv");
         let lt = InMemoryBackend::new("lt");
-        let lt_fail: BoxedBackend = Box::new(SelectiveFailBackend::new(lt.clone(), FailOn::Put));
-        let storage = TieredStorage {
-            high_volume_backend: Box::new(hv.clone()),
-            long_term_backend: lt_fail,
-        };
+        let storage = make_failing_storage(&hv, &lt, FailSide::Lt, FailOn::Put);
 
-        let payload = vec![0xABu8; 2 * 1024 * 1024];
+        let payload = large_payload();
         let result = storage
             .insert_object(
                 make_context(),
@@ -1048,7 +965,6 @@ mod tests {
             .await;
 
         assert!(result.is_err());
-        // Nothing should have been written to either backend.
         assert!(hv.is_empty());
         assert!(lt.is_empty());
     }
@@ -1060,19 +976,14 @@ mod tests {
     async fn insert_small_hv_put_fails() {
         let hv = InMemoryBackend::new("hv");
         let lt = InMemoryBackend::new("lt");
-        let hv_fail: BoxedBackend = Box::new(SelectiveFailBackend::new(hv.clone(), FailOn::Put));
-        let storage = TieredStorage {
-            high_volume_backend: hv_fail,
-            long_term_backend: Box::new(lt.clone()),
-        };
+        let storage = make_failing_storage(&hv, &lt, FailSide::Hv, FailOn::Put);
 
-        let payload = vec![0u8; 100]; // small
         let result = storage
             .insert_object(
                 make_context(),
                 Some("small-put-fail".into()),
                 &Default::default(),
-                make_stream(&payload),
+                make_stream(SMALL),
             )
             .await;
 
@@ -1088,33 +999,13 @@ mod tests {
     async fn get_large_hv_fails() {
         let hv = InMemoryBackend::new("hv");
         let lt = InMemoryBackend::new("lt");
+        let setup = make_tiered_from(&hv, &lt);
+        let id = insert_large(&setup, "get-hv-fail").await;
 
-        // Insert a large object normally first.
-        let setup_storage = TieredStorage {
-            high_volume_backend: Box::new(hv.clone()),
-            long_term_backend: Box::new(lt.clone()),
-        };
-        let payload = vec![0xAAu8; 2 * 1024 * 1024];
-        let id = setup_storage
-            .insert_object(
-                make_context(),
-                Some("get-hv-fail".into()),
-                &Default::default(),
-                make_stream(&payload),
-            )
-            .await
-            .unwrap();
-
-        // Now read with a failing HV.
-        let hv_fail: BoxedBackend = Box::new(SelectiveFailBackend::new(hv.clone(), FailOn::Get));
-        let storage = TieredStorage {
-            high_volume_backend: hv_fail,
-            long_term_backend: Box::new(lt.clone()),
-        };
-
+        let storage = make_failing_storage(&hv, &lt, FailSide::Hv, FailOn::Get);
         let result = storage.get_object(&id).await;
         assert!(result.is_err());
-        assert_consistent(&setup_storage, &hv, &lt, &id).await;
+        assert_consistent(&setup, &hv, &lt, &id).await;
     }
 
     /// HV returns tombstone successfully but LT.get_object fails.
@@ -1122,33 +1013,13 @@ mod tests {
     async fn get_large_lt_fails_after_tombstone() {
         let hv = InMemoryBackend::new("hv");
         let lt = InMemoryBackend::new("lt");
+        let setup = make_tiered_from(&hv, &lt);
+        let id = insert_large(&setup, "get-lt-fail").await;
 
-        // Insert a large object normally first.
-        let setup_storage = TieredStorage {
-            high_volume_backend: Box::new(hv.clone()),
-            long_term_backend: Box::new(lt.clone()),
-        };
-        let payload = vec![0xAAu8; 2 * 1024 * 1024];
-        let id = setup_storage
-            .insert_object(
-                make_context(),
-                Some("get-lt-fail".into()),
-                &Default::default(),
-                make_stream(&payload),
-            )
-            .await
-            .unwrap();
-
-        // Now read with a failing LT.
-        let lt_fail: BoxedBackend = Box::new(SelectiveFailBackend::new(lt.clone(), FailOn::Get));
-        let storage = TieredStorage {
-            high_volume_backend: Box::new(hv.clone()),
-            long_term_backend: lt_fail,
-        };
-
+        let storage = make_failing_storage(&hv, &lt, FailSide::Lt, FailOn::Get);
         let result = storage.get_object(&id).await;
         assert!(result.is_err());
-        assert_consistent(&setup_storage, &hv, &lt, &id).await;
+        assert_consistent(&setup, &hv, &lt, &id).await;
     }
 
     // --- Get small: outage tests ---
@@ -1158,33 +1029,13 @@ mod tests {
     async fn get_small_hv_fails() {
         let hv = InMemoryBackend::new("hv");
         let lt = InMemoryBackend::new("lt");
+        let setup = make_tiered_from(&hv, &lt);
+        let id = insert_small(&setup, "get-small-fail").await;
 
-        // Insert a small object normally first.
-        let setup_storage = TieredStorage {
-            high_volume_backend: Box::new(hv.clone()),
-            long_term_backend: Box::new(lt.clone()),
-        };
-        let payload = vec![0u8; 100];
-        let id = setup_storage
-            .insert_object(
-                make_context(),
-                Some("get-small-fail".into()),
-                &Default::default(),
-                make_stream(&payload),
-            )
-            .await
-            .unwrap();
-
-        // Now read with a failing HV.
-        let hv_fail: BoxedBackend = Box::new(SelectiveFailBackend::new(hv.clone(), FailOn::Get));
-        let storage = TieredStorage {
-            high_volume_backend: hv_fail,
-            long_term_backend: Box::new(lt.clone()),
-        };
-
+        let storage = make_failing_storage(&hv, &lt, FailSide::Hv, FailOn::Get);
         let result = storage.get_object(&id).await;
         assert!(result.is_err());
-        assert_consistent(&setup_storage, &hv, &lt, &id).await;
+        assert_consistent(&setup, &hv, &lt, &id).await;
     }
 
     // --- Delete large: outage tests ---
@@ -1195,38 +1046,17 @@ mod tests {
     async fn delete_large_hv_delete_non_tombstone_fails() {
         let hv = InMemoryBackend::new("hv");
         let lt = InMemoryBackend::new("lt");
-
-        // Insert a large object normally first.
-        let setup_storage = TieredStorage {
-            high_volume_backend: Box::new(hv.clone()),
-            long_term_backend: Box::new(lt.clone()),
-        };
-        let payload = vec![0xAAu8; 2 * 1024 * 1024];
-        let id = setup_storage
-            .insert_object(
-                make_context(),
-                Some("del-large-fail".into()),
-                &Default::default(),
-                make_stream(&payload),
-            )
-            .await
-            .unwrap();
+        let setup = make_tiered_from(&hv, &lt);
+        let id = insert_large(&setup, "del-large-fail").await;
 
         // delete_non_tombstone calls get_metadata then delete_object.
         // Failing get_metadata prevents the delete path from proceeding.
-        let hv_fail: BoxedBackend =
-            Box::new(SelectiveFailBackend::new(hv.clone(), FailOn::GetMetadata));
-        let storage = TieredStorage {
-            high_volume_backend: hv_fail,
-            long_term_backend: Box::new(lt.clone()),
-        };
-
+        let storage = make_failing_storage(&hv, &lt, FailSide::Hv, FailOn::GetMetadata);
         let result = storage.delete_object(&id).await;
         assert!(result.is_err());
-        assert_consistent(&setup_storage, &hv, &lt, &id).await;
+        assert_consistent(&setup, &hv, &lt, &id).await;
 
-        // Data should still be reachable.
-        let get_result = setup_storage.get_object(&id).await.unwrap();
+        let get_result = setup.get_object(&id).await.unwrap();
         assert!(get_result.is_some());
     }
 
@@ -1238,36 +1068,16 @@ mod tests {
     async fn delete_small_hv_delete_fails() {
         let hv = InMemoryBackend::new("hv");
         let lt = InMemoryBackend::new("lt");
-
-        // Insert a small object normally first.
-        let setup_storage = TieredStorage {
-            high_volume_backend: Box::new(hv.clone()),
-            long_term_backend: Box::new(lt.clone()),
-        };
-        let payload = vec![0u8; 100];
-        let id = setup_storage
-            .insert_object(
-                make_context(),
-                Some("del-small-fail".into()),
-                &Default::default(),
-                make_stream(&payload),
-            )
-            .await
-            .unwrap();
+        let setup = make_tiered_from(&hv, &lt);
+        let id = insert_small(&setup, "del-small-fail").await;
 
         // delete_non_tombstone calls get_metadata (succeeds), then delete_object (fails).
-        let hv_fail: BoxedBackend = Box::new(SelectiveFailBackend::new(hv.clone(), FailOn::Delete));
-        let storage = TieredStorage {
-            high_volume_backend: hv_fail,
-            long_term_backend: Box::new(lt.clone()),
-        };
-
+        let storage = make_failing_storage(&hv, &lt, FailSide::Hv, FailOn::Delete);
         let result = storage.delete_object(&id).await;
         assert!(result.is_err());
-        assert_consistent(&setup_storage, &hv, &lt, &id).await;
+        assert_consistent(&setup, &hv, &lt, &id).await;
 
-        // Data should still be reachable.
-        let get_result = setup_storage.get_object(&id).await.unwrap();
+        let get_result = setup.get_object(&id).await.unwrap();
         assert!(get_result.is_some());
     }
 
@@ -1290,7 +1100,7 @@ mod tests {
             long_term_backend: Box::new(lt),
         };
 
-        let payload = vec![0xEEu8; 2 * 1024 * 1024];
+        let payload = large_payload();
         let result = storage
             .insert_object(
                 make_context(),
@@ -1321,30 +1131,11 @@ mod tests {
     async fn delete_tombstone_cleanup_failure_leaves_orphan_tombstone() {
         let hv = InMemoryBackend::new("hv");
         let lt = InMemoryBackend::new("lt");
-
-        let setup_storage = TieredStorage {
-            high_volume_backend: Box::new(hv.clone()),
-            long_term_backend: Box::new(lt.clone()),
-        };
-
-        let payload = vec![0xFFu8; 2 * 1024 * 1024];
-        let id = setup_storage
-            .insert_object(
-                make_context(),
-                Some("orphan-tombstone-delete".into()),
-                &Default::default(),
-                make_stream(&payload),
-            )
-            .await
-            .unwrap();
+        let setup = make_tiered_from(&hv, &lt);
+        let id = insert_large(&setup, "orphan-tombstone-delete").await;
 
         // HV delete always fails → tombstone cleanup will fail.
-        let hv_fail = SelectiveFailBackend::new(hv.clone(), FailOn::Delete);
-        let delete_storage = TieredStorage {
-            high_volume_backend: Box::new(hv_fail),
-            long_term_backend: Box::new(lt.clone()),
-        };
-
+        let delete_storage = make_failing_storage(&hv, &lt, FailSide::Hv, FailOn::Delete);
         let result = delete_storage.delete_object(&id).await;
         assert!(result.is_err());
 
@@ -1353,7 +1144,7 @@ mod tests {
         assert!(hv_meta.is_tombstone(), "tombstone should survive");
 
         // OrphanTombstone is accepted: assert_consistent verifies reads return None.
-        assert_consistent(&setup_storage, &hv, &lt, &id).await;
+        assert_consistent(&setup, &hv, &lt, &id).await;
     }
 
     // ==========================================
@@ -1377,7 +1168,7 @@ mod tests {
         };
 
         let id = ObjectId::new(make_context(), "pod-kill-insert".into());
-        let payload = vec![0xABu8; 2 * 1024 * 1024];
+        let payload = large_payload();
 
         // Start the insert; it will block at the HV put (tombstone write).
         let insert_handle = tokio::spawn(async move {
@@ -1414,23 +1205,9 @@ mod tests {
     async fn pod_kill_during_delete_large_after_lt_delete() {
         let hv = InMemoryBackend::new("hv");
         let lt = InMemoryBackend::new("lt");
-
-        // First, insert a large object normally.
-        let setup_storage = TieredStorage {
-            high_volume_backend: Box::new(hv.clone()),
-            long_term_backend: Box::new(lt.clone()),
-        };
-        let payload = vec![0xAAu8; 2 * 1024 * 1024];
-        let id = setup_storage
-            .insert_object(
-                make_context(),
-                Some("pod-kill-delete".into()),
-                &Default::default(),
-                make_stream(&payload),
-            )
-            .await
-            .unwrap();
-        assert_consistent(&setup_storage, &hv, &lt, &id).await;
+        let setup = make_tiered_from(&hv, &lt);
+        let id = insert_large(&setup, "pod-kill-delete").await;
+        assert_consistent(&setup, &hv, &lt, &id).await;
 
         // Now set up a storage where HV blocks on delete_object (tombstone cleanup).
         let never_signal = Arc::new(Notify::new());
@@ -1455,7 +1232,7 @@ mod tests {
         // After cancellation: tombstone in HV, nothing in LT -> OrphanTombstone.
         assert!(hv.contains(&id), "HV should still have the tombstone");
         assert!(!lt.contains(&id), "LT data should have been deleted");
-        assert_consistent(&setup_storage, &hv, &lt, &id).await;
+        assert_consistent(&setup, &hv, &lt, &id).await;
     }
 
     // ==========================================
@@ -1468,22 +1245,8 @@ mod tests {
     async fn race_concurrent_delete_delete_is_safe() {
         let hv = InMemoryBackend::new("hv");
         let lt = InMemoryBackend::new("lt");
-
-        // Insert a large object.
-        let storage = Arc::new(TieredStorage {
-            high_volume_backend: Box::new(hv.clone()),
-            long_term_backend: Box::new(lt.clone()),
-        });
-        let payload = vec![0xAAu8; 2 * 1024 * 1024];
-        let id = storage
-            .insert_object(
-                make_context(),
-                Some("race-delete".into()),
-                &Default::default(),
-                make_stream(&payload),
-            )
-            .await
-            .unwrap();
+        let storage = Arc::new(make_tiered_from(&hv, &lt));
+        let id = insert_large(&storage, "race-delete").await;
 
         // Spawn two concurrent deletes.
         let storage1 = Arc::clone(&storage);
@@ -1517,17 +1280,13 @@ mod tests {
         use bytes::{Bytes, BytesMut};
         use futures_util::{StreamExt, TryStreamExt};
         use objectstore_types::metadata::Metadata;
-        use objectstore_types::scope::{Scope, Scopes};
         use tokio::sync::Notify;
 
         use super::*;
-        use crate::stream::make_stream;
 
         type Store = HashMap<ObjectId, (Metadata, Bytes)>;
 
-        /// Checks consistency invariants against raw stores (parallel to
-        /// `check_invariants` which takes `InMemoryBackend`).
-        fn check_invariants_raw(
+        fn check_store_invariants(
             hv_store: &Store,
             lt_store: &Store,
             id: &ObjectId,
@@ -1536,21 +1295,7 @@ mod tests {
             let hv_present = hv_entry.is_some();
             let hv_tombstone = hv_entry.is_some_and(|(m, _)| m.is_tombstone());
             let lt_present = lt_store.contains_key(id);
-
-            match (hv_present, hv_tombstone, lt_present) {
-                (false, _, false) => Ok(()),
-                (true, false, false) => Ok(()),
-                (true, true, true) => Ok(()),
-                (true, true, false) => Ok(()),
-                (false, _, true) => Err(format!(
-                    "OrphanLT: data in LT for key {:?} but nothing in HV",
-                    id.key()
-                )),
-                (true, false, true) => Err(format!(
-                    "DualData: non-tombstone in HV AND data in LT for key {:?}",
-                    id.key()
-                )),
-            }
+            check_invariants_core(hv_present, hv_tombstone, lt_present, id.key())
         }
 
         /// A backend backed by a shared HashMap with Notify-based sync hooks
@@ -1567,7 +1312,7 @@ mod tests {
         }
 
         impl SyncBackend {
-            fn plain(name: &'static str, store: Arc<Mutex<Store>>) -> Self {
+            fn new(name: &'static str, store: Arc<Mutex<Store>>) -> Self {
                 Self {
                     name,
                     store,
@@ -1577,6 +1322,33 @@ mod tests {
                     delete_wait: None,
                     delete_signal: None,
                 }
+            }
+
+            fn on_put(mut self, wait: Arc<Notify>, signal: Arc<Notify>) -> Self {
+                self.put_wait = Some(wait);
+                self.put_signal = Some(signal);
+                self
+            }
+
+            fn on_put_wait(mut self, wait: Arc<Notify>) -> Self {
+                self.put_wait = Some(wait);
+                self
+            }
+
+            fn on_get_metadata_signal(mut self, signal: Arc<Notify>) -> Self {
+                self.get_metadata_signal = Some(signal);
+                self
+            }
+
+            fn on_delete(mut self, wait: Arc<Notify>, signal: Arc<Notify>) -> Self {
+                self.delete_wait = Some(wait);
+                self.delete_signal = Some(signal);
+                self
+            }
+
+            fn on_delete_wait(mut self, wait: Arc<Notify>) -> Self {
+                self.delete_wait = Some(wait);
+                self
             }
         }
 
@@ -1643,13 +1415,6 @@ mod tests {
             }
         }
 
-        fn make_context() -> ObjectContext {
-            ObjectContext {
-                usecase: "race-test".into(),
-                scopes: Scopes::from_iter([Scope::create("test", "concurrent").unwrap()]),
-            }
-        }
-
         /// Race 1: Concurrent insert(large) + insert(small) → OrphanLT.
         ///
         /// ```text
@@ -1671,58 +1436,53 @@ mod tests {
 
             // A: HV put waits for B's metadata check, then signals when done.
             let storage_a = TieredStorage {
-                high_volume_backend: Box::new(SyncBackend {
-                    name: "hv-a",
-                    store: Arc::clone(&shared_hv_store),
-                    put_wait: Some(Arc::clone(&b_metadata_checked)),
-                    put_signal: Some(Arc::clone(&a_tombstone_written)),
-                    get_metadata_signal: None,
-                    delete_wait: None,
-                    delete_signal: None,
-                }),
-                long_term_backend: Box::new(SyncBackend::plain(
-                    "lt-a",
-                    Arc::clone(&shared_lt_store),
-                )),
+                high_volume_backend: Box::new(
+                    SyncBackend::new("hv-a", Arc::clone(&shared_hv_store)).on_put(
+                        Arc::clone(&b_metadata_checked),
+                        Arc::clone(&a_tombstone_written),
+                    ),
+                ),
+                long_term_backend: Box::new(SyncBackend::new("lt-a", Arc::clone(&shared_lt_store))),
             };
 
             // B: HV get_metadata signals when done; HV put waits for A's tombstone.
             let storage_b = TieredStorage {
-                high_volume_backend: Box::new(SyncBackend {
-                    name: "hv-b",
-                    store: Arc::clone(&shared_hv_store),
-                    put_wait: Some(Arc::clone(&a_tombstone_written)),
-                    put_signal: None,
-                    get_metadata_signal: Some(Arc::clone(&b_metadata_checked)),
-                    delete_wait: None,
-                    delete_signal: None,
-                }),
-                long_term_backend: Box::new(SyncBackend::plain(
-                    "lt-b",
-                    Arc::clone(&shared_lt_store),
-                )),
+                high_volume_backend: Box::new(
+                    SyncBackend::new("hv-b", Arc::clone(&shared_hv_store))
+                        .on_put_wait(Arc::clone(&a_tombstone_written))
+                        .on_get_metadata_signal(Arc::clone(&b_metadata_checked)),
+                ),
+                long_term_backend: Box::new(SyncBackend::new("lt-b", Arc::clone(&shared_lt_store))),
             };
 
             let context = make_context();
             let key = "race-insert-insert";
-            let large_payload = vec![0xAAu8; 2 * 1024 * 1024];
-            let small_payload = vec![0xBBu8; 100];
+            let large_payload = super::large_payload();
+            let small_payload = SMALL;
 
             let task_a = {
                 let ctx = context.clone();
-                let p = large_payload.clone();
                 tokio::spawn(async move {
                     storage_a
-                        .insert_object(ctx, Some(key.into()), &Default::default(), make_stream(&p))
+                        .insert_object(
+                            ctx,
+                            Some(key.into()),
+                            &Default::default(),
+                            make_stream(&large_payload),
+                        )
                         .await
                 })
             };
             let task_b = {
                 let ctx = context.clone();
-                let p = small_payload.clone();
                 tokio::spawn(async move {
                     storage_b
-                        .insert_object(ctx, Some(key.into()), &Default::default(), make_stream(&p))
+                        .insert_object(
+                            ctx,
+                            Some(key.into()),
+                            &Default::default(),
+                            make_stream(small_payload),
+                        )
                         .await
                 })
             };
@@ -1735,7 +1495,7 @@ mod tests {
             let id = ObjectId::new(context, key.into());
             let hv_store = shared_hv_store.lock().unwrap();
             let lt_store = shared_lt_store.lock().unwrap();
-            let violation = check_invariants_raw(&hv_store, &lt_store, &id);
+            let violation = check_store_invariants(&hv_store, &lt_store, &id);
             assert!(
                 violation.unwrap_err().contains("DualData"),
                 "concurrent insert+insert must violate consistency"
@@ -1774,10 +1534,7 @@ mod tests {
                     .insert(id.clone(), (tombstone_meta, Bytes::new()));
                 shared_lt_store.lock().unwrap().insert(
                     id.clone(),
-                    (
-                        Metadata::default(),
-                        Bytes::from(vec![0xFFu8; 2 * 1024 * 1024]),
-                    ),
+                    (Metadata::default(), Bytes::from(super::large_payload())),
                 );
             }
 
@@ -1788,58 +1545,40 @@ mod tests {
             // A (delete): LT delete waits for B's metadata check, signals when done.
             //             HV delete waits for B's LT write.
             let storage_a = TieredStorage {
-                high_volume_backend: Box::new(SyncBackend {
-                    name: "hv-a",
-                    store: Arc::clone(&shared_hv_store),
-                    put_wait: None,
-                    put_signal: None,
-                    get_metadata_signal: None,
-                    delete_wait: Some(Arc::clone(&b_wrote_lt)),
-                    delete_signal: None,
-                }),
-                long_term_backend: Box::new(SyncBackend {
-                    name: "lt-a",
-                    store: Arc::clone(&shared_lt_store),
-                    put_wait: None,
-                    put_signal: None,
-                    get_metadata_signal: None,
-                    delete_wait: Some(Arc::clone(&b_checked_metadata)),
-                    delete_signal: Some(Arc::clone(&a_deleted_lt)),
-                }),
+                high_volume_backend: Box::new(
+                    SyncBackend::new("hv-a", Arc::clone(&shared_hv_store))
+                        .on_delete_wait(Arc::clone(&b_wrote_lt)),
+                ),
+                long_term_backend: Box::new(
+                    SyncBackend::new("lt-a", Arc::clone(&shared_lt_store))
+                        .on_delete(Arc::clone(&b_checked_metadata), Arc::clone(&a_deleted_lt)),
+                ),
             };
 
             // B (insert): HV get_metadata signals when done.
             //             LT put waits for A's LT delete, signals when done.
             let storage_b = TieredStorage {
-                high_volume_backend: Box::new(SyncBackend {
-                    name: "hv-b",
-                    store: Arc::clone(&shared_hv_store),
-                    put_wait: None,
-                    put_signal: None,
-                    get_metadata_signal: Some(Arc::clone(&b_checked_metadata)),
-                    delete_wait: None,
-                    delete_signal: None,
-                }),
-                long_term_backend: Box::new(SyncBackend {
-                    name: "lt-b",
-                    store: Arc::clone(&shared_lt_store),
-                    put_wait: Some(Arc::clone(&a_deleted_lt)),
-                    put_signal: Some(Arc::clone(&b_wrote_lt)),
-                    get_metadata_signal: None,
-                    delete_wait: None,
-                    delete_signal: None,
-                }),
+                high_volume_backend: Box::new(
+                    SyncBackend::new("hv-b", Arc::clone(&shared_hv_store))
+                        .on_get_metadata_signal(Arc::clone(&b_checked_metadata)),
+                ),
+                long_term_backend: Box::new(
+                    SyncBackend::new("lt-b", Arc::clone(&shared_lt_store))
+                        .on_put(Arc::clone(&a_deleted_lt), Arc::clone(&b_wrote_lt)),
+                ),
             };
-
-            let new_payload = vec![0xCCu8; 100];
 
             let task_a = tokio::spawn(async move { storage_a.delete_object(&id).await });
             let task_b = {
                 let ctx = context.clone();
-                let p = new_payload.clone();
                 tokio::spawn(async move {
                     storage_b
-                        .insert_object(ctx, Some(key.into()), &Default::default(), make_stream(&p))
+                        .insert_object(
+                            ctx,
+                            Some(key.into()),
+                            &Default::default(),
+                            make_stream(SMALL),
+                        )
                         .await
                 })
             };
@@ -1852,7 +1591,7 @@ mod tests {
             let id = ObjectId::new(make_context(), key.into());
             let hv_store = shared_hv_store.lock().unwrap();
             let lt_store = shared_lt_store.lock().unwrap();
-            let violation = check_invariants_raw(&hv_store, &lt_store, &id);
+            let violation = check_store_invariants(&hv_store, &lt_store, &id);
             assert!(
                 violation.unwrap_err().contains("OrphanLT"),
                 "concurrent insert+delete must produce OrphanLT"

--- a/objectstore-service/src/tiered.rs
+++ b/objectstore-service/src/tiered.rs
@@ -259,12 +259,14 @@ impl GetResponseExt for GetResponse {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
     use std::time::Duration;
 
     use bytes::BytesMut;
     use futures_util::TryStreamExt;
     use objectstore_types::metadata::ExpirationPolicy;
     use objectstore_types::scope::{Scope, Scopes};
+    use tokio::sync::Notify;
 
     use super::*;
     use crate::backend::common::BoxedBackend;
@@ -289,7 +291,212 @@ mod tests {
         (storage, hv, lt)
     }
 
-    // --- Basic behavior ---
+    fn simulated_error(msg: &str) -> Error {
+        Error::Io(std::io::Error::new(
+            std::io::ErrorKind::ConnectionRefused,
+            msg.to_owned(),
+        ))
+    }
+
+    // ==========================================
+    // Correctness predicate
+    // ==========================================
+    //
+    // Invariants for any given key:
+    // - No OrphanLT: if LT has data, HV must have a tombstone pointing to it
+    // - No DualData: HV and LT must not both contain non-tombstone data
+    // - OrphanTombstone is safe: tombstone in HV with nothing in LT must
+    //   return None on read
+    //
+    // `check_invariants` is the sync core that returns Err on violation.
+    // `assert_consistent` wraps it and additionally verifies OrphanTombstone
+    // reads return None.
+
+    /// Checks the three consistency invariants. Returns `Err(msg)` on violation.
+    fn check_invariants(
+        hv: &InMemoryBackend,
+        lt: &InMemoryBackend,
+        id: &ObjectId,
+    ) -> std::result::Result<(), String> {
+        let hv_entry = hv.get_stored(id);
+        let lt_entry = lt.get_stored(id);
+
+        let hv_present = hv_entry.is_some();
+        let hv_tombstone = hv_entry.as_ref().is_some_and(|(m, _)| m.is_tombstone());
+        let lt_present = lt_entry.is_some();
+
+        match (hv_present, hv_tombstone, lt_present) {
+            (false, _, false) => Ok(()),    // Empty
+            (true, false, false) => Ok(()), // Small
+            (true, true, true) => Ok(()),   // Large
+            (true, true, false) => Ok(()),  // OrphanTombstone (async check in assert_consistent)
+            (false, _, true) => Err(format!(
+                "OrphanLT: data in LT for key {:?} but nothing in HV",
+                id.key()
+            )),
+            (true, false, true) => Err(format!(
+                "DualData: non-tombstone in HV AND data in LT for key {:?}",
+                id.key()
+            )),
+        }
+    }
+
+    /// Panics if invariants are violated. For OrphanTombstone, additionally
+    /// verifies that reads return None.
+    async fn assert_consistent(
+        storage: &TieredStorage,
+        hv: &InMemoryBackend,
+        lt: &InMemoryBackend,
+        id: &ObjectId,
+    ) {
+        check_invariants(hv, lt, id).unwrap_or_else(|msg| panic!("{msg}"));
+
+        // OrphanTombstone acceptance check: reads must return None.
+        let is_orphan_tombstone =
+            hv.get_stored(id).is_some_and(|(m, _)| m.is_tombstone()) && !lt.contains(id);
+        if is_orphan_tombstone {
+            assert!(
+                storage.get_object(id).await.unwrap().is_none(),
+                "OrphanTombstone: get_object should return None for key {:?}",
+                id.key()
+            );
+            assert!(
+                storage.get_metadata(id).await.unwrap().is_none(),
+                "OrphanTombstone: get_metadata should return None for key {:?}",
+                id.key()
+            );
+        }
+    }
+
+    // ==========================================
+    // Shared mock backends
+    // ==========================================
+
+    /// Which backend operation should fail.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum FailOn {
+        Put,
+        Get,
+        GetMetadata,
+        Delete,
+    }
+
+    /// A backend that delegates to an inner `InMemoryBackend` but fails on a
+    /// configurable operation.
+    #[derive(Debug)]
+    struct SelectiveFailBackend {
+        inner: InMemoryBackend,
+        fail_on: FailOn,
+    }
+
+    impl SelectiveFailBackend {
+        fn new(inner: InMemoryBackend, fail_on: FailOn) -> Self {
+            Self { inner, fail_on }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl crate::backend::common::Backend for SelectiveFailBackend {
+        fn name(&self) -> &'static str {
+            "selective-fail"
+        }
+
+        async fn put_object(
+            &self,
+            id: &ObjectId,
+            metadata: &Metadata,
+            stream: PayloadStream,
+        ) -> Result<()> {
+            if self.fail_on == FailOn::Put {
+                return Err(simulated_error("selective-fail: put_object"));
+            }
+            self.inner.put_object(id, metadata, stream).await
+        }
+
+        async fn get_object(&self, id: &ObjectId) -> Result<Option<(Metadata, PayloadStream)>> {
+            if self.fail_on == FailOn::Get {
+                return Err(simulated_error("selective-fail: get_object"));
+            }
+            self.inner.get_object(id).await
+        }
+
+        async fn get_metadata(&self, id: &ObjectId) -> Result<Option<Metadata>> {
+            if self.fail_on == FailOn::GetMetadata {
+                return Err(simulated_error("selective-fail: get_metadata"));
+            }
+            self.inner.get_metadata(id).await
+        }
+
+        async fn delete_object(&self, id: &ObjectId) -> Result<()> {
+            if self.fail_on == FailOn::Delete {
+                return Err(simulated_error("selective-fail: delete_object"));
+            }
+            self.inner.delete_object(id).await
+        }
+    }
+
+    /// A backend that pauses on a specific operation until a `Notify` is signaled,
+    /// then delegates to the inner `InMemoryBackend`.
+    #[derive(Debug)]
+    struct SyncBackend {
+        inner: InMemoryBackend,
+        sync_on: FailOn,
+        notify: Arc<Notify>,
+    }
+
+    impl SyncBackend {
+        fn new(inner: InMemoryBackend, sync_on: FailOn, notify: Arc<Notify>) -> Self {
+            Self {
+                inner,
+                sync_on,
+                notify,
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl crate::backend::common::Backend for SyncBackend {
+        fn name(&self) -> &'static str {
+            "sync"
+        }
+
+        async fn put_object(
+            &self,
+            id: &ObjectId,
+            metadata: &Metadata,
+            stream: PayloadStream,
+        ) -> Result<()> {
+            if self.sync_on == FailOn::Put {
+                self.notify.notified().await;
+            }
+            self.inner.put_object(id, metadata, stream).await
+        }
+
+        async fn get_object(&self, id: &ObjectId) -> Result<Option<(Metadata, PayloadStream)>> {
+            if self.sync_on == FailOn::Get {
+                self.notify.notified().await;
+            }
+            self.inner.get_object(id).await
+        }
+
+        async fn get_metadata(&self, id: &ObjectId) -> Result<Option<Metadata>> {
+            if self.sync_on == FailOn::GetMetadata {
+                self.notify.notified().await;
+            }
+            self.inner.get_metadata(id).await
+        }
+
+        async fn delete_object(&self, id: &ObjectId) -> Result<()> {
+            if self.sync_on == FailOn::Delete {
+                self.notify.notified().await;
+            }
+            self.inner.delete_object(id).await
+        }
+    }
+
+    // ==========================================
+    // Happy path: state transitions
+    // ==========================================
 
     #[tokio::test]
     async fn get_nonexistent_returns_none() {
@@ -329,8 +536,6 @@ mod tests {
         assert_eq!(body.as_ref(), b"auto-keyed");
     }
 
-    // --- Size-based routing tests ---
-
     #[tokio::test]
     async fn small_object_goes_to_high_volume() {
         let (storage, hv, lt) = make_tiered_storage();
@@ -348,6 +553,7 @@ mod tests {
 
         assert!(hv.contains(&id), "expected in high-volume");
         assert!(!lt.contains(&id), "leaked to long-term");
+        assert_consistent(&storage, &hv, &lt, &id).await;
     }
 
     #[tokio::test]
@@ -373,13 +579,15 @@ mod tests {
         // A redirect tombstone should exist in high-volume
         let (hv_meta, _) = hv.get_stored(&id).unwrap();
         assert!(hv_meta.is_tombstone());
+
+        assert_consistent(&storage, &hv, &lt, &id).await;
     }
 
     #[tokio::test]
     async fn reinsert_with_existing_tombstone_routes_to_long_term() {
         let (storage, hv, lt) = make_tiered_storage();
 
-        // First: insert a large object → creates tombstone in hv, payload in lt
+        // First: insert a large object -> creates tombstone in hv, payload in lt
         let large_payload = vec![0xABu8; 2 * 1024 * 1024];
         let id = storage
             .insert_object(
@@ -415,6 +623,8 @@ mod tests {
         // The tombstone in hv should still be present
         let (hv_meta, _) = hv.get_stored(&id).unwrap();
         assert!(hv_meta.is_tombstone());
+
+        assert_consistent(&storage, &hv, &lt, &id).await;
     }
 
     #[tokio::test]
@@ -453,8 +663,6 @@ mod tests {
         assert_eq!(lt_meta.expiration_policy, metadata_in.expiration_policy);
     }
 
-    // --- Tombstone redirect tests ---
-
     #[tokio::test]
     async fn reads_follow_tombstone_redirect() {
         let (storage, _hv, _lt) = make_tiered_storage();
@@ -486,98 +694,6 @@ mod tests {
         assert_eq!(metadata.content_type, "image/png");
     }
 
-    // --- Tombstone inconsistency tests ---
-
-    /// A backend where put_object always fails, but reads/deletes work normally.
-    #[derive(Debug)]
-    struct FailingPutBackend(InMemoryBackend);
-
-    #[async_trait::async_trait]
-    impl crate::backend::common::Backend for FailingPutBackend {
-        fn name(&self) -> &'static str {
-            "failing-put"
-        }
-
-        async fn put_object(
-            &self,
-            _id: &ObjectId,
-            _metadata: &Metadata,
-            _stream: PayloadStream,
-        ) -> Result<()> {
-            Err(Error::Io(std::io::Error::new(
-                std::io::ErrorKind::ConnectionRefused,
-                "simulated tombstone write failure",
-            )))
-        }
-
-        async fn get_object(&self, id: &ObjectId) -> Result<Option<(Metadata, PayloadStream)>> {
-            self.0.get_object(id).await
-        }
-
-        async fn delete_object(&self, id: &ObjectId) -> Result<()> {
-            self.0.delete_object(id).await
-        }
-    }
-
-    /// If the tombstone write to the high-volume backend fails after the long-term
-    /// write succeeds, the long-term object must be cleaned up so we never leave
-    /// an unreachable orphan in long-term storage.
-    #[tokio::test]
-    async fn no_orphan_when_tombstone_write_fails() {
-        let lt = InMemoryBackend::new("lt");
-        let hv: BoxedBackend = Box::new(FailingPutBackend(InMemoryBackend::new("hv")));
-        let storage = TieredStorage {
-            high_volume_backend: hv,
-            long_term_backend: Box::new(lt.clone()),
-        };
-
-        let payload = vec![0xABu8; 2 * 1024 * 1024]; // 2 MiB -> long-term path
-        let result = storage
-            .insert_object(
-                make_context(),
-                Some("orphan-test".into()),
-                &Default::default(),
-                make_stream(&payload),
-            )
-            .await;
-
-        assert!(result.is_err());
-        assert!(lt.is_empty(), "long-term object not cleaned up");
-    }
-
-    /// If a tombstone exists in high-volume but the corresponding object is
-    /// missing from long-term storage (e.g. due to a race condition or partial
-    /// cleanup), reads should gracefully return None rather than error.
-    #[tokio::test]
-    async fn orphan_tombstone_returns_none() {
-        let (storage, _hv, lt) = make_tiered_storage();
-        let payload = vec![0xCDu8; 2 * 1024 * 1024]; // 2 MiB
-
-        let id = storage
-            .insert_object(
-                make_context(),
-                Some("orphan-tombstone".into()),
-                &Default::default(),
-                make_stream(&payload),
-            )
-            .await
-            .unwrap();
-
-        // Remove the long-term object, leaving an orphan tombstone in hv
-        lt.remove(&id);
-
-        assert!(
-            storage.get_object(&id).await.unwrap().is_none(),
-            "orphan tombstone should resolve to None on get_object"
-        );
-        assert!(
-            storage.get_metadata(&id).await.unwrap().is_none(),
-            "orphan tombstone should resolve to None on get_metadata"
-        );
-    }
-
-    // --- Delete tests ---
-
     #[tokio::test]
     async fn delete_cleans_up_both_backends() {
         let (storage, hv, lt) = make_tiered_storage();
@@ -597,37 +713,232 @@ mod tests {
 
         assert!(!hv.contains(&id), "tombstone not cleaned up");
         assert!(!lt.contains(&id), "object not cleaned up");
+        assert_consistent(&storage, &hv, &lt, &id).await;
     }
 
-    /// A backend wrapper that delegates everything except `delete_object`, which always fails.
-    #[derive(Debug)]
-    struct FailingDeleteBackend(InMemoryBackend);
+    #[tokio::test]
+    async fn orphan_tombstone_returns_none() {
+        let (storage, hv, lt) = make_tiered_storage();
+        let payload = vec![0xCDu8; 2 * 1024 * 1024]; // 2 MiB
 
-    #[async_trait::async_trait]
-    impl crate::backend::common::Backend for FailingDeleteBackend {
-        fn name(&self) -> &'static str {
-            "failing-delete"
-        }
+        let id = storage
+            .insert_object(
+                make_context(),
+                Some("orphan-tombstone".into()),
+                &Default::default(),
+                make_stream(&payload),
+            )
+            .await
+            .unwrap();
 
-        async fn put_object(
-            &self,
-            id: &ObjectId,
-            metadata: &Metadata,
-            stream: PayloadStream,
-        ) -> Result<()> {
-            self.0.put_object(id, metadata, stream).await
-        }
+        // Remove the long-term object, leaving an orphan tombstone in hv
+        lt.remove(&id);
 
-        async fn get_object(&self, id: &ObjectId) -> Result<Option<(Metadata, PayloadStream)>> {
-            self.0.get_object(id).await
-        }
+        assert_consistent(&storage, &hv, &lt, &id).await;
+    }
 
-        async fn delete_object(&self, _id: &ObjectId) -> Result<()> {
-            Err(Error::Io(std::io::Error::new(
-                std::io::ErrorKind::ConnectionRefused,
-                "simulated long-term delete failure",
-            )))
+    #[tokio::test]
+    async fn multi_chunk_large_object_chains_buffered_and_remaining() {
+        let (storage, _hv, lt) = make_tiered_storage();
+
+        // Deliver a 2 MiB payload across multiple chunks that individually
+        // fit under the threshold but collectively exceed it.
+        let chunk_size = 512 * 1024; // 512 KiB per chunk
+        let chunk_count = 4; // 4 x 512 KiB = 2 MiB total
+        let chunks: Vec<std::io::Result<bytes::Bytes>> = (0..chunk_count)
+            .map(|i| Ok(bytes::Bytes::from(vec![i as u8; chunk_size])))
+            .collect();
+        let stream = futures_util::stream::iter(chunks).boxed();
+
+        let id = storage
+            .insert_object(
+                make_context(),
+                Some("multi-chunk".into()),
+                &Default::default(),
+                stream,
+            )
+            .await
+            .unwrap();
+
+        // Should have been routed to long-term (over 1 MiB).
+        let (lt_meta, lt_bytes) = lt.get_stored(&id).unwrap();
+        assert!(!lt_meta.is_tombstone());
+        assert_eq!(lt_bytes.len(), chunk_size * chunk_count);
+
+        // Verify data integrity -- each chunk's fill byte should appear in order.
+        for i in 0..chunk_count {
+            let offset = i * chunk_size;
+            assert!(
+                lt_bytes[offset..offset + chunk_size]
+                    .iter()
+                    .all(|&b| b == i as u8),
+                "data mismatch in chunk {i}"
+            );
         }
+    }
+
+    #[tokio::test]
+    async fn overwrite_small_with_large_no_prior_tombstone() {
+        let (storage, hv, lt) = make_tiered_storage();
+        let small_payload = vec![0xAAu8; 100];
+        let large_payload = vec![0xBBu8; 2 * 1024 * 1024];
+
+        let id = storage
+            .insert_object(
+                make_context(),
+                Some("overwrite-key".into()),
+                &Default::default(),
+                make_stream(&small_payload),
+            )
+            .await
+            .unwrap();
+
+        let (hv_meta, hv_bytes) = hv.get_stored(&id).unwrap();
+        assert!(!hv_meta.is_tombstone());
+        assert_eq!(hv_bytes.len(), small_payload.len());
+        assert!(!lt.contains(&id));
+
+        storage
+            .insert_object(
+                make_context(),
+                Some("overwrite-key".into()),
+                &Default::default(),
+                make_stream(&large_payload),
+            )
+            .await
+            .unwrap();
+
+        let (hv_meta, _) = hv.get_stored(&id).unwrap();
+        assert!(hv_meta.is_tombstone());
+        let (lt_meta, lt_bytes) = lt.get_stored(&id).unwrap();
+        assert!(!lt_meta.is_tombstone());
+        assert_eq!(lt_bytes.len(), large_payload.len());
+        assert_consistent(&storage, &hv, &lt, &id).await;
+    }
+
+    #[tokio::test]
+    async fn overwrite_large_with_small_after_delete() {
+        let (storage, hv, lt) = make_tiered_storage();
+        let large_payload = vec![0xAAu8; 2 * 1024 * 1024];
+        let small_payload = vec![0xBBu8; 100];
+
+        let id = storage
+            .insert_object(
+                make_context(),
+                Some("reinsert-small".into()),
+                &Default::default(),
+                make_stream(&large_payload),
+            )
+            .await
+            .unwrap();
+        storage.delete_object(&id).await.unwrap();
+
+        storage
+            .insert_object(
+                make_context(),
+                Some("reinsert-small".into()),
+                &Default::default(),
+                make_stream(&small_payload),
+            )
+            .await
+            .unwrap();
+
+        let (hv_meta, hv_bytes) = hv.get_stored(&id).unwrap();
+        assert!(!hv_meta.is_tombstone());
+        assert_eq!(hv_bytes.len(), small_payload.len());
+        assert!(!lt.contains(&id));
+        assert_consistent(&storage, &hv, &lt, &id).await;
+    }
+
+    #[tokio::test]
+    async fn delete_small_only_object() {
+        let (storage, hv, lt) = make_tiered_storage();
+        let id = storage
+            .insert_object(
+                make_context(),
+                Some("delete-small".into()),
+                &Default::default(),
+                make_stream(&vec![0xCCu8; 512]),
+            )
+            .await
+            .unwrap();
+
+        storage.delete_object(&id).await.unwrap();
+
+        assert!(!hv.contains(&id));
+        assert!(!lt.contains(&id));
+        assert_consistent(&storage, &hv, &lt, &id).await;
+    }
+
+    #[tokio::test]
+    async fn exact_threshold_goes_to_high_volume() {
+        let (storage, hv, lt) = make_tiered_storage();
+        let payload = vec![0xDDu8; BACKEND_SIZE_THRESHOLD];
+
+        let id = storage
+            .insert_object(
+                make_context(),
+                Some("exact-threshold".into()),
+                &Default::default(),
+                make_stream(&payload),
+            )
+            .await
+            .unwrap();
+
+        let (hv_meta, hv_bytes) = hv.get_stored(&id).unwrap();
+        assert!(!hv_meta.is_tombstone());
+        assert_eq!(hv_bytes.len(), BACKEND_SIZE_THRESHOLD);
+        assert!(!lt.contains(&id));
+        assert_consistent(&storage, &hv, &lt, &id).await;
+    }
+
+    #[tokio::test]
+    async fn empty_object_goes_to_high_volume() {
+        let (storage, hv, lt) = make_tiered_storage();
+        let id = storage
+            .insert_object(
+                make_context(),
+                Some("empty-object".into()),
+                &Default::default(),
+                make_stream(&[]),
+            )
+            .await
+            .unwrap();
+
+        assert!(hv.contains(&id));
+        assert!(!lt.contains(&id));
+        assert_consistent(&storage, &hv, &lt, &id).await;
+    }
+
+    // ==========================================
+    // Backend outages: error at each operation step
+    // ==========================================
+
+    /// If the tombstone write to the high-volume backend fails after the long-term
+    /// write succeeds, the long-term object must be cleaned up so we never leave
+    /// an unreachable orphan in long-term storage.
+    #[tokio::test]
+    async fn no_orphan_when_tombstone_write_fails() {
+        let lt = InMemoryBackend::new("lt");
+        let hv = InMemoryBackend::new("hv");
+        let hv_fail: BoxedBackend = Box::new(SelectiveFailBackend::new(hv, FailOn::Put));
+        let storage = TieredStorage {
+            high_volume_backend: hv_fail,
+            long_term_backend: Box::new(lt.clone()),
+        };
+
+        let payload = vec![0xABu8; 2 * 1024 * 1024]; // 2 MiB -> long-term path
+        let result = storage
+            .insert_object(
+                make_context(),
+                Some("orphan-test".into()),
+                &Default::default(),
+                make_stream(&payload),
+            )
+            .await;
+
+        assert!(result.is_err());
+        assert!(lt.is_empty(), "long-term object not cleaned up");
     }
 
     /// When the long-term delete fails, the tombstone must be preserved so the
@@ -635,7 +946,8 @@ mod tests {
     #[tokio::test]
     async fn tombstone_preserved_when_long_term_delete_fails() {
         let hv = InMemoryBackend::new("hv");
-        let lt: BoxedBackend = Box::new(FailingDeleteBackend(InMemoryBackend::new("lt")));
+        let lt_inner = InMemoryBackend::new("lt");
+        let lt: BoxedBackend = Box::new(SelectiveFailBackend::new(lt_inner, FailOn::Delete));
         let storage = TieredStorage {
             high_volume_backend: Box::new(hv.clone()),
             long_term_backend: lt,
@@ -665,45 +977,1031 @@ mod tests {
         assert!(!metadata.is_tombstone());
     }
 
-    // --- Multi-chunk streaming tests ---
+    // --- Insert large: outage tests ---
 
+    /// HV.get_metadata fails before any writes during insert of a large object
+    /// with an existing key. State should remain unchanged.
     #[tokio::test]
-    async fn multi_chunk_large_object_chains_buffered_and_remaining() {
-        let (storage, _hv, lt) = make_tiered_storage();
+    async fn insert_large_hv_metadata_check_fails() {
+        let hv = InMemoryBackend::new("hv");
+        let lt = InMemoryBackend::new("lt");
 
-        // Deliver a 2 MiB payload across multiple chunks that individually
-        // fit under the threshold but collectively exceed it.
-        let chunk_size = 512 * 1024; // 512 KiB per chunk
-        let chunk_count = 4; // 4 × 512 KiB = 2 MiB total
-        let chunks: Vec<std::io::Result<bytes::Bytes>> = (0..chunk_count)
-            .map(|i| Ok(bytes::Bytes::from(vec![i as u8; chunk_size])))
-            .collect();
-        let stream = futures_util::stream::iter(chunks).boxed();
-
-        let id = storage
+        // Pre-populate a large object so there's a tombstone + LT data.
+        let pre_storage = TieredStorage {
+            high_volume_backend: Box::new(hv.clone()),
+            long_term_backend: Box::new(lt.clone()),
+        };
+        let payload = vec![0xAAu8; 2 * 1024 * 1024];
+        let id = pre_storage
             .insert_object(
                 make_context(),
-                Some("multi-chunk".into()),
+                Some("meta-fail".into()),
                 &Default::default(),
-                stream,
+                make_stream(&payload),
+            )
+            .await
+            .unwrap();
+        assert_consistent(&pre_storage, &hv, &lt, &id).await;
+
+        // Now create a storage with HV that fails on get_metadata.
+        let hv_fail: BoxedBackend =
+            Box::new(SelectiveFailBackend::new(hv.clone(), FailOn::GetMetadata));
+        let storage = TieredStorage {
+            high_volume_backend: hv_fail,
+            long_term_backend: Box::new(lt.clone()),
+        };
+
+        let new_payload = vec![0xBBu8; 2 * 1024 * 1024];
+        let result = storage
+            .insert_object(
+                make_context(),
+                Some("meta-fail".into()),
+                &Default::default(),
+                make_stream(&new_payload),
+            )
+            .await;
+
+        assert!(result.is_err());
+        assert_consistent(&pre_storage, &hv, &lt, &id).await;
+    }
+
+    /// LT.put_object fails before the tombstone write during large insert.
+    /// State should remain unchanged (no writes succeed).
+    #[tokio::test]
+    async fn insert_large_lt_put_fails() {
+        let hv = InMemoryBackend::new("hv");
+        let lt = InMemoryBackend::new("lt");
+        let lt_fail: BoxedBackend = Box::new(SelectiveFailBackend::new(lt.clone(), FailOn::Put));
+        let storage = TieredStorage {
+            high_volume_backend: Box::new(hv.clone()),
+            long_term_backend: lt_fail,
+        };
+
+        let payload = vec![0xABu8; 2 * 1024 * 1024];
+        let result = storage
+            .insert_object(
+                make_context(),
+                Some("lt-put-fail".into()),
+                &Default::default(),
+                make_stream(&payload),
+            )
+            .await;
+
+        assert!(result.is_err());
+        // Nothing should have been written to either backend.
+        assert!(hv.is_empty());
+        assert!(lt.is_empty());
+    }
+
+    // --- Insert small: outage tests ---
+
+    /// HV.put_object fails during small insert. Nothing should be written.
+    #[tokio::test]
+    async fn insert_small_hv_put_fails() {
+        let hv = InMemoryBackend::new("hv");
+        let lt = InMemoryBackend::new("lt");
+        let hv_fail: BoxedBackend = Box::new(SelectiveFailBackend::new(hv.clone(), FailOn::Put));
+        let storage = TieredStorage {
+            high_volume_backend: hv_fail,
+            long_term_backend: Box::new(lt.clone()),
+        };
+
+        let payload = vec![0u8; 100]; // small
+        let result = storage
+            .insert_object(
+                make_context(),
+                Some("small-put-fail".into()),
+                &Default::default(),
+                make_stream(&payload),
+            )
+            .await;
+
+        assert!(result.is_err());
+        assert!(hv.is_empty());
+        assert!(lt.is_empty());
+    }
+
+    // --- Get large: outage tests ---
+
+    /// HV.get_object returns error when reading a large object.
+    #[tokio::test]
+    async fn get_large_hv_fails() {
+        let hv = InMemoryBackend::new("hv");
+        let lt = InMemoryBackend::new("lt");
+
+        // Insert a large object normally first.
+        let setup_storage = TieredStorage {
+            high_volume_backend: Box::new(hv.clone()),
+            long_term_backend: Box::new(lt.clone()),
+        };
+        let payload = vec![0xAAu8; 2 * 1024 * 1024];
+        let id = setup_storage
+            .insert_object(
+                make_context(),
+                Some("get-hv-fail".into()),
+                &Default::default(),
+                make_stream(&payload),
             )
             .await
             .unwrap();
 
-        // Should have been routed to long-term (over 1 MiB).
-        let (lt_meta, lt_bytes) = lt.get_stored(&id).unwrap();
-        assert!(!lt_meta.is_tombstone());
-        assert_eq!(lt_bytes.len(), chunk_size * chunk_count);
+        // Now read with a failing HV.
+        let hv_fail: BoxedBackend = Box::new(SelectiveFailBackend::new(hv.clone(), FailOn::Get));
+        let storage = TieredStorage {
+            high_volume_backend: hv_fail,
+            long_term_backend: Box::new(lt.clone()),
+        };
 
-        // Verify data integrity — each chunk's fill byte should appear in order.
-        for i in 0..chunk_count {
-            let offset = i * chunk_size;
+        let result = storage.get_object(&id).await;
+        assert!(result.is_err());
+        assert_consistent(&setup_storage, &hv, &lt, &id).await;
+    }
+
+    /// HV returns tombstone successfully but LT.get_object fails.
+    #[tokio::test]
+    async fn get_large_lt_fails_after_tombstone() {
+        let hv = InMemoryBackend::new("hv");
+        let lt = InMemoryBackend::new("lt");
+
+        // Insert a large object normally first.
+        let setup_storage = TieredStorage {
+            high_volume_backend: Box::new(hv.clone()),
+            long_term_backend: Box::new(lt.clone()),
+        };
+        let payload = vec![0xAAu8; 2 * 1024 * 1024];
+        let id = setup_storage
+            .insert_object(
+                make_context(),
+                Some("get-lt-fail".into()),
+                &Default::default(),
+                make_stream(&payload),
+            )
+            .await
+            .unwrap();
+
+        // Now read with a failing LT.
+        let lt_fail: BoxedBackend = Box::new(SelectiveFailBackend::new(lt.clone(), FailOn::Get));
+        let storage = TieredStorage {
+            high_volume_backend: Box::new(hv.clone()),
+            long_term_backend: lt_fail,
+        };
+
+        let result = storage.get_object(&id).await;
+        assert!(result.is_err());
+        assert_consistent(&setup_storage, &hv, &lt, &id).await;
+    }
+
+    // --- Get small: outage tests ---
+
+    /// HV.get_object returns error when reading a small object.
+    #[tokio::test]
+    async fn get_small_hv_fails() {
+        let hv = InMemoryBackend::new("hv");
+        let lt = InMemoryBackend::new("lt");
+
+        // Insert a small object normally first.
+        let setup_storage = TieredStorage {
+            high_volume_backend: Box::new(hv.clone()),
+            long_term_backend: Box::new(lt.clone()),
+        };
+        let payload = vec![0u8; 100];
+        let id = setup_storage
+            .insert_object(
+                make_context(),
+                Some("get-small-fail".into()),
+                &Default::default(),
+                make_stream(&payload),
+            )
+            .await
+            .unwrap();
+
+        // Now read with a failing HV.
+        let hv_fail: BoxedBackend = Box::new(SelectiveFailBackend::new(hv.clone(), FailOn::Get));
+        let storage = TieredStorage {
+            high_volume_backend: hv_fail,
+            long_term_backend: Box::new(lt.clone()),
+        };
+
+        let result = storage.get_object(&id).await;
+        assert!(result.is_err());
+        assert_consistent(&setup_storage, &hv, &lt, &id).await;
+    }
+
+    // --- Delete large: outage tests ---
+
+    /// The metadata check in delete_non_tombstone fails for a large object.
+    /// The tombstone and LT data should remain intact.
+    #[tokio::test]
+    async fn delete_large_hv_delete_non_tombstone_fails() {
+        let hv = InMemoryBackend::new("hv");
+        let lt = InMemoryBackend::new("lt");
+
+        // Insert a large object normally first.
+        let setup_storage = TieredStorage {
+            high_volume_backend: Box::new(hv.clone()),
+            long_term_backend: Box::new(lt.clone()),
+        };
+        let payload = vec![0xAAu8; 2 * 1024 * 1024];
+        let id = setup_storage
+            .insert_object(
+                make_context(),
+                Some("del-large-fail".into()),
+                &Default::default(),
+                make_stream(&payload),
+            )
+            .await
+            .unwrap();
+
+        // delete_non_tombstone calls get_metadata then delete_object.
+        // Failing get_metadata prevents the delete path from proceeding.
+        let hv_fail: BoxedBackend =
+            Box::new(SelectiveFailBackend::new(hv.clone(), FailOn::GetMetadata));
+        let storage = TieredStorage {
+            high_volume_backend: hv_fail,
+            long_term_backend: Box::new(lt.clone()),
+        };
+
+        let result = storage.delete_object(&id).await;
+        assert!(result.is_err());
+        assert_consistent(&setup_storage, &hv, &lt, &id).await;
+
+        // Data should still be reachable.
+        let get_result = setup_storage.get_object(&id).await.unwrap();
+        assert!(get_result.is_some());
+    }
+
+    // --- Delete small: outage tests ---
+
+    /// The delete_object call inside delete_non_tombstone fails for a small object.
+    /// The HV data should remain.
+    #[tokio::test]
+    async fn delete_small_hv_delete_fails() {
+        let hv = InMemoryBackend::new("hv");
+        let lt = InMemoryBackend::new("lt");
+
+        // Insert a small object normally first.
+        let setup_storage = TieredStorage {
+            high_volume_backend: Box::new(hv.clone()),
+            long_term_backend: Box::new(lt.clone()),
+        };
+        let payload = vec![0u8; 100];
+        let id = setup_storage
+            .insert_object(
+                make_context(),
+                Some("del-small-fail".into()),
+                &Default::default(),
+                make_stream(&payload),
+            )
+            .await
+            .unwrap();
+
+        // delete_non_tombstone calls get_metadata (succeeds), then delete_object (fails).
+        let hv_fail: BoxedBackend = Box::new(SelectiveFailBackend::new(hv.clone(), FailOn::Delete));
+        let storage = TieredStorage {
+            high_volume_backend: hv_fail,
+            long_term_backend: Box::new(lt.clone()),
+        };
+
+        let result = storage.delete_object(&id).await;
+        assert!(result.is_err());
+        assert_consistent(&setup_storage, &hv, &lt, &id).await;
+
+        // Data should still be reachable.
+        let get_result = setup_storage.get_object(&id).await.unwrap();
+        assert!(get_result.is_some());
+    }
+
+    // --- Insert large: double failure (G1) ---
+
+    /// When the tombstone write to HV fails AND the subsequent LT cleanup also
+    /// fails, an OrphanLT exists (data in LT, nothing in HV). This documents
+    /// gap G1 from the consistency analysis.
+    #[tokio::test]
+    async fn insert_cleanup_double_failure_leaves_orphan_lt() {
+        let lt_inner = InMemoryBackend::new("lt");
+        // LT: put succeeds (data write), delete always fails (cleanup).
+        let lt = SelectiveFailBackend::new(lt_inner.clone(), FailOn::Delete);
+        // HV: put always fails (tombstone write).
+        let hv_inner = InMemoryBackend::new("hv");
+        let hv = SelectiveFailBackend::new(hv_inner.clone(), FailOn::Put);
+
+        let storage = TieredStorage {
+            high_volume_backend: Box::new(hv),
+            long_term_backend: Box::new(lt),
+        };
+
+        let payload = vec![0xEEu8; 2 * 1024 * 1024];
+        let result = storage
+            .insert_object(
+                make_context(),
+                Some("double-fail".into()),
+                &Default::default(),
+                make_stream(&payload),
+            )
+            .await;
+
+        assert!(result.is_err(), "double failure should return an error");
+
+        // TODO(consistency): Fix insert cleanup to not lose the original error
+        // and to retry or accept the orphan gracefully.
+        let id = ObjectId::new(make_context(), "double-fail".into());
+        let violation = check_invariants(&hv_inner, &lt_inner, &id);
+        assert!(
+            violation.unwrap_err().contains("OrphanLT"),
+            "double failure must produce OrphanLT"
+        );
+    }
+
+    // --- Delete large: tombstone cleanup failure ---
+
+    /// When deleting a large object, if the HV tombstone cleanup fails after
+    /// the LT delete succeeds, an OrphanTombstone remains. Subsequent reads
+    /// should return None (accepted state via assert_consistent).
+    #[tokio::test]
+    async fn delete_tombstone_cleanup_failure_leaves_orphan_tombstone() {
+        let hv = InMemoryBackend::new("hv");
+        let lt = InMemoryBackend::new("lt");
+
+        let setup_storage = TieredStorage {
+            high_volume_backend: Box::new(hv.clone()),
+            long_term_backend: Box::new(lt.clone()),
+        };
+
+        let payload = vec![0xFFu8; 2 * 1024 * 1024];
+        let id = setup_storage
+            .insert_object(
+                make_context(),
+                Some("orphan-tombstone-delete".into()),
+                &Default::default(),
+                make_stream(&payload),
+            )
+            .await
+            .unwrap();
+
+        // HV delete always fails → tombstone cleanup will fail.
+        let hv_fail = SelectiveFailBackend::new(hv.clone(), FailOn::Delete);
+        let delete_storage = TieredStorage {
+            high_volume_backend: Box::new(hv_fail),
+            long_term_backend: Box::new(lt.clone()),
+        };
+
+        let result = delete_storage.delete_object(&id).await;
+        assert!(result.is_err());
+
+        assert!(!lt.contains(&id), "LT data should be deleted");
+        let (hv_meta, _) = hv.get_stored(&id).unwrap();
+        assert!(hv_meta.is_tombstone(), "tombstone should survive");
+
+        // OrphanTombstone is accepted: assert_consistent verifies reads return None.
+        assert_consistent(&setup_storage, &hv, &lt, &id).await;
+    }
+
+    // ==========================================
+    // Pod termination: drop between backend calls
+    // ==========================================
+
+    /// Insert large object: LT write completes, then the task is killed before
+    /// the tombstone write to HV. Result: OrphanLT (data in LT, nothing in HV).
+    /// This documents the known vulnerability.
+    #[tokio::test]
+    async fn pod_kill_during_insert_large_after_lt_write() {
+        let hv = InMemoryBackend::new("hv");
+        let lt = InMemoryBackend::new("lt");
+
+        // HV will block on put_object (the tombstone write), simulating a kill.
+        let never_signal = Arc::new(Notify::new());
+        let hv_sync = SyncBackend::new(hv.clone(), FailOn::Put, Arc::clone(&never_signal));
+        let storage = TieredStorage {
+            high_volume_backend: Box::new(hv_sync),
+            long_term_backend: Box::new(lt.clone()),
+        };
+
+        let id = ObjectId::new(make_context(), "pod-kill-insert".into());
+        let payload = vec![0xABu8; 2 * 1024 * 1024];
+
+        // Start the insert; it will block at the HV put (tombstone write).
+        let insert_handle = tokio::spawn(async move {
+            storage
+                .insert_object(
+                    make_context(),
+                    Some("pod-kill-insert".into()),
+                    &Default::default(),
+                    make_stream(&payload),
+                )
+                .await
+        });
+
+        // Wait just enough for LT write to complete, then cancel.
+        let timeout_result = tokio::time::timeout(Duration::from_millis(500), insert_handle).await;
+        assert!(
+            timeout_result.is_err(),
+            "insert should have been blocked on tombstone write"
+        );
+
+        // TODO(consistency): The tombstone must be written atomically with the
+        // LT data, or the incomplete insert must be rolled back on recovery.
+        let violation = check_invariants(&hv, &lt, &id);
+        assert!(
+            violation.unwrap_err().contains("OrphanLT"),
+            "pod kill after LT write must produce OrphanLT"
+        );
+    }
+
+    /// Delete large object: LT delete completes, then the task is killed before
+    /// the HV tombstone cleanup. Result: OrphanTombstone (tombstone in HV,
+    /// nothing in LT). Reads return None (accepted state).
+    #[tokio::test]
+    async fn pod_kill_during_delete_large_after_lt_delete() {
+        let hv = InMemoryBackend::new("hv");
+        let lt = InMemoryBackend::new("lt");
+
+        // First, insert a large object normally.
+        let setup_storage = TieredStorage {
+            high_volume_backend: Box::new(hv.clone()),
+            long_term_backend: Box::new(lt.clone()),
+        };
+        let payload = vec![0xAAu8; 2 * 1024 * 1024];
+        let id = setup_storage
+            .insert_object(
+                make_context(),
+                Some("pod-kill-delete".into()),
+                &Default::default(),
+                make_stream(&payload),
+            )
+            .await
+            .unwrap();
+        assert_consistent(&setup_storage, &hv, &lt, &id).await;
+
+        // Now set up a storage where HV blocks on delete_object (tombstone cleanup).
+        let never_signal = Arc::new(Notify::new());
+        let hv_sync = SyncBackend::new(hv.clone(), FailOn::Delete, Arc::clone(&never_signal));
+        let storage = Arc::new(TieredStorage {
+            high_volume_backend: Box::new(hv_sync),
+            long_term_backend: Box::new(lt.clone()),
+        });
+
+        let storage_clone = Arc::clone(&storage);
+        let id_clone = id.clone();
+        let delete_handle =
+            tokio::spawn(async move { storage_clone.delete_object(&id_clone).await });
+
+        // Wait just enough for LT delete to complete, then cancel.
+        let timeout_result = tokio::time::timeout(Duration::from_millis(500), delete_handle).await;
+        assert!(
+            timeout_result.is_err(),
+            "delete should have been blocked on HV tombstone cleanup"
+        );
+
+        // After cancellation: tombstone in HV, nothing in LT -> OrphanTombstone.
+        assert!(hv.contains(&id), "HV should still have the tombstone");
+        assert!(!lt.contains(&id), "LT data should have been deleted");
+        assert_consistent(&setup_storage, &hv, &lt, &id).await;
+    }
+
+    // ==========================================
+    // Concurrent races
+    // ==========================================
+
+    /// Two concurrent deletes on the same large object. Both should complete
+    /// without error (one may no-op). Backend state should be Empty.
+    #[tokio::test]
+    async fn race_concurrent_delete_delete_is_safe() {
+        let hv = InMemoryBackend::new("hv");
+        let lt = InMemoryBackend::new("lt");
+
+        // Insert a large object.
+        let storage = Arc::new(TieredStorage {
+            high_volume_backend: Box::new(hv.clone()),
+            long_term_backend: Box::new(lt.clone()),
+        });
+        let payload = vec![0xAAu8; 2 * 1024 * 1024];
+        let id = storage
+            .insert_object(
+                make_context(),
+                Some("race-delete".into()),
+                &Default::default(),
+                make_stream(&payload),
+            )
+            .await
+            .unwrap();
+
+        // Spawn two concurrent deletes.
+        let storage1 = Arc::clone(&storage);
+        let id1 = id.clone();
+        let handle1 = tokio::spawn(async move { storage1.delete_object(&id1).await });
+
+        let storage2 = Arc::clone(&storage);
+        let id2 = id.clone();
+        let handle2 = tokio::spawn(async move { storage2.delete_object(&id2).await });
+
+        let (r1, r2) = tokio::join!(handle1, handle2);
+        // Both should succeed (InMemoryBackend deletes are idempotent).
+        r1.unwrap().unwrap();
+        r2.unwrap().unwrap();
+
+        assert!(!hv.contains(&id), "HV should be empty");
+        assert!(!lt.contains(&id), "LT should be empty");
+        assert_consistent(&storage, &hv, &lt, &id).await;
+    }
+
+    // --- Deterministic race reproduction ---
+    //
+    // These tests use mock backends with synchronization primitives to
+    // deterministically reproduce the race conditions identified in the
+    // tiered consistency analysis. They prove that the OrphanLT gaps are real.
+
+    mod concurrent_races {
+        use std::collections::HashMap;
+        use std::sync::{Arc, Mutex};
+
+        use bytes::{Bytes, BytesMut};
+        use futures_util::{StreamExt, TryStreamExt};
+        use objectstore_types::metadata::Metadata;
+        use objectstore_types::scope::{Scope, Scopes};
+        use tokio::sync::Notify;
+
+        use super::*;
+        use crate::stream::make_stream;
+
+        type Store = HashMap<ObjectId, (Metadata, Bytes)>;
+
+        /// Checks consistency invariants against raw stores (parallel to
+        /// `check_invariants` which takes `InMemoryBackend`).
+        fn check_invariants_raw(
+            hv_store: &Store,
+            lt_store: &Store,
+            id: &ObjectId,
+        ) -> std::result::Result<(), String> {
+            let hv_entry = hv_store.get(id);
+            let hv_present = hv_entry.is_some();
+            let hv_tombstone = hv_entry.is_some_and(|(m, _)| m.is_tombstone());
+            let lt_present = lt_store.contains_key(id);
+
+            match (hv_present, hv_tombstone, lt_present) {
+                (false, _, false) => Ok(()),
+                (true, false, false) => Ok(()),
+                (true, true, true) => Ok(()),
+                (true, true, false) => Ok(()),
+                (false, _, true) => Err(format!(
+                    "OrphanLT: data in LT for key {:?} but nothing in HV",
+                    id.key()
+                )),
+                (true, false, true) => Err(format!(
+                    "DualData: non-tombstone in HV AND data in LT for key {:?}",
+                    id.key()
+                )),
+            }
+        }
+
+        /// A backend backed by a shared HashMap with Notify-based sync hooks
+        /// for precise interleaving control.
+        #[derive(Debug)]
+        struct SyncBackend {
+            name: &'static str,
+            store: Arc<Mutex<Store>>,
+            put_wait: Option<Arc<Notify>>,
+            put_signal: Option<Arc<Notify>>,
+            get_metadata_signal: Option<Arc<Notify>>,
+            delete_wait: Option<Arc<Notify>>,
+            delete_signal: Option<Arc<Notify>>,
+        }
+
+        impl SyncBackend {
+            fn plain(name: &'static str, store: Arc<Mutex<Store>>) -> Self {
+                Self {
+                    name,
+                    store,
+                    put_wait: None,
+                    put_signal: None,
+                    get_metadata_signal: None,
+                    delete_wait: None,
+                    delete_signal: None,
+                }
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl crate::backend::common::Backend for SyncBackend {
+            fn name(&self) -> &'static str {
+                self.name
+            }
+
+            async fn put_object(
+                &self,
+                id: &ObjectId,
+                metadata: &Metadata,
+                stream: PayloadStream,
+            ) -> crate::error::Result<()> {
+                let bytes: BytesMut = stream.try_collect().await?;
+                if let Some(wait) = &self.put_wait {
+                    wait.notified().await;
+                }
+                self.store
+                    .lock()
+                    .unwrap()
+                    .insert(id.clone(), (metadata.clone(), bytes.freeze()));
+                if let Some(signal) = &self.put_signal {
+                    signal.notify_one();
+                }
+                Ok(())
+            }
+
+            async fn get_object(
+                &self,
+                id: &ObjectId,
+            ) -> crate::error::Result<Option<(Metadata, PayloadStream)>> {
+                let entry = self.store.lock().unwrap().get(id).cloned();
+                Ok(entry.map(|(metadata, bytes)| {
+                    let mut metadata = metadata;
+                    metadata.size = Some(bytes.len());
+                    let stream = futures_util::stream::once(async move { Ok(bytes) }).boxed();
+                    (metadata, stream)
+                }))
+            }
+
+            async fn get_metadata(&self, id: &ObjectId) -> crate::error::Result<Option<Metadata>> {
+                let result = self.store.lock().unwrap().get(id).map(|(m, b)| {
+                    let mut m = m.clone();
+                    m.size = Some(b.len());
+                    m
+                });
+                if let Some(signal) = &self.get_metadata_signal {
+                    signal.notify_one();
+                }
+                Ok(result)
+            }
+
+            async fn delete_object(&self, id: &ObjectId) -> crate::error::Result<()> {
+                if let Some(wait) = &self.delete_wait {
+                    wait.notified().await;
+                }
+                self.store.lock().unwrap().remove(id);
+                if let Some(signal) = &self.delete_signal {
+                    signal.notify_one();
+                }
+                Ok(())
+            }
+        }
+
+        fn make_context() -> ObjectContext {
+            ObjectContext {
+                usecase: "race-test".into(),
+                scopes: Scopes::from_iter([Scope::create("test", "concurrent").unwrap()]),
+            }
+        }
+
+        /// Race 1: Concurrent insert(large) + insert(small) → OrphanLT.
+        ///
+        /// ```text
+        /// A: insert large "foo"     B: insert small "foo"
+        /// A: peek -> LongTerm       B: peek -> HighVolume
+        ///                            B: check HV -> no tombstone
+        /// A: write data to LT
+        /// A: write tombstone to HV
+        ///                            B: write small to HV (overwrites tombstone!)
+        /// Result: HV=small data, LT=large data (OrphanLT)
+        /// ```
+        #[tokio::test]
+        async fn race_concurrent_insert_insert_causes_orphan_lt() {
+            let shared_hv_store: Arc<Mutex<Store>> = Arc::new(Mutex::new(HashMap::new()));
+            let shared_lt_store: Arc<Mutex<Store>> = Arc::new(Mutex::new(HashMap::new()));
+
+            let a_tombstone_written = Arc::new(Notify::new());
+            let b_metadata_checked = Arc::new(Notify::new());
+
+            // A: HV put waits for B's metadata check, then signals when done.
+            let storage_a = TieredStorage {
+                high_volume_backend: Box::new(SyncBackend {
+                    name: "hv-a",
+                    store: Arc::clone(&shared_hv_store),
+                    put_wait: Some(Arc::clone(&b_metadata_checked)),
+                    put_signal: Some(Arc::clone(&a_tombstone_written)),
+                    get_metadata_signal: None,
+                    delete_wait: None,
+                    delete_signal: None,
+                }),
+                long_term_backend: Box::new(SyncBackend::plain(
+                    "lt-a",
+                    Arc::clone(&shared_lt_store),
+                )),
+            };
+
+            // B: HV get_metadata signals when done; HV put waits for A's tombstone.
+            let storage_b = TieredStorage {
+                high_volume_backend: Box::new(SyncBackend {
+                    name: "hv-b",
+                    store: Arc::clone(&shared_hv_store),
+                    put_wait: Some(Arc::clone(&a_tombstone_written)),
+                    put_signal: None,
+                    get_metadata_signal: Some(Arc::clone(&b_metadata_checked)),
+                    delete_wait: None,
+                    delete_signal: None,
+                }),
+                long_term_backend: Box::new(SyncBackend::plain(
+                    "lt-b",
+                    Arc::clone(&shared_lt_store),
+                )),
+            };
+
+            let context = make_context();
+            let key = "race-insert-insert";
+            let large_payload = vec![0xAAu8; 2 * 1024 * 1024];
+            let small_payload = vec![0xBBu8; 100];
+
+            let task_a = {
+                let ctx = context.clone();
+                let p = large_payload.clone();
+                tokio::spawn(async move {
+                    storage_a
+                        .insert_object(ctx, Some(key.into()), &Default::default(), make_stream(&p))
+                        .await
+                })
+            };
+            let task_b = {
+                let ctx = context.clone();
+                let p = small_payload.clone();
+                tokio::spawn(async move {
+                    storage_b
+                        .insert_object(ctx, Some(key.into()), &Default::default(), make_stream(&p))
+                        .await
+                })
+            };
+
+            task_a.await.unwrap().unwrap();
+            task_b.await.unwrap().unwrap();
+
+            // TODO(consistency): Prevent concurrent insert+insert from producing
+            // OrphanLT, e.g. via per-key serialization or conditional writes.
+            let id = ObjectId::new(context, key.into());
+            let hv_store = shared_hv_store.lock().unwrap();
+            let lt_store = shared_lt_store.lock().unwrap();
+            let violation = check_invariants_raw(&hv_store, &lt_store, &id);
             assert!(
-                lt_bytes[offset..offset + chunk_size]
-                    .iter()
-                    .all(|&b| b == i as u8),
-                "data mismatch in chunk {i}"
+                violation.unwrap_err().contains("DualData"),
+                "concurrent insert+insert must violate consistency"
             );
+        }
+
+        /// Race 2: Concurrent insert(small) + delete → OrphanLT.
+        ///
+        /// ```text
+        /// State: Large (HV=tombstone, LT=data)
+        /// A: delete "foo"            B: insert small "foo"
+        /// A: delete_non_tombstone -> Tombstone
+        ///                            B: check HV -> IS tombstone -> route to LT
+        /// A: delete from LT          B: write new data to LT
+        /// A: delete tombstone from HV
+        /// Result: HV=nothing, LT=new data (OrphanLT)
+        /// ```
+        #[tokio::test]
+        async fn race_concurrent_insert_delete_causes_orphan_lt() {
+            let shared_hv_store: Arc<Mutex<Store>> = Arc::new(Mutex::new(HashMap::new()));
+            let shared_lt_store: Arc<Mutex<Store>> = Arc::new(Mutex::new(HashMap::new()));
+
+            let context = make_context();
+            let key = "race-insert-delete";
+            let id = ObjectId::new(context.clone(), key.into());
+
+            // Pre-seed Large state.
+            {
+                let tombstone_meta = Metadata {
+                    is_redirect_tombstone: Some(true),
+                    ..Default::default()
+                };
+                shared_hv_store
+                    .lock()
+                    .unwrap()
+                    .insert(id.clone(), (tombstone_meta, Bytes::new()));
+                shared_lt_store.lock().unwrap().insert(
+                    id.clone(),
+                    (
+                        Metadata::default(),
+                        Bytes::from(vec![0xFFu8; 2 * 1024 * 1024]),
+                    ),
+                );
+            }
+
+            let b_checked_metadata = Arc::new(Notify::new());
+            let a_deleted_lt = Arc::new(Notify::new());
+            let b_wrote_lt = Arc::new(Notify::new());
+
+            // A (delete): LT delete waits for B's metadata check, signals when done.
+            //             HV delete waits for B's LT write.
+            let storage_a = TieredStorage {
+                high_volume_backend: Box::new(SyncBackend {
+                    name: "hv-a",
+                    store: Arc::clone(&shared_hv_store),
+                    put_wait: None,
+                    put_signal: None,
+                    get_metadata_signal: None,
+                    delete_wait: Some(Arc::clone(&b_wrote_lt)),
+                    delete_signal: None,
+                }),
+                long_term_backend: Box::new(SyncBackend {
+                    name: "lt-a",
+                    store: Arc::clone(&shared_lt_store),
+                    put_wait: None,
+                    put_signal: None,
+                    get_metadata_signal: None,
+                    delete_wait: Some(Arc::clone(&b_checked_metadata)),
+                    delete_signal: Some(Arc::clone(&a_deleted_lt)),
+                }),
+            };
+
+            // B (insert): HV get_metadata signals when done.
+            //             LT put waits for A's LT delete, signals when done.
+            let storage_b = TieredStorage {
+                high_volume_backend: Box::new(SyncBackend {
+                    name: "hv-b",
+                    store: Arc::clone(&shared_hv_store),
+                    put_wait: None,
+                    put_signal: None,
+                    get_metadata_signal: Some(Arc::clone(&b_checked_metadata)),
+                    delete_wait: None,
+                    delete_signal: None,
+                }),
+                long_term_backend: Box::new(SyncBackend {
+                    name: "lt-b",
+                    store: Arc::clone(&shared_lt_store),
+                    put_wait: Some(Arc::clone(&a_deleted_lt)),
+                    put_signal: Some(Arc::clone(&b_wrote_lt)),
+                    get_metadata_signal: None,
+                    delete_wait: None,
+                    delete_signal: None,
+                }),
+            };
+
+            let new_payload = vec![0xCCu8; 100];
+
+            let task_a = tokio::spawn(async move { storage_a.delete_object(&id).await });
+            let task_b = {
+                let ctx = context.clone();
+                let p = new_payload.clone();
+                tokio::spawn(async move {
+                    storage_b
+                        .insert_object(ctx, Some(key.into()), &Default::default(), make_stream(&p))
+                        .await
+                })
+            };
+
+            task_a.await.unwrap().unwrap();
+            task_b.await.unwrap().unwrap();
+
+            // TODO(consistency): Prevent concurrent insert+delete from producing
+            // OrphanLT, e.g. via per-key serialization or conditional writes.
+            let id = ObjectId::new(make_context(), key.into());
+            let hv_store = shared_hv_store.lock().unwrap();
+            let lt_store = shared_lt_store.lock().unwrap();
+            let violation = check_invariants_raw(&hv_store, &lt_store, &id);
+            assert!(
+                violation.unwrap_err().contains("OrphanLT"),
+                "concurrent insert+delete must produce OrphanLT"
+            );
+        }
+    }
+
+    // ==========================================
+    // Property-based fuzzing
+    // ==========================================
+
+    mod proptest_state_machine {
+        use std::collections::HashMap;
+
+        use bytes::BytesMut;
+        use futures_util::TryStreamExt;
+        use objectstore_types::scope::{Scope, Scopes};
+        use proptest::prelude::*;
+
+        use super::*;
+
+        #[derive(Debug, Clone, PartialEq)]
+        enum KeyState {
+            Empty,
+            Small(Vec<u8>),
+            Large(Vec<u8>),
+        }
+
+        #[derive(Debug, Clone)]
+        enum Op {
+            Insert { key_idx: usize, small: bool },
+            Get { key_idx: usize },
+            Delete { key_idx: usize },
+            GetMetadata { key_idx: usize },
+        }
+
+        const KEY_NAMES: &[&str] = &["key-a", "key-b", "key-c"];
+        const SMALL_SIZE: usize = 100;
+        const LARGE_SIZE: usize = 2 * 1024 * 1024;
+
+        fn arb_op() -> impl Strategy<Value = Op> {
+            let key_idx = 0..KEY_NAMES.len();
+            prop_oneof![
+                (key_idx.clone(), any::<bool>())
+                    .prop_map(|(key_idx, small)| Op::Insert { key_idx, small }),
+                key_idx.clone().prop_map(|key_idx| Op::Get { key_idx }),
+                key_idx.clone().prop_map(|key_idx| Op::Delete { key_idx }),
+                key_idx.prop_map(|key_idx| Op::GetMetadata { key_idx }),
+            ]
+        }
+
+        fn make_payload(key_idx: usize, small: bool) -> Vec<u8> {
+            let size = if small { SMALL_SIZE } else { LARGE_SIZE };
+            vec![key_idx as u8; size]
+        }
+
+        proptest! {
+            #![proptest_config(ProptestConfig::with_cases(100))]
+
+            #[test]
+            fn sequential_operations_maintain_invariants(ops in prop::collection::vec(arb_op(), 1..30)) {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+
+                rt.block_on(async {
+                    let hv = InMemoryBackend::new("proptest-hv");
+                    let lt = InMemoryBackend::new("proptest-lt");
+                    let storage = TieredStorage {
+                        high_volume_backend: Box::new(hv.clone()),
+                        long_term_backend: Box::new(lt.clone()),
+                    };
+
+                    let context = ObjectContext {
+                        usecase: "proptest".into(),
+                        scopes: Scopes::from_iter([
+                            Scope::create("test", "prop").unwrap(),
+                        ]),
+                    };
+
+                    let ids: Vec<ObjectId> = KEY_NAMES
+                        .iter()
+                        .map(|&name| ObjectId::new(context.clone(), name.into()))
+                        .collect();
+
+                    let mut expected: HashMap<usize, KeyState> = HashMap::new();
+                    for i in 0..KEY_NAMES.len() {
+                        expected.insert(i, KeyState::Empty);
+                    }
+
+                    for op in &ops {
+                        match op {
+                            Op::Insert { key_idx, small } => {
+                                let payload = make_payload(*key_idx, *small);
+                                let stream = crate::stream::make_stream(&payload);
+                                storage
+                                    .insert_object(
+                                        context.clone(),
+                                        Some(KEY_NAMES[*key_idx].into()),
+                                        &Default::default(),
+                                        stream,
+                                    )
+                                    .await
+                                    .unwrap();
+                                if *small {
+                                    expected.insert(*key_idx, KeyState::Small(payload));
+                                } else {
+                                    expected.insert(*key_idx, KeyState::Large(payload));
+                                }
+                            }
+                            Op::Get { key_idx } => {
+                                let result = storage.get_object(&ids[*key_idx]).await.unwrap();
+                                match expected.get(key_idx).unwrap() {
+                                    KeyState::Empty => {
+                                        assert!(result.is_none());
+                                    }
+                                    KeyState::Small(data) | KeyState::Large(data) => {
+                                        let (metadata, stream) = result.unwrap();
+                                        assert!(!metadata.is_tombstone());
+                                        let body: BytesMut =
+                                            stream.try_collect().await.unwrap();
+                                        assert_eq!(body.len(), data.len());
+                                    }
+                                }
+                            }
+                            Op::Delete { key_idx } => {
+                                storage.delete_object(&ids[*key_idx]).await.unwrap();
+                                expected.insert(*key_idx, KeyState::Empty);
+                            }
+                            Op::GetMetadata { key_idx } => {
+                                let result =
+                                    storage.get_metadata(&ids[*key_idx]).await.unwrap();
+                                match expected.get(key_idx).unwrap() {
+                                    KeyState::Empty => assert!(result.is_none()),
+                                    KeyState::Small(_) | KeyState::Large(_) => {
+                                        assert!(!result.unwrap().is_tombstone());
+                                    }
+                                }
+                            }
+                        }
+
+                        // After every operation, verify backend invariants.
+                        for id in &ids {
+                            assert_consistent(&storage, &hv, &lt, id).await;
+                        }
+                    }
+                });
+            }
         }
     }
 }


### PR DESCRIPTION
Formalizes three consistency invariants for `TieredStorage` and adds a structured test suite that proves they hold under normal operation and documents where they break.

## Invariants

- **No OrphanLT**: if LT has data, HV must have a tombstone pointing to it
- **No DualData**: HV and LT must not both contain non-tombstone data
- **OrphanTombstone is safe**: tombstone in HV with nothing in LT must return None on read

## Testing strategy

Tests are organized into five categories, all using mocked backends (no real GCS/BigTable):

1. **Happy path** (16 tests) — all state transitions including overwrites, boundary cases (0 bytes, exactly 1 MiB), and tombstone redirect behavior
2. **Backend outages** (12 tests) — error injection at every step of every operation, verifying `check_invariants` passes after each failure (state unchanged or safely degraded)
3. **Pod termination** (2 tests) — drop futures mid-operation via `SyncBackend` + timeout, proving OrphanLT occurs on insert kill and OrphanTombstone (safe) on delete kill
4. **Concurrent races** (3 tests) — deterministic interleaving via `Notify`-based sync hooks, proving insert+insert and insert+delete produce invariant violations
5. **Property-based fuzzing** (1 proptest, 100 random sequences) — random operation sequences on 3 keys with `assert_consistent` after every operation

## Known violations

All four known violations run through `check_invariants` and assert it returns `Err`:

- Pod kill between LT write and tombstone write → OrphanLT
- Concurrent insert+insert on same key → DualData
- Concurrent insert+delete on same key → OrphanLT
- Insert tombstone write fails AND cleanup fails → OrphanLT

When a fix lands, `check_invariants` will return `Ok`, the `unwrap_err()` will panic, and the test must be updated to `assert_consistent` — making fixes self-enforcing.

Ref FS-236