### PR TITLE
feat(server): Add per-usecase expiration policy configuration

### DIFF
--- a/objectstore-server/docs/architecture.md
+++ b/objectstore-server/docs/architecture.md
@@ -109,6 +109,7 @@ Key configuration sections:
 - `http` — HTTP layer parameters (concurrency limit)
 - `service` — storage service parameters (backend concurrency limit)
 - `killswitches` — traffic blocking rules
+- `usecases` — per-use-case properties (expiration policy constraints)
 - `runtime` — worker threads, metrics interval
 - `sentry` / `metrics` / `logging` — observability
 
@@ -272,3 +273,14 @@ matched, cause requests to be rejected with HTTP 403:
 A killswitch with no conditions matches all traffic. Multiple killswitches are
 evaluated with OR semantics — any match triggers rejection. Killswitches are
 checked during request extraction, before the handler runs.
+
+## Use Cases
+
+The `usecases` config block configures per-use-case properties. Use cases
+not present in the map are unconstrained. Currently this covers expiration
+policy constraints: which policies are permitted and their maximum durations.
+Writes that violate the constraints are rejected with HTTP 400. Validation
+applies to all insert paths: single-object `POST` and `PUT` endpoints and
+batch `INSERT` operations.
+
+See [`usecases`] for the full configuration schema and YAML examples.

--- a/objectstore-server/src/config.rs
+++ b/objectstore-server/src/config.rs
@@ -50,6 +50,7 @@ pub use objectstore_service::backend::StorageConfig;
 
 use crate::killswitches::Killswitches;
 use crate::rate_limits::RateLimits;
+use crate::usecases::UseCases;
 
 /// Environment variable prefix for all configuration options.
 const ENV_PREFIX: &str = "OS__";
@@ -451,6 +452,14 @@ pub struct Config {
     /// Definitions for rate limits to enforce on incoming requests.
     pub rate_limits: RateLimits,
 
+    /// Per-use-case configuration.
+    ///
+    /// Controls properties of individual use cases such as which expiration
+    /// policies are permitted and their maximum durations. Use cases not
+    /// present in the map receive default configuration (all policies allowed,
+    /// no duration caps).
+    pub usecases: UseCases,
+
     /// Configuration for the [`StorageService`](objectstore_service::StorageService).
     pub service: Service,
 
@@ -558,6 +567,7 @@ impl Default for Config {
             auth: AuthZ::default(),
             killswitches: Killswitches::default(),
             rate_limits: RateLimits::default(),
+            usecases: UseCases::default(),
             service: Service::default(),
             http: Http::default(),
         }

--- a/objectstore-server/src/endpoints/batch.rs
+++ b/objectstore-server/src/endpoints/batch.rs
@@ -93,8 +93,24 @@ async fn batch(
         move |op| service.check_permission(op.permission(), &context)
     });
 
-    // Step 4: stamp inserts with time_created and record bandwidth
-    let stamped = authorized.map({
+    // Step 4: use case policy validation
+    let policy_checked = validate(authorized, {
+        let state = Arc::clone(&state);
+        let usecase = context.usecase.clone();
+        move |op| {
+            if let Operation::Insert(ins) = op {
+                state
+                    .config
+                    .usecases
+                    .validate(&usecase, &ins.metadata)
+                    .map_err(|e| ApiError::Client(e.to_string()))?;
+            }
+            Ok(())
+        }
+    });
+
+    // Step 5: stamp inserts with time_created and record bandwidth
+    let stamped = policy_checked.map({
         let state = Arc::clone(&state);
         let context = context.clone();
         move |(idx, mut item)| {
@@ -106,7 +122,7 @@ async fn batch(
         }
     });
 
-    // Step 5: execute concurrently, then convert each result to a multipart Part
+    // Step 6: execute concurrently, then convert each result to a multipart Part
     let state_ref = Arc::clone(&state);
     let context_ref = context.clone();
     let responses = batch.execute(context, stamped).then(move |(idx, result)| {

--- a/objectstore-server/src/endpoints/objects.rs
+++ b/objectstore-server/src/endpoints/objects.rs
@@ -12,7 +12,7 @@ use objectstore_types::metadata::Metadata;
 use serde::Serialize;
 
 use crate::auth::AuthAwareService;
-use crate::endpoints::common::ApiResult;
+use crate::endpoints::common::{ApiError, ApiResult};
 use crate::extractors::{Xt, body::MeteredBody};
 use crate::state::ServiceState;
 
@@ -38,12 +38,19 @@ pub struct InsertObjectResponse {
 
 async fn objects_post(
     service: AuthAwareService,
+    State(state): State<ServiceState>,
     Xt(context): Xt<ObjectContext>,
     headers: HeaderMap,
     MeteredBody(body): MeteredBody,
 ) -> ApiResult<Response> {
     let mut metadata = Metadata::from_headers(&headers, "").map_err(ServiceError::from)?;
     metadata.time_created = Some(SystemTime::now());
+
+    state
+        .config
+        .usecases
+        .validate(&context.usecase, &metadata)
+        .map_err(|e| ApiError::Client(e.to_string()))?;
 
     let response_id = service.insert_object(context, None, metadata, body).await?;
     let response = Json(InsertObjectResponse {
@@ -80,6 +87,7 @@ async fn object_head(service: AuthAwareService, Xt(id): Xt<ObjectId>) -> ApiResu
 
 async fn object_put(
     service: AuthAwareService,
+    State(state): State<ServiceState>,
     Xt(id): Xt<ObjectId>,
     headers: HeaderMap,
     MeteredBody(body): MeteredBody,
@@ -88,6 +96,13 @@ async fn object_put(
     metadata.time_created = Some(SystemTime::now());
 
     let ObjectId { context, key } = id;
+
+    state
+        .config
+        .usecases
+        .validate(&context.usecase, &metadata)
+        .map_err(|e| ApiError::Client(e.to_string()))?;
+
     let response_id = service
         .insert_object(context, Some(key), metadata, body)
         .await?;

--- a/objectstore-server/src/lib.rs
+++ b/objectstore-server/src/lib.rs
@@ -14,4 +14,5 @@ pub mod multipart;
 pub mod observability;
 pub mod rate_limits;
 pub mod state;
+pub mod usecases;
 pub mod web;

--- a/objectstore-server/src/usecases.rs
+++ b/objectstore-server/src/usecases.rs
@@ -38,9 +38,7 @@ use thiserror::Error;
 /// Maps use case names to their configuration. Use cases not present in the map
 /// receive the default configuration (all expiration policies allowed, no caps).
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq)]
-pub struct UseCases {
-    config: HashMap<String, UseCaseConfig>,
-}
+pub struct UseCases(pub HashMap<String, UseCaseConfig>);
 
 impl UseCases {
     /// Validates metadata against the configuration for the given use case.
@@ -48,7 +46,7 @@ impl UseCases {
     /// Returns an error if any metadata field violates the use case's policy.
     /// Use cases not present in the configuration are always valid.
     pub fn validate(&self, usecase: &str, metadata: &Metadata) -> Result<(), UseCaseError> {
-        if let Some(config) = self.config.get(usecase) {
+        if let Some(config) = self.0.get(usecase) {
             config.validate(usecase, metadata)?
         }
         Ok(())
@@ -201,7 +199,7 @@ mod tests {
     fn usecases_from(config: UseCaseConfig) -> UseCases {
         let mut map = HashMap::new();
         map.insert("test".to_owned(), config);
-        UseCases { config: map }
+        UseCases(map)
     }
 
     // --- unconfigured use case ---

--- a/objectstore-server/src/usecases.rs
+++ b/objectstore-server/src/usecases.rs
@@ -1,0 +1,399 @@
+//! Configuration and validation for use case properties.
+//!
+//! Use cases are user-defined strings that namespace objects (e.g. `attachments`,
+//! `debug-files`). This module provides a central place to configure properties
+//! of use cases, such as which expiration policies are permitted and any duration
+//! caps.
+//!
+//! Unconfigured use cases receive the default configuration: all expiration
+//! policies are allowed with no duration caps.
+//!
+//! # YAML Configuration
+//!
+//! ```yaml
+//! usecases:
+//!   attachments:
+//!     expiration:
+//!       manual:
+//!         allowed: false
+//!       ttl:
+//!         max: "90d"
+//!       tti:
+//!         allowed: false
+//!   debug-files:
+//!     expiration:
+//!       tti:
+//!         max: "90d"
+//! ```
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use objectstore_types::metadata::{ExpirationPolicy, Metadata};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Configuration for all use case properties.
+///
+/// Maps use case names to their configuration. Use cases not present in the map
+/// receive the default configuration (all expiration policies allowed, no caps).
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq)]
+pub struct UseCases {
+    config: HashMap<String, UseCaseConfig>,
+}
+
+impl UseCases {
+    /// Validates metadata against the configuration for the given use case.
+    ///
+    /// Returns an error if any metadata field violates the use case's policy.
+    /// Use cases not present in the configuration are always valid.
+    pub fn validate(&self, usecase: &str, metadata: &Metadata) -> Result<(), UseCaseError> {
+        if let Some(config) = self.config.get(usecase) {
+            config.validate(usecase, metadata)?
+        }
+        Ok(())
+    }
+}
+
+/// Configuration for a single use case.
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(default)]
+pub struct UseCaseConfig {
+    /// Expiration policy constraints for this use case.
+    pub expiration: ExpirationConfig,
+}
+
+impl UseCaseConfig {
+    fn validate(&self, usecase: &str, metadata: &Metadata) -> Result<(), UseCaseError> {
+        match metadata.expiration_policy {
+            ExpirationPolicy::Manual => {
+                if !self.expiration.manual.allowed {
+                    return Err(UseCaseError::PolicyNotAllowed {
+                        usecase: usecase.to_owned(),
+                        policy: metadata.expiration_policy,
+                    });
+                }
+            }
+            ExpirationPolicy::TimeToLive(duration) => {
+                if !self.expiration.ttl.allowed {
+                    return Err(UseCaseError::PolicyNotAllowed {
+                        usecase: usecase.to_owned(),
+                        policy: metadata.expiration_policy,
+                    });
+                }
+                if let Some(max) = self.expiration.ttl.max
+                    && duration > max
+                {
+                    return Err(UseCaseError::DurationExceeded {
+                        usecase: usecase.to_owned(),
+                        duration: humantime::format_duration(duration).to_string(),
+                        max: humantime::format_duration(max).to_string(),
+                    });
+                }
+            }
+            ExpirationPolicy::TimeToIdle(duration) => {
+                if !self.expiration.tti.allowed {
+                    return Err(UseCaseError::PolicyNotAllowed {
+                        usecase: usecase.to_owned(),
+                        policy: metadata.expiration_policy,
+                    });
+                }
+                if let Some(max) = self.expiration.tti.max
+                    && duration > max
+                {
+                    return Err(UseCaseError::DurationExceeded {
+                        usecase: usecase.to_owned(),
+                        duration: humantime::format_duration(duration).to_string(),
+                        max: humantime::format_duration(max).to_string(),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Controls which expiration policies are allowed and their duration constraints.
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(default)]
+pub struct ExpirationConfig {
+    /// Configuration for the [`ExpirationPolicy::Manual`] policy.
+    pub manual: ManualPolicyConfig,
+    /// Configuration for the [`ExpirationPolicy::TimeToLive`] policy.
+    pub ttl: DurationPolicyConfig,
+    /// Configuration for the [`ExpirationPolicy::TimeToIdle`] policy.
+    pub tti: DurationPolicyConfig,
+}
+
+/// Configuration for the [`ExpirationPolicy::Manual`] policy.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(default)]
+pub struct ManualPolicyConfig {
+    /// Whether the manual expiration policy is allowed. Defaults to `true`.
+    pub allowed: bool,
+}
+
+impl Default for ManualPolicyConfig {
+    fn default() -> Self {
+        Self { allowed: true }
+    }
+}
+
+/// Configuration for a duration-based expiration policy (TTL or TTI).
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(default)]
+pub struct DurationPolicyConfig {
+    /// Whether this expiration policy is allowed. Defaults to `true`.
+    pub allowed: bool,
+    /// Maximum allowed duration. `None` means no limit.
+    #[serde(default, with = "humantime_serde")]
+    pub max: Option<Duration>,
+}
+
+impl Default for DurationPolicyConfig {
+    fn default() -> Self {
+        Self {
+            allowed: true,
+            max: None,
+        }
+    }
+}
+
+/// Errors produced when metadata violates a use case's configuration.
+#[derive(Debug, Error)]
+pub enum UseCaseError {
+    /// The expiration policy kind is not permitted for this use case.
+    #[error("expiration policy '{policy}' is not allowed for use case '{usecase}'")]
+    PolicyNotAllowed {
+        /// The use case name.
+        usecase: String,
+        /// The disallowed policy, in wire format.
+        policy: ExpirationPolicy,
+    },
+
+    /// The expiration duration exceeds the maximum for this use case.
+    #[error("expiration duration {duration} exceeds maximum of {max} for use case '{usecase}'")]
+    DurationExceeded {
+        /// The use case name.
+        usecase: String,
+        /// The requested duration, in humantime format.
+        duration: String,
+        /// The configured maximum, in humantime format.
+        max: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use objectstore_types::metadata::{ExpirationPolicy, Metadata};
+
+    use super::*;
+
+    fn make_metadata(policy: ExpirationPolicy) -> Metadata {
+        Metadata {
+            expiration_policy: policy,
+            ..Metadata::default()
+        }
+    }
+
+    fn usecases_from(config: UseCaseConfig) -> UseCases {
+        let mut map = HashMap::new();
+        map.insert("test".to_owned(), config);
+        UseCases { config: map }
+    }
+
+    // --- unconfigured use case ---
+
+    #[test]
+    fn unconfigured_usecase_allows_manual() {
+        let usecases = UseCases::default();
+        let metadata = make_metadata(ExpirationPolicy::Manual);
+        usecases.validate("anything", &metadata).unwrap();
+    }
+
+    #[test]
+    fn unconfigured_usecase_allows_ttl() {
+        let usecases = UseCases::default();
+        let metadata = make_metadata(ExpirationPolicy::TimeToLive(Duration::from_secs(3600)));
+        usecases.validate("anything", &metadata).unwrap();
+    }
+
+    #[test]
+    fn unconfigured_usecase_allows_tti() {
+        let usecases = UseCases::default();
+        let metadata = make_metadata(ExpirationPolicy::TimeToIdle(Duration::from_secs(3600)));
+        usecases.validate("anything", &metadata).unwrap();
+    }
+
+    // --- manual policy ---
+
+    #[test]
+    fn manual_disallowed_rejects() {
+        let usecases = usecases_from(UseCaseConfig {
+            expiration: ExpirationConfig {
+                manual: ManualPolicyConfig { allowed: false },
+                ..ExpirationConfig::default()
+            },
+        });
+
+        let metadata = make_metadata(ExpirationPolicy::Manual);
+        let err = usecases.validate("test", &metadata).unwrap_err();
+        assert!(matches!(err, UseCaseError::PolicyNotAllowed { .. }));
+    }
+
+    #[test]
+    fn manual_allowed_passes() {
+        let usecases = usecases_from(UseCaseConfig {
+            expiration: ExpirationConfig {
+                manual: ManualPolicyConfig { allowed: true },
+                ..ExpirationConfig::default()
+            },
+        });
+
+        let metadata = make_metadata(ExpirationPolicy::Manual);
+        usecases.validate("test", &metadata).unwrap();
+    }
+
+    // --- ttl policy ---
+
+    #[test]
+    fn ttl_disallowed_rejects() {
+        let usecases = usecases_from(UseCaseConfig {
+            expiration: ExpirationConfig {
+                ttl: DurationPolicyConfig {
+                    allowed: false,
+                    max: None,
+                },
+                ..ExpirationConfig::default()
+            },
+        });
+
+        let metadata = make_metadata(ExpirationPolicy::TimeToLive(Duration::from_secs(3600)));
+        let err = usecases.validate("test", &metadata).unwrap_err();
+        assert!(matches!(err, UseCaseError::PolicyNotAllowed { .. }));
+    }
+
+    #[test]
+    fn ttl_within_max_passes() {
+        let usecases = usecases_from(UseCaseConfig {
+            expiration: ExpirationConfig {
+                ttl: DurationPolicyConfig {
+                    allowed: true,
+                    max: Some(Duration::from_secs(7200)),
+                },
+                ..ExpirationConfig::default()
+            },
+        });
+
+        let metadata = make_metadata(ExpirationPolicy::TimeToLive(Duration::from_secs(3600)));
+        usecases.validate("test", &metadata).unwrap();
+    }
+
+    #[test]
+    fn ttl_at_max_passes() {
+        let usecases = usecases_from(UseCaseConfig {
+            expiration: ExpirationConfig {
+                ttl: DurationPolicyConfig {
+                    allowed: true,
+                    max: Some(Duration::from_secs(3600)),
+                },
+                ..ExpirationConfig::default()
+            },
+        });
+
+        let metadata = make_metadata(ExpirationPolicy::TimeToLive(Duration::from_secs(3600)));
+        usecases.validate("test", &metadata).unwrap();
+    }
+
+    #[test]
+    fn ttl_exceeds_max_rejects() {
+        let usecases = usecases_from(UseCaseConfig {
+            expiration: ExpirationConfig {
+                ttl: DurationPolicyConfig {
+                    allowed: true,
+                    max: Some(Duration::from_secs(3600)),
+                },
+                ..ExpirationConfig::default()
+            },
+        });
+
+        let metadata = make_metadata(ExpirationPolicy::TimeToLive(Duration::from_secs(7200)));
+        let err = usecases.validate("test", &metadata).unwrap_err();
+        assert!(matches!(err, UseCaseError::DurationExceeded { .. }));
+    }
+
+    // --- tti policy ---
+
+    #[test]
+    fn tti_disallowed_rejects() {
+        let usecases = usecases_from(UseCaseConfig {
+            expiration: ExpirationConfig {
+                tti: DurationPolicyConfig {
+                    allowed: false,
+                    max: None,
+                },
+                ..ExpirationConfig::default()
+            },
+        });
+
+        let metadata = make_metadata(ExpirationPolicy::TimeToIdle(Duration::from_secs(3600)));
+        let err = usecases.validate("test", &metadata).unwrap_err();
+        assert!(matches!(err, UseCaseError::PolicyNotAllowed { .. }));
+    }
+
+    #[test]
+    fn tti_within_max_passes() {
+        let usecases = usecases_from(UseCaseConfig {
+            expiration: ExpirationConfig {
+                tti: DurationPolicyConfig {
+                    allowed: true,
+                    max: Some(Duration::from_secs(7200)),
+                },
+                ..ExpirationConfig::default()
+            },
+        });
+
+        let metadata = make_metadata(ExpirationPolicy::TimeToIdle(Duration::from_secs(3600)));
+        usecases.validate("test", &metadata).unwrap();
+    }
+
+    #[test]
+    fn tti_exceeds_max_rejects() {
+        let usecases = usecases_from(UseCaseConfig {
+            expiration: ExpirationConfig {
+                tti: DurationPolicyConfig {
+                    allowed: true,
+                    max: Some(Duration::from_secs(3600)),
+                },
+                ..ExpirationConfig::default()
+            },
+        });
+
+        let metadata = make_metadata(ExpirationPolicy::TimeToIdle(Duration::from_secs(7200)));
+        let err = usecases.validate("test", &metadata).unwrap_err();
+        assert!(matches!(err, UseCaseError::DurationExceeded { .. }));
+    }
+
+    // --- partial config ---
+
+    #[test]
+    fn other_policies_unaffected_when_only_tti_restricted() {
+        let usecases = usecases_from(UseCaseConfig {
+            expiration: ExpirationConfig {
+                tti: DurationPolicyConfig {
+                    allowed: false,
+                    max: None,
+                },
+                ..ExpirationConfig::default()
+            },
+        });
+
+        let metadata = make_metadata(ExpirationPolicy::Manual);
+        usecases.validate("test", &metadata).unwrap();
+
+        let metadata = make_metadata(ExpirationPolicy::TimeToLive(Duration::from_secs(3600)));
+        usecases.validate("test", &metadata).unwrap();
+    }
+}

--- a/objectstore-server/tests/limits.rs
+++ b/objectstore-server/tests/limits.rs
@@ -3,13 +3,17 @@
 //! These tests assert safety-related behavior of the objectstore-server, such as enforcing
 //! maximum object sizes, rate limiting, and killswitches.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
+use std::time::Duration;
 
 use anyhow::Result;
 use objectstore_server::config::{AuthZ, Config, Http, Service};
 use objectstore_server::killswitches::{Killswitch, Killswitches};
 use objectstore_server::rate_limits::{
     BandwidthLimits, RateLimits, ThroughputLimits, ThroughputRule,
+};
+use objectstore_server::usecases::{
+    DurationPolicyConfig, ExpirationConfig, ManualPolicyConfig, UseCaseConfig, UseCases,
 };
 use objectstore_test::server::TestServer;
 
@@ -535,6 +539,186 @@ async fn test_batch_at_capacity_returns_429() -> Result<()> {
         response.status(),
         reqwest::StatusCode::TOO_MANY_REQUESTS,
         "expected 429 when service has no available permits"
+    );
+
+    Ok(())
+}
+
+// --- Use case policy tests ---
+
+#[tokio::test]
+async fn test_usecase_expiration_policy() -> Result<()> {
+    let server = TestServer::with_config(Config {
+        auth: AuthZ {
+            enforce: false,
+            ..Default::default()
+        },
+        usecases: UseCases(HashMap::from([
+            (
+                "attachments".to_owned(),
+                UseCaseConfig {
+                    expiration: ExpirationConfig {
+                        manual: ManualPolicyConfig { allowed: false },
+                        ttl: DurationPolicyConfig {
+                            allowed: true,
+                            max: Some(Duration::from_secs(90 * 24 * 3600)),
+                        },
+                        tti: DurationPolicyConfig {
+                            allowed: false,
+                            max: None,
+                        },
+                    },
+                },
+            ),
+            (
+                "debug-files".to_owned(),
+                UseCaseConfig {
+                    expiration: ExpirationConfig {
+                        manual: ManualPolicyConfig { allowed: false },
+                        ttl: DurationPolicyConfig {
+                            allowed: false,
+                            max: None,
+                        },
+                        tti: DurationPolicyConfig {
+                            allowed: true,
+                            max: Some(Duration::from_secs(90 * 24 * 3600)),
+                        },
+                    },
+                },
+            ),
+            (
+                "avatars".to_owned(),
+                UseCaseConfig {
+                    expiration: ExpirationConfig {
+                        manual: ManualPolicyConfig { allowed: true },
+                        ttl: DurationPolicyConfig {
+                            allowed: false,
+                            max: None,
+                        },
+                        tti: DurationPolicyConfig {
+                            allowed: false,
+                            max: None,
+                        },
+                    },
+                },
+            ),
+        ])),
+        ..Default::default()
+    })
+    .await;
+
+    let client = reqwest::Client::new();
+
+    // Matching requests — one per use case with its permitted policy.
+    let response = client
+        .put(server.url("/v1/objects/attachments/org=1/key"))
+        .header("x-sn-expiration", "ttl:30d")
+        .body("data")
+        .send()
+        .await?;
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::OK,
+        "attachments: ttl within cap"
+    );
+
+    let response = client
+        .put(server.url("/v1/objects/debug-files/org=1/key"))
+        .header("x-sn-expiration", "tti:30d")
+        .body("data")
+        .send()
+        .await?;
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::OK,
+        "debug-files: tti within cap"
+    );
+
+    let response = client
+        .put(server.url("/v1/objects/avatars/org=1/key"))
+        .header("x-sn-expiration", "manual")
+        .body("data")
+        .send()
+        .await?;
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::OK,
+        "avatars: manual"
+    );
+
+    // Duration exceeded — TTL and TTI caps.
+    let response = client
+        .put(server.url("/v1/objects/attachments/org=1/key"))
+        .header("x-sn-expiration", "ttl:100d")
+        .body("data")
+        .send()
+        .await?;
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::BAD_REQUEST,
+        "attachments: ttl exceeds 90d cap"
+    );
+
+    let response = client
+        .put(server.url("/v1/objects/debug-files/org=1/key"))
+        .header("x-sn-expiration", "tti:100d")
+        .body("data")
+        .send()
+        .await?;
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::BAD_REQUEST,
+        "debug-files: tti exceeds 90d cap"
+    );
+
+    // Wrong policy — one disallowed policy request per use case.
+    let response = client
+        .put(server.url("/v1/objects/attachments/org=1/key"))
+        .header("x-sn-expiration", "manual")
+        .body("data")
+        .send()
+        .await?;
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::BAD_REQUEST,
+        "attachments: manual not allowed"
+    );
+
+    let response = client
+        .put(server.url("/v1/objects/debug-files/org=1/key"))
+        .header("x-sn-expiration", "ttl:30d")
+        .body("data")
+        .send()
+        .await?;
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::BAD_REQUEST,
+        "debug-files: ttl not allowed"
+    );
+
+    let response = client
+        .put(server.url("/v1/objects/avatars/org=1/key"))
+        .header("x-sn-expiration", "tti:30d")
+        .body("data")
+        .send()
+        .await?;
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::BAD_REQUEST,
+        "avatars: tti not allowed"
+    );
+
+    // Unconfigured use case — any policy is accepted.
+    let response = client
+        .put(server.url("/v1/objects/uploads/org=1/key"))
+        .header("x-sn-expiration", "manual")
+        .body("data")
+        .send()
+        .await?;
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::OK,
+        "uploads: unconfigured use case accepts manual"
     );
 
     Ok(())


### PR DESCRIPTION
Introduces a central configuration block for use case properties. For now, this covers expiration policy constraints: operators can restrict which policies (manual, TTL, TTI) are permitted for a given use case, and cap the maximum duration for time-based policies.

Writes that violate the configured constraints are rejected with 400. Unconfigured use cases continue to accept any policy, so this is fully opt-in with no impact on existing deployments.

This is the foundation for a richer use case configuration block — rate limits and killswitches may move here over time, and a per-use-case default expiration policy is planned as a follow-up.

See also https://github.com/getsentry/ops/pull/19947
Ref FS-322