### PR TITLE
feat(server): Add X-Os-Auth as alternative auth header

### DIFF
--- a/clients/python/src/objectstore_client/client.py
+++ b/clients/python/src/objectstore_client/client.py
@@ -245,7 +245,7 @@ class Session:
                 dict(sentry_sdk.get_current_scope().iter_trace_propagation_headers())
             )
         if token := self.mint_token():
-            headers["x-objectstore-auth"] = f"Bearer {token}"
+            headers["x-os-auth"] = f"Bearer {token}"
         return headers
 
     def _make_url(self, key: str | None, full: bool = False) -> str:

--- a/clients/python/src/objectstore_client/client.py
+++ b/clients/python/src/objectstore_client/client.py
@@ -245,7 +245,7 @@ class Session:
                 dict(sentry_sdk.get_current_scope().iter_trace_propagation_headers())
             )
         if token := self.mint_token():
-            headers["Authorization"] = f"Bearer {token}"
+            headers["x-objectstore-auth"] = f"Bearer {token}"
         return headers
 
     def _make_url(self, key: str | None, full: bool = False) -> str:

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -466,7 +466,7 @@ impl Session {
 
     fn prepare_builder(&self, mut builder: RequestBuilder) -> crate::Result<RequestBuilder> {
         if let Some(token) = self.mint_token()? {
-            builder = builder.bearer_auth(token);
+            builder = builder.header("x-objectstore-auth", format!("Bearer {token}"));
         }
         if self.client.propagate_traces {
             let trace_headers =

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -466,7 +466,7 @@ impl Session {
 
     fn prepare_builder(&self, mut builder: RequestBuilder) -> crate::Result<RequestBuilder> {
         if let Some(token) = self.mint_token()? {
-            builder = builder.header("x-objectstore-auth", format!("Bearer {token}"));
+            builder = builder.header("x-os-auth", format!("Bearer {token}"));
         }
         if self.client.propagate_traces {
             let trace_headers =

--- a/objectstore-server/docs/architecture.md
+++ b/objectstore-server/docs/architecture.md
@@ -40,8 +40,10 @@ A request flows through several layers before reaching the storage service:
    recovery, Sentry transaction tracing, distributed tracing.
 2. **Extractors**: path parameters are parsed into an
    [`ObjectId`](objectstore_service::id::ObjectId) or
-   [`ObjectContext`](objectstore_service::id::ObjectContext). The `Authorization`
-   header is validated and decoded into an [`AuthContext`](auth::AuthContext).
+   [`ObjectContext`](objectstore_service::id::ObjectContext). The auth token is
+   read from the `X-Objectstore-Auth` header (preferred) or the standard
+   `Authorization` header (fallback), then validated and decoded into an
+   [`AuthContext`](auth::AuthContext).
    The optional `x-downstream-service` header is extracted for killswitch
    matching.
 3. **Admission control**: [killswitches](killswitches) and

--- a/objectstore-server/docs/architecture.md
+++ b/objectstore-server/docs/architecture.md
@@ -41,7 +41,7 @@ A request flows through several layers before reaching the storage service:
 2. **Extractors**: path parameters are parsed into an
    [`ObjectId`](objectstore_service::id::ObjectId) or
    [`ObjectContext`](objectstore_service::id::ObjectContext). The auth token is
-   read from the `X-Objectstore-Auth` header (preferred) or the standard
+   read from the `X-Os-Auth` header (preferred) or the standard
    `Authorization` header (fallback), then validated and decoded into an
    [`AuthContext`](auth::AuthContext).
    The optional `x-downstream-service` header is extracted for killswitch

--- a/objectstore-server/src/auth/key_directory.rs
+++ b/objectstore-server/src/auth/key_directory.rs
@@ -49,7 +49,7 @@ impl TryFrom<&AuthZVerificationKey> for PublicKeyConfig {
 
 /// Directory of keys that may be used to verify a request's auth token.
 ///
-/// The auth token is read from the `X-Objectstore-Auth` header (preferred) or the
+/// The auth token is read from the `X-Os-Auth` header (preferred) or the
 /// standard `Authorization` header (fallback). This directory contains a map keyed
 /// on a key's ID. When verifying a JWT, the `kid` field should be read from the
 /// JWT header and used to index into this directory to select the appropriate key.

--- a/objectstore-server/src/auth/key_directory.rs
+++ b/objectstore-server/src/auth/key_directory.rs
@@ -26,9 +26,9 @@ pub struct PublicKeyConfig {
 
     /// The maximum set of permissions that this key's signer is authorized to grant.
     ///
-    /// If a request's `Authorization` header grants full permission but it was signed by
-    /// a key that is only allowed to grant read permission, then the request only has
-    /// read permission.
+    /// If a request's auth token grants full permission but it was signed by a key that
+    /// is only allowed to grant read permission, then the request only has read
+    /// permission.
     pub max_permissions: HashSet<Permission>,
 }
 
@@ -47,11 +47,12 @@ impl TryFrom<&AuthZVerificationKey> for PublicKeyConfig {
     }
 }
 
-/// Directory of keys that may be used to verify a request's `Authorization` header.
+/// Directory of keys that may be used to verify a request's auth token.
 ///
-/// This directory contains a map that is keyed on a key's ID. When verifying a JWT
-/// from the `Authorization` header, the `kid` field should be read from the JWT
-/// header and used to index into this directory to select the appropriate key.
+/// The auth token is read from the `X-Objectstore-Auth` header (preferred) or the
+/// standard `Authorization` header (fallback). This directory contains a map keyed
+/// on a key's ID. When verifying a JWT, the `kid` field should be read from the
+/// JWT header and used to index into this directory to select the appropriate key.
 #[derive(Debug)]
 pub struct PublicKeyDirectory {
     /// Mapping from key ID to key configuration.

--- a/objectstore-server/src/config.rs
+++ b/objectstore-server/src/config.rs
@@ -311,8 +311,8 @@ impl Default for Sentry {
 // Logging configuration is defined in `objectstore_log::LoggingConfig`.
 // Metrics configuration is defined in `objectstore_metrics::MetricsConfig`.
 
-/// A key that may be used to verify a request's `Authorization` header and its
-/// associated permissions. May contain multiple key versions to facilitate rotation.
+/// A key that may be used to verify a request's auth token and its associated
+/// permissions. May contain multiple key versions to facilitate rotation.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct AuthZVerificationKey {
     /// Files that contain versions of this key's key material which may be used to verify
@@ -325,8 +325,8 @@ pub struct AuthZVerificationKey {
 
     /// The maximum set of permissions that this key's signer is authorized to grant.
     ///
-    /// If a request's `Authorization` header grants full permission but it was signed by
-    /// a key that is only allowed to grant read permission, then the request only has
+    /// If a request's auth token grants full permission but it was signed by a key
+    /// that is only allowed to grant read permission, then the request only has
     /// read permission.
     #[serde(default)]
     pub max_permissions: HashSet<Permission>,
@@ -341,11 +341,13 @@ pub struct AuthZ {
     /// in `403 Unauthorized` responses.
     pub enforce: bool,
 
-    /// Keys that may be used to verify a request's `Authorization` header.
+    /// Keys that may be used to verify a request's auth token.
     ///
-    /// This field is a container that is keyed on a key's ID. When verifying a JWT
-    /// from the `Authorization` header, the `kid` field should be read from the JWT
-    /// header and used to index into this map to select the appropriate key.
+    /// The auth token is read from the `X-Objectstore-Auth` header (preferred)
+    /// or the standard `Authorization` header (fallback). This field is a
+    /// container keyed on a key's ID. When verifying a JWT, the `kid` field
+    /// should be read from the JWT header and used to index into this map to
+    /// select the appropriate key.
     #[serde(default)]
     pub keys: BTreeMap<String, AuthZVerificationKey>,
 }
@@ -443,7 +445,7 @@ pub struct Config {
     /// Content-based authorization configuration.
     ///
     /// Controls the verification and enforcement of content-based access control based on the
-    /// JWT in a request's `Authorization` header.
+    /// JWT in a request's `X-Objectstore-Auth` or `Authorization` header.
     pub auth: AuthZ,
 
     /// A list of matchers for requests to discard without processing.

--- a/objectstore-server/src/config.rs
+++ b/objectstore-server/src/config.rs
@@ -343,7 +343,7 @@ pub struct AuthZ {
 
     /// Keys that may be used to verify a request's auth token.
     ///
-    /// The auth token is read from the `X-Objectstore-Auth` header (preferred)
+    /// The auth token is read from the `X-Os-Auth` header (preferred)
     /// or the standard `Authorization` header (fallback). This field is a
     /// container keyed on a key's ID. When verifying a JWT, the `kid` field
     /// should be read from the JWT header and used to index into this map to
@@ -445,7 +445,7 @@ pub struct Config {
     /// Content-based authorization configuration.
     ///
     /// Controls the verification and enforcement of content-based access control based on the
-    /// JWT in a request's `X-Objectstore-Auth` or `Authorization` header.
+    /// JWT in a request's `X-Os-Auth` or `Authorization` header.
     pub auth: AuthZ,
 
     /// A list of matchers for requests to discard without processing.

--- a/objectstore-server/src/extractors/service.rs
+++ b/objectstore-server/src/extractors/service.rs
@@ -20,8 +20,6 @@ impl FromRequestParts<ServiceState> for AuthAwareService {
         parts: &mut Parts,
         state: &ServiceState,
     ) -> Result<Self, Self::Rejection> {
-        // Check the custom header first, then fall back to the standard
-        // Authorization header for backwards compatibility.
         let encoded_token = parts
             .headers
             .get(OBJECTSTORE_AUTH_HEADER)

--- a/objectstore-server/src/extractors/service.rs
+++ b/objectstore-server/src/extractors/service.rs
@@ -11,7 +11,7 @@ const BEARER_PREFIX: &str = "Bearer ";
 /// `Authorization` header so that proxy setups (e.g. Django) can use
 /// `Authorization` for their own auth while forwarding an Objectstore token in
 /// this header.
-const OBJECTSTORE_AUTH_HEADER: &str = "x-objectstore-auth";
+const OBJECTSTORE_AUTH_HEADER: &str = "x-os-auth";
 
 impl FromRequestParts<ServiceState> for AuthAwareService {
     type Rejection = ApiError;

--- a/objectstore-server/src/extractors/service.rs
+++ b/objectstore-server/src/extractors/service.rs
@@ -7,6 +7,12 @@ use crate::state::ServiceState;
 
 const BEARER_PREFIX: &str = "Bearer ";
 
+/// Custom header for Objectstore authentication. Checked before the standard
+/// `Authorization` header so that proxy setups (e.g. Django) can use
+/// `Authorization` for their own auth while forwarding an Objectstore token in
+/// this header.
+const OBJECTSTORE_AUTH_HEADER: &str = "x-objectstore-auth";
+
 impl FromRequestParts<ServiceState> for AuthAwareService {
     type Rejection = ApiError;
 
@@ -14,9 +20,12 @@ impl FromRequestParts<ServiceState> for AuthAwareService {
         parts: &mut Parts,
         state: &ServiceState,
     ) -> Result<Self, Self::Rejection> {
+        // Check the custom header first, then fall back to the standard
+        // Authorization header for backwards compatibility.
         let encoded_token = parts
             .headers
-            .get(header::AUTHORIZATION)
+            .get(OBJECTSTORE_AUTH_HEADER)
+            .or_else(|| parts.headers.get(header::AUTHORIZATION))
             .and_then(|v| v.to_str().ok())
             .and_then(strip_bearer);
 


### PR DESCRIPTION
Requests proxied through Django need the standard `Authorization` header for Django auth, at least until we enable and enforce auth everywhere. That header clashes with objectstore's own JWT auth.

This PR introduces a dedicated `X-Os-Auth` header (mirroring Relay's `X-Sentry-Auth` convention):

- **Server**: checks `X-Os-Auth` first, falls back to `Authorization` for backwards compatibility
- **Rust client**: sends token via `X-Os-Auth` instead of `Authorization`
- **Python client**: sends token via `X-Os-Auth` instead of `Authorization`

We use the `X-Sn-<key>` prefix for other headers (such as object metadata), so this new `X-Os` prefix is not consistent with it.
Still, I thought it would make sense to explicitly prefix this with `X-Os` to make it immediately clear what it's for (when e.g. looking at traces in Sentry) and to avoid any clashes that `X-Sn-Authorization` could cause, now or in the future.

A separate task, out of scope for this PR, would be to change metadata to also use `X-Os` as prefix, which will need a migration period where we double read before all clients are updated.