### PR TITLE
feat(server): Accept auth token via query parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2547,6 +2547,7 @@ dependencies = [
  "bytes",
  "elegant-departure",
  "figment",
+ "form_urlencoded",
  "futures",
  "futures-util",
  "globset",

--- a/objectstore-server/Cargo.toml
+++ b/objectstore-server/Cargo.toml
@@ -53,6 +53,7 @@ tower-http = { version = "0.6.6", default-features = false, features = [
     "trace",
 ] }
 papaya = "0.2.3"
+form_urlencoded = "1.2.2"
 
 [dev-dependencies]
 nix = { version = "0.30.1", features = ["signal"] }

--- a/objectstore-server/docs/architecture.md
+++ b/objectstore-server/docs/architecture.md
@@ -41,8 +41,9 @@ A request flows through several layers before reaching the storage service:
 2. **Extractors**: path parameters are parsed into an
    [`ObjectId`](objectstore_service::id::ObjectId) or
    [`ObjectContext`](objectstore_service::id::ObjectContext). The auth token is
-   read from the `X-Objectstore-Auth` header (preferred) or the standard
-   `Authorization` header (fallback), then validated and decoded into an
+   read from the `X-Objectstore-Auth` header (preferred), the
+   `x-objectstore-auth` query parameter, or the standard `Authorization`
+   header (fallback), then validated and decoded into an
    [`AuthContext`](auth::AuthContext).
    The optional `x-downstream-service` header is extracted for killswitch
    matching.

--- a/objectstore-server/src/extractors/service.rs
+++ b/objectstore-server/src/extractors/service.rs
@@ -7,11 +7,11 @@ use crate::state::ServiceState;
 
 const BEARER_PREFIX: &str = "Bearer ";
 
-/// Custom header for Objectstore authentication. Checked before the standard
-/// `Authorization` header so that proxy setups (e.g. Django) can use
-/// `Authorization` for their own auth while forwarding an Objectstore token in
-/// this header.
-const OBJECTSTORE_AUTH_HEADER: &str = "x-objectstore-auth";
+/// Custom header (preferred), query parameter, or standard `Authorization`
+/// header (fallback) for Objectstore authentication. This allows proxy setups
+/// (e.g. Django) to use `Authorization` for their own auth while forwarding an
+/// Objectstore token separately.
+const OBJECTSTORE_AUTH_KEY: &str = "x-objectstore-auth";
 
 impl FromRequestParts<ServiceState> for AuthAwareService {
     type Rejection = ApiError;
@@ -20,16 +20,11 @@ impl FromRequestParts<ServiceState> for AuthAwareService {
         parts: &mut Parts,
         state: &ServiceState,
     ) -> Result<Self, Self::Rejection> {
-        let encoded_token = parts
-            .headers
-            .get(OBJECTSTORE_AUTH_HEADER)
-            .or_else(|| parts.headers.get(header::AUTHORIZATION))
-            .and_then(|v| v.to_str().ok())
-            .and_then(strip_bearer);
+        let token = extract_token(parts);
 
         let enforce = state.config.auth.enforce;
         // Attempt to decode / verify the JWT, logging failure
-        let auth_result = AuthContext::from_encoded_jwt(encoded_token, &state.key_directory)
+        let auth_result = AuthContext::from_encoded_jwt(token.as_deref(), &state.key_directory)
             .inspect_err(|err| err.log(None, None, enforce));
 
         // If auth enforcement is enabled, `from_encoded_jwt()` must have succeeded.
@@ -46,6 +41,42 @@ impl FromRequestParts<ServiceState> for AuthAwareService {
             state.config.auth.enforce,
         )
     }
+}
+
+/// Extracts a bearer token from (in order):
+/// 1. The `X-Objectstore-Auth` header
+/// 2. The `x-objectstore-auth` query parameter
+/// 3. The standard `Authorization` header
+fn extract_token(parts: &Parts) -> Option<String> {
+    // 1. Custom header
+    if let Some(token) = parts
+        .headers
+        .get(OBJECTSTORE_AUTH_KEY)
+        .and_then(|v| v.to_str().ok())
+        .and_then(strip_bearer)
+    {
+        return Some(token.to_owned());
+    }
+
+    // 2. Query parameter
+    if let Some(token) = parts
+        .uri
+        .query()
+        .into_iter()
+        .flat_map(|q| form_urlencoded::parse(q.as_bytes()))
+        .find(|(key, _)| key.eq_ignore_ascii_case(OBJECTSTORE_AUTH_KEY))
+        .and_then(|(_, value)| strip_bearer(&value).map(str::to_owned))
+    {
+        return Some(token);
+    }
+
+    // 3. Standard Authorization header
+    parts
+        .headers
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(strip_bearer)
+        .map(str::to_owned)
 }
 
 fn strip_bearer(header_value: &str) -> Option<&str> {


### PR DESCRIPTION
For requests that go from the frontend (users' browser) to Objectstore, we currently have no way to authenticate properly.
This begins to solve that problem by introducing a `X-Objectstore-Auth` query parameter that, when present, carries auth information, and is checked as one of the possible places where the JWT is.
Our Django endpoints can then return URLs embedding such a query parameter, to provide the auth info to the client that will be able to fetch images/files/whatever from the proxy endpoint directly.