### PR TITLE
feat: Add pre-signed URL support for GET/HEAD requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2494,11 +2494,14 @@ name = "objectstore-client"
 version = "0.1.6"
 dependencies = [
  "async-compression",
+ "base64",
  "bytes",
+ "ed25519-dalek",
  "futures-util",
  "infer",
  "jsonwebtoken",
  "multer",
+ "objectstore-shared",
  "objectstore-test",
  "objectstore-types",
  "percent-encoding",
@@ -2544,7 +2547,9 @@ dependencies = [
  "argh",
  "async-stream",
  "axum",
+ "base64",
  "bytes",
+ "ed25519-dalek",
  "elegant-departure",
  "figment",
  "futures",
@@ -2560,6 +2565,7 @@ dependencies = [
  "objectstore-log",
  "objectstore-metrics",
  "objectstore-service",
+ "objectstore-shared",
  "objectstore-test",
  "objectstore-types",
  "papaya",
@@ -2609,6 +2615,13 @@ dependencies = [
  "tracing",
  "uuid",
  "zstd",
+]
+
+[[package]]
+name = "objectstore-shared"
+version = "0.1.0"
+dependencies = [
+ "percent-encoding",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ objectstore-log = { path = "objectstore-log" }
 objectstore-metrics = { path = "objectstore-metrics" }
 objectstore-server = { path = "objectstore-server" }
 objectstore-service = { path = "objectstore-service" }
+objectstore-shared = { path = "objectstore-shared", version = "0.1.0" }
 objectstore-test = { path = "objectstore-test" }
 objectstore-types = { path = "objectstore-types", version = "0.1.6" }
 percent-encoding = "2.3"
@@ -33,7 +34,9 @@ stresstest = { path = "stresstest" }
 
 anyhow = "1.0.69"
 async-trait = "0.1.88"
+base64 = "0.22.1"
 bytes = "1.11.1"
+ed25519-dalek = { version = "2.2.0", features = ["pkcs8", "pem"] }
 futures = "0.3.31"
 futures-util = "0.3.31"
 http = "1.3.1"

--- a/clients/python/src/objectstore_client/__init__.py
+++ b/clients/python/src/objectstore_client/__init__.py
@@ -14,7 +14,7 @@ from objectstore_client.metadata import (
     TimeToLive,
 )
 from objectstore_client.metrics import MetricsBackend, NoOpMetricsBackend
-from objectstore_client.utils import parse_accept_encoding
+from objectstore_client.utils import parse_accept_encoding, presign_url
 
 __all__ = [
     "Client",
@@ -33,4 +33,5 @@ __all__ = [
     "MetricsBackend",
     "NoOpMetricsBackend",
     "parse_accept_encoding",
+    "presign_url",
 ]

--- a/clients/python/src/objectstore_client/presign.py
+++ b/clients/python/src/objectstore_client/presign.py
@@ -1,0 +1,141 @@
+"""Pre-signed URL generation for Objectstore."""
+
+from __future__ import annotations
+
+import base64
+from datetime import UTC, datetime, timedelta
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+PARAM_EXPIRES = "X-Os-Expires"
+PARAM_KEY_ID = "X-Os-KeyId"
+PARAM_SIGNATURE = "X-Os-Signature"
+
+DEFAULT_PRESIGNED_EXPIRY = 300  # 5 minutes
+
+
+def presign_url(
+    kid: str,
+    secret_key: str,
+    method: str,
+    url: str,
+    expires_in: int = DEFAULT_PRESIGNED_EXPIRY,
+) -> str:
+    """
+    Generate a pre-signed URL for reading an object.
+
+    The returned URL is valid for both GET and HEAD requests.
+
+    Args:
+        kid: The key ID that the Objectstore server uses to look up the public key.
+        secret_key: An Ed25519 private key in PEM format.
+        method: The HTTP method (``"GET"`` or ``"HEAD"``). Both produce the same
+            signature since HEAD is semantically equivalent to GET.
+        url: The object URL to sign (as returned by ``Session.object_url``).
+        expires_in: How long the URL should remain valid, in seconds.
+            Defaults to 300 (5 minutes).
+
+    Returns:
+        The pre-signed URL string including signature query parameters.
+
+    Raises:
+        ValueError: If the method is not GET or HEAD.
+    """
+    method_upper = method.upper()
+    if method_upper not in ("GET", "HEAD"):
+        raise ValueError(
+            f"Unsupported method for pre-signed URL: {method}. "
+            "Only GET and HEAD are supported."
+        )
+
+    private_key = load_pem_private_key(secret_key.encode("utf-8"), password=None)
+    if not isinstance(private_key, Ed25519PrivateKey):
+        raise ValueError("secret_key must be an Ed25519 private key")
+
+    expires_at = datetime.now(tz=UTC) + timedelta(seconds=expires_in)
+    expires_ts = int(expires_at.timestamp())
+
+    # Parse URL and add query params
+    parsed = urlparse(url)
+    existing_params = parse_qsl(parsed.query, keep_blank_values=True)
+    existing_params.append((PARAM_EXPIRES, str(expires_ts)))
+    existing_params.append((PARAM_KEY_ID, kid))
+
+    # Build URL without signature for canonical form computation
+    url_without_sig = urlunparse(parsed._replace(query=urlencode(existing_params)))
+    parsed_without_sig = urlparse(url_without_sig)
+
+    # Build canonical form and sign
+    canonical = _canonical_presigned_request(
+        parsed_without_sig.path, parsed_without_sig.query
+    )
+    signature = private_key.sign(canonical.encode("utf-8"))
+    sig_b64 = base64.urlsafe_b64encode(signature).rstrip(b"=").decode("ascii")
+
+    # Append signature
+    existing_params.append((PARAM_SIGNATURE, sig_b64))
+    return urlunparse(parsed._replace(query=urlencode(existing_params)))
+
+
+def _canonical_presigned_request(path: str, query: str) -> str:
+    """
+    Build the canonical request string for pre-signed URL signing/verification.
+
+    The canonical form is::
+
+        GET\\n{canonical_path}\\n{canonical_query}
+
+    - Method is always ``GET`` (HEAD maps to GET).
+    - Path uses the encoded URI path as received by the service.
+    - Percent-encoded octets are normalized to uppercase hex digits.
+    - Query params use the encoded keys and optional values from the URI, excluding
+      ``X-Os-Signature``, sorted by encoded key.
+    """
+    canonical_path = _normalize_percent_encoding(path)
+
+    params = []
+    for pair in query.split("&"):
+        if not pair:
+            continue
+        if "=" in pair:
+            k, _, v = pair.partition("=")
+            value = _normalize_percent_encoding(v)
+        else:
+            k = pair
+            value = None
+        k = _normalize_percent_encoding(k)
+        if k == PARAM_SIGNATURE:
+            continue
+        params.append((k, value))
+
+    params.sort(key=lambda x: (x[0], x[1]))
+
+    query_str = "&".join(k if v is None else f"{k}={v}" for k, v in params)
+    return f"GET\n{canonical_path}\n{query_str}"
+
+
+def _normalize_percent_encoding(value: str) -> str:
+    """Normalize percent-encoded octets to use uppercase hex digits."""
+    chars: list[str] = []
+    i = 0
+    while i < len(value):
+        if (
+            value[i] == "%"
+            and i + 2 < len(value)
+            and value[i + 1].isalnum()
+            and value[i + 1].lower() in "0123456789abcdef"
+            and value[i + 2].isalnum()
+            and value[i + 2].lower() in "0123456789abcdef"
+        ):
+            chars.append("%")
+            chars.append(value[i + 1].upper())
+            chars.append(value[i + 2].upper())
+            i += 3
+            continue
+
+        chars.append(value[i])
+        i += 1
+
+    return "".join(chars)

--- a/clients/python/src/objectstore_client/utils.py
+++ b/clients/python/src/objectstore_client/utils.py
@@ -6,6 +6,8 @@ from typing import IO, Any
 import filetype  # type: ignore[import-untyped]
 from zstandard import ZstdCompressionReader
 
+from objectstore_client.presign import presign_url as presign_url  # re-export
+
 
 def parse_accept_encoding(header: str) -> list[str]:
     """Parse an Accept-Encoding header value for use in objectstore GET requests.

--- a/clients/python/tests/test_presign.py
+++ b/clients/python/tests/test_presign.py
@@ -1,0 +1,133 @@
+import os
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from objectstore_client.presign import (
+    _canonical_presigned_request,
+    presign_url,
+)
+
+TEST_EDDSA_KID: str = "test_kid"
+TEST_EDDSA_PRIVKEY_PATH: str = (
+    os.path.dirname(os.path.realpath(__file__)) + "/ed25519.private.pem"
+)
+
+
+def _read_private_key() -> str:
+    with open(TEST_EDDSA_PRIVKEY_PATH) as f:
+        return f.read()
+
+
+class TestCanonicalForm:
+    def test_basic(self) -> None:
+        canonical = _canonical_presigned_request(
+            "/v1/objects/attachments/org=123;project=456/my-key",
+            "X-Os-Expires=1712668800&X-Os-KeyId=relay-prod&X-Os-Signature=abc123",
+        )
+        assert canonical == (
+            "GET\n"
+            "/v1/objects/attachments/org=123;project=456/my-key\n"
+            "X-Os-Expires=1712668800&X-Os-KeyId=relay-prod"
+        )
+
+    def test_preserves_encoded_path_bytes(self) -> None:
+        canonical_slash = _canonical_presigned_request(
+            "/v1/objects/test/_/folder/file.txt",
+            "X-Os-Expires=1712668800&X-Os-KeyId=relay-prod",
+        )
+        canonical_encoded_slash = _canonical_presigned_request(
+            "/v1/objects/test/_/folder%2Ffile.txt",
+            "X-Os-Expires=1712668800&X-Os-KeyId=relay-prod",
+        )
+        assert canonical_slash != canonical_encoded_slash
+
+    def test_lowercase_hex(self) -> None:
+        # Lowercase and uppercase hex digits produce the same canonical form
+        canonical_upper = _canonical_presigned_request(
+            "/v1/objects/test/org%3D1/key",
+            "X-Os-Expires=1000&X-Os-KeyId=test",
+        )
+        canonical_lower = _canonical_presigned_request(
+            "/v1/objects/test/org%3d1/key",
+            "X-Os-Expires=1000&X-Os-KeyId=test",
+        )
+        assert canonical_upper == canonical_lower
+
+    def test_keeps_query_encoding(self) -> None:
+        canonical = _canonical_presigned_request(
+            "/path",
+            "X-Os-Expires=1000&foo=one%2Btwo&bar=hello+world&X-Os-KeyId=test",
+        )
+        assert canonical == (
+            "GET\n"
+            "/path\n"
+            "X-Os-Expires=1000&X-Os-KeyId=test&bar=hello+world&foo=one%2Btwo"
+        )
+
+    def test_reordered_query_params(self) -> None:
+        c1 = _canonical_presigned_request(
+            "/path",
+            "X-Os-KeyId=test&X-Os-Expires=1000",
+        )
+        c2 = _canonical_presigned_request(
+            "/path",
+            "X-Os-Expires=1000&X-Os-KeyId=test",
+        )
+        assert c1 == c2
+
+    def test_bare_query_params(self) -> None:
+        canonical = _canonical_presigned_request(
+            "/path",
+            "y&X-Os-KeyId=test&x=1&X-Os-Expires=1000&z",
+        )
+        assert canonical == ("GET\n/path\nX-Os-Expires=1000&X-Os-KeyId=test&x=1&y&z")
+
+
+class TestPresignUrl:
+    def test_produces_valid_format(self) -> None:
+        url = "http://localhost:8888/v1/objects/attachments/org=123;project=456/my-key"
+        result = presign_url(TEST_EDDSA_KID, _read_private_key(), "GET", url)
+
+        assert isinstance(result, str)
+        parsed = urlparse(result)
+        query = parse_qs(parsed.query)
+
+        assert "X-Os-Expires" in query
+        assert query["X-Os-KeyId"] == [TEST_EDDSA_KID]
+        assert "X-Os-Signature" in query
+
+    def test_head_produces_same_canonical(self) -> None:
+        """Both GET and HEAD produce canonical forms starting with GET."""
+        url = "http://localhost:8888/v1/objects/test/org=1/key"
+
+        r1 = presign_url(TEST_EDDSA_KID, _read_private_key(), "GET", url)
+        r2 = presign_url(TEST_EDDSA_KID, _read_private_key(), "HEAD", url)
+
+        p1 = urlparse(r1)
+        p2 = urlparse(r2)
+        c1 = _canonical_presigned_request(p1.path, p1.query)
+        c2 = _canonical_presigned_request(p2.path, p2.query)
+
+        assert c1.startswith("GET\n")
+        assert c2.startswith("GET\n")
+
+    def test_invalid_method(self) -> None:
+        url = "http://localhost:8888/v1/objects/test/org=1/key"
+        with pytest.raises(ValueError, match="Unsupported method"):
+            presign_url(TEST_EDDSA_KID, _read_private_key(), "PUT", url)
+
+    def test_custom_expiry(self) -> None:
+        url = "http://localhost:8888/v1/objects/test/org=1/key"
+        result = presign_url(
+            TEST_EDDSA_KID, _read_private_key(), "GET", url, expires_in=60
+        )
+
+        # Verify the expires param is ~60s from now
+        parsed = urlparse(result)
+        query = parse_qs(parsed.query)
+        expires_ts = int(query["X-Os-Expires"][0])
+
+        from datetime import UTC, datetime
+
+        diff = expires_ts - int(datetime.now(tz=UTC).timestamp())
+        assert 58 <= diff <= 61

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -12,13 +12,16 @@ publish = true
 
 [dependencies]
 async-compression = { version = "0.4.27", features = ["tokio", "zstd"] }
-percent-encoding = { workspace = true }
+base64 = { workspace = true }
 bytes = { workspace = true }
+ed25519-dalek = { workspace = true }
 futures-util = { workspace = true }
 infer = { version = "0.19.0", default-features = false }
 jsonwebtoken = { workspace = true }
 multer = "3.1.0"
+objectstore-shared = { workspace = true }
 objectstore-types = { workspace = true }
+percent-encoding = { workspace = true }
 reqwest = { version = "0.13.1", default-features = false, features = ["charset", "http2", "system-proxy", "json", "stream", "multipart"] }
 sentry-core = { version = ">=0.41", features = ["client"] }
 serde = { workspace = true }

--- a/clients/rust/src/error.rs
+++ b/clients/rust/src/error.rs
@@ -21,6 +21,9 @@ pub enum Error {
     /// Error when creating auth tokens, such as invalid keys.
     #[error(transparent)]
     TokenError(#[from] jsonwebtoken::errors::Error),
+    /// Error when generating a pre-signed URL.
+    #[error(transparent)]
+    Presign(#[from] PresignError),
     /// Error when URL manipulation fails.
     #[error("{message}")]
     InvalidUrl {
@@ -44,6 +47,23 @@ pub enum Error {
         /// The error message.
         message: String,
     },
+}
+
+/// Errors that can occur when generating a pre-signed URL.
+#[derive(Debug, thiserror::Error)]
+pub enum PresignError {
+    /// The HTTP method is not supported for pre-signed URLs.
+    #[error("unsupported method: {method}. Only GET and HEAD are supported")]
+    UnsupportedMethod {
+        /// The unsupported method that was provided.
+        method: String,
+    },
+    /// Failed to parse the Ed25519 private key.
+    #[error("failed to parse Ed25519 private key: {0}")]
+    InvalidKey(#[from] ed25519_dalek::pkcs8::Error),
+    /// The expiry time could not be represented as a UNIX timestamp.
+    #[error("invalid expiry: {0}")]
+    InvalidExpiry(#[from] std::time::SystemTimeError),
 }
 
 /// A convenience alias that defaults our [`Error`] type.

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -9,6 +9,7 @@ mod error;
 mod get;
 mod key;
 mod many;
+mod presign;
 mod put;
 pub mod utils;
 

--- a/clients/rust/src/presign.rs
+++ b/clients/rust/src/presign.rs
@@ -1,0 +1,139 @@
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use ed25519_dalek::pkcs8::DecodePrivateKey;
+use ed25519_dalek::{Signer, SigningKey};
+use objectstore_shared::presign::{
+    PARAM_EXPIRES, PARAM_KEY_ID, PARAM_SIGNATURE, canonical_presigned_request,
+};
+use url::Url;
+
+use crate::auth::SecretKey;
+
+/// Default pre-signed URL lifetime: 5 minutes.
+const DEFAULT_PRESIGNED_EXPIRY: Duration = Duration::from_secs(300);
+
+/// Generate a pre-signed URL for reading an object.
+///
+/// The returned URL is valid for both GET and HEAD requests.
+/// The `method` parameter must be `"GET"` or `"HEAD"` — both produce the same
+/// signature since HEAD is semantically equivalent to GET for authorization.
+///
+/// # Arguments
+///
+/// * `secret_key` - The Ed25519 private key and key ID used for signing.
+/// * `method` - The HTTP method (`"GET"` or `"HEAD"`).
+/// * `url` - The object URL to sign (as returned by [`Session::object_url`](crate::Session::object_url)).
+/// * `expires_in` - How long the URL should remain valid. Defaults to 5 minutes if `None`.
+///
+/// # Errors
+///
+/// Returns an error if the method is not GET or HEAD, or if the private key cannot be parsed.
+pub fn presign_url(
+    secret_key: &SecretKey,
+    method: &str,
+    url: &Url,
+    expires_in: Option<Duration>,
+) -> crate::Result<Url> {
+    let method_upper = method.to_ascii_uppercase();
+    if method_upper != "GET" && method_upper != "HEAD" {
+        return Err(crate::PresignError::UnsupportedMethod {
+            method: method.to_owned(),
+        }
+        .into());
+    }
+
+    let signing_key = SigningKey::from_pkcs8_pem(&secret_key.secret_key)
+        .map_err(crate::PresignError::InvalidKey)?;
+
+    let expires_in = expires_in.unwrap_or(DEFAULT_PRESIGNED_EXPIRY);
+    let expires_at = SystemTime::now() + expires_in;
+    let expires_ts = expires_at
+        .duration_since(UNIX_EPOCH)
+        .map_err(crate::PresignError::InvalidExpiry)?
+        .as_secs();
+
+    let mut url = url.clone();
+
+    // Add X-Os-Expires and X-Os-KeyId query params
+    url.query_pairs_mut()
+        .append_pair(PARAM_EXPIRES, &expires_ts.to_string())
+        .append_pair(PARAM_KEY_ID, &secret_key.kid);
+
+    // Build canonical form and sign
+    let canonical = canonical_presigned_request(url.path(), url.query());
+    let signature = signing_key.sign(canonical.as_bytes());
+    let sig_b64 = URL_SAFE_NO_PAD.encode(signature.to_bytes());
+
+    // Append signature
+    url.query_pairs_mut().append_pair(PARAM_SIGNATURE, &sig_b64);
+
+    Ok(url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use objectstore_test::server::{TEST_EDDSA_KID, TEST_EDDSA_PRIVKEY};
+
+    fn test_secret_key() -> SecretKey {
+        SecretKey {
+            kid: TEST_EDDSA_KID.to_string(),
+            secret_key: TEST_EDDSA_PRIVKEY.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_presign_url_produces_valid_format() {
+        let url =
+            Url::parse("http://localhost:8888/v1/objects/attachments/org=123;project=456/my-key")
+                .unwrap();
+
+        let result = presign_url(
+            &test_secret_key(),
+            "GET",
+            &url,
+            Some(Duration::from_secs(300)),
+        )
+        .unwrap();
+
+        let query = result.query().unwrap();
+        assert!(query.contains("X-Os-Expires="));
+        assert!(query.contains("X-Os-KeyId=test_kid"));
+        assert!(query.contains("X-Os-Signature="));
+    }
+
+    #[test]
+    fn test_presign_url_head_produces_same_signature() {
+        let url = Url::parse("http://localhost:8888/v1/objects/test/org=1/key").unwrap();
+
+        let result1 = presign_url(
+            &test_secret_key(),
+            "GET",
+            &url,
+            Some(Duration::from_secs(300)),
+        )
+        .unwrap();
+        let result2 = presign_url(
+            &test_secret_key(),
+            "HEAD",
+            &url,
+            Some(Duration::from_secs(300)),
+        )
+        .unwrap();
+
+        let canonical1 = canonical_presigned_request(result1.path(), result1.query());
+        let canonical2 = canonical_presigned_request(result2.path(), result2.query());
+
+        assert!(canonical1.starts_with("GET\n"));
+        assert!(canonical2.starts_with("GET\n"));
+    }
+
+    #[test]
+    fn test_presign_url_invalid_method() {
+        let url = Url::parse("http://localhost:8888/v1/objects/test/org=1/key").unwrap();
+        let result = presign_url(&test_secret_key(), "PUT", &url, None);
+        assert!(result.is_err());
+    }
+}

--- a/clients/rust/src/utils.rs
+++ b/clients/rust/src/utils.rs
@@ -1,5 +1,7 @@
 //! Utility functions that might be useful when working with Objectstore.
 
+pub use crate::presign::presign_url;
+
 /// Attempts to guess the MIME type from the given contents.
 pub fn guess_mime_type<T: AsRef<[u8]>>(contents: T) -> Option<&'static str> {
     infer::get(contents.as_ref()).map(|kind| kind.mime_type())

--- a/objectstore-server/Cargo.toml
+++ b/objectstore-server/Cargo.toml
@@ -16,7 +16,9 @@ argh = "0.1.13"
 async-stream = "0.3.6"
 axum = { version = "0.8.4", features = ["multipart"] }
 percent-encoding = { workspace = true }
+base64 = { workspace = true }
 bytes = { workspace = true }
+ed25519-dalek = { workspace = true }
 elegant-departure = { version = "0.3.2", features = ["tokio"] }
 figment = { version = "0.10.19", features = ["env", "test", "yaml"] }
 futures = { workspace = true }
@@ -31,6 +33,7 @@ num_cpus = "1.17.0"
 objectstore-log = { workspace = true, features = ["init", "sentry"] }
 objectstore-metrics = { workspace = true }
 objectstore-service = { workspace = true }
+objectstore-shared = { workspace = true }
 objectstore-types = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true }

--- a/objectstore-server/docs/architecture.md
+++ b/objectstore-server/docs/architecture.md
@@ -95,6 +95,52 @@ operations are checked against an
 [`ObjectId`](objectstore_service::id::ObjectId). Scope values in the token can
 use wildcards to grant broad access.
 
+### Pre-Signed URLs
+
+Pre-signed URLs provide time-limited, read-only access to specific objects
+without requiring an auth header. They are an alternative to JWT-based
+authentication for `GET` and `HEAD` requests.
+
+**URL format:**
+
+```text
+/v1/objects/{usecase}/{scopes}/{key}?X-Os-Expires={unix_ts}&X-Os-KeyId={kid}&X-Os-Signature={base64url_sig}
+```
+
+- `X-Os-Expires` — Unix timestamp (seconds) when the URL expires
+- `X-Os-KeyId` — key ID mapping to a key in the `PublicKeyDirectory`
+- `X-Os-Signature` — base64url-encoded Ed25519 signature (no padding)
+
+**Canonical form** — the signed content is:
+
+```text
+GET\n{canonical_path}\n{canonical_query}
+```
+
+- Method is always `GET` (HEAD maps to GET, allowing a single URL for both).
+- The path uses the encoded request path as received over HTTP.
+- Percent-encoded octets are normalized only by uppercasing their hex digits.
+- Query params exclude `X-Os-Signature`, keep their encoded key/value bytes,
+  are sorted alphabetically by encoded key, and joined as `key=value` pairs
+  with `&`.
+
+**Verification flow:**
+
+Pre-signed URL parameters take precedence over header-based JWT auth.
+The extractor checks for pre-signed URL query parameters first, then
+falls back to JWT headers.
+
+1. The request method must be `GET` or `HEAD`.
+2. Expiry is checked against the current time.
+3. The key's `max_permissions` must include `ObjectRead`.
+4. The canonical request string is reconstructed and verified against the
+   Ed25519 signature using the public key(s) for the given `kid`.
+5. An object-bound `AuthContext` is created with `ObjectRead` permission and
+   the exact [`ObjectId`](objectstore_service::id::ObjectId) parsed from the
+   URL path.
+6. Context-level authorization checks reject object-bound auth contexts, so a
+   pre-signed URL can authorize only the exact object it was signed for.
+
 ## Configuration
 
 Configuration uses [figment](https://docs.rs/figment) for layered merging with

--- a/objectstore-server/src/auth/context.rs
+++ b/objectstore-server/src/auth/context.rs
@@ -1,5 +1,7 @@
 use std::collections::{BTreeMap, HashSet};
+use std::time::{SystemTime, UNIX_EPOCH};
 
+use ed25519_dalek::{Signature, Verifier};
 use jsonwebtoken::{Algorithm, Header, TokenData, Validation, decode, decode_header};
 use objectstore_service::id::{ObjectContext, ObjectId, ObjectKey};
 use objectstore_types::auth::Permission;
@@ -7,7 +9,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::auth::error::AuthError;
 use crate::auth::key_directory::PublicKeyDirectory;
+use objectstore_shared::presign::canonical_presigned_request;
+
+use crate::auth::presigned::PreSignedParams;
 use crate::auth::util::StringOrWildcard;
+use crate::extractors::id::parse_object_id_from_path;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 struct JwtRes {
@@ -86,12 +92,9 @@ impl AuthContext {
     /// header field and attempt verification. It will also ensure that the timestamp from the
     /// `exp` claim field has not passed.
     pub fn from_encoded_jwt(
-        encoded_token: Option<&str>,
+        encoded_token: &str,
         key_directory: &PublicKeyDirectory,
     ) -> Result<AuthContext, AuthError> {
-        let encoded_token =
-            encoded_token.ok_or(AuthError::BadRequest("No authorization token provided"))?;
-
         let jwt_header = decode_header(encoded_token)?;
         let key_id = jwt_header
             .kid
@@ -153,6 +156,90 @@ impl AuthContext {
             scopes_vec,
             permissions,
             object_key: None,
+        })
+    }
+
+    /// Construct an `AuthContext` from pre-signed URL parameters.
+    ///
+    /// Verifies that the URL has not expired, that the signing key exists and permits
+    /// `ObjectRead`, and that the Ed25519 signature matches the canonical request.
+    /// The resulting context is always scoped to `ObjectRead` only.
+    pub fn from_presigned_url(
+        params: &PreSignedParams,
+        method: &http::Method,
+        uri: &http::Uri,
+        key_directory: &PublicKeyDirectory,
+    ) -> Result<AuthContext, AuthError> {
+        // Pre-signed URLs are only valid for read operations
+        if method != http::Method::GET && method != http::Method::HEAD {
+            return Err(AuthError::BadRequest(
+                "Pre-signed URLs are only valid for GET and HEAD requests",
+            ));
+        }
+
+        // Check expiry
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        if params.expires <= now {
+            return Err(AuthError::BadRequest("Pre-signed URL has expired"));
+        }
+
+        // Look up key config
+        let key_config = key_directory.keys.get(&params.key_id).ok_or_else(|| {
+            AuthError::InternalError(format!("Key `{}` not configured", params.key_id))
+        })?;
+
+        // Check key has read permission
+        if !key_config.max_permissions.contains(&Permission::ObjectRead) {
+            return Err(AuthError::NotPermitted);
+        }
+
+        // Build canonical request
+        let canonical = canonical_presigned_request(uri.path(), uri.query());
+
+        // Parse signature bytes
+        let signature = Signature::from_slice(&params.signature)
+            .map_err(|_| AuthError::BadRequest("Invalid signature format"))?;
+
+        // Verify against each key version
+        let verified = key_config
+            .verifying_keys
+            .iter()
+            .any(|vk| vk.verify(canonical.as_bytes(), &signature).is_ok());
+
+        if !verified {
+            return Err(AuthError::VerificationFailure);
+        }
+
+        // Parse the exact object ID from the path so this remains an object-bound grant rather
+        // than a widened scope-bound grant.
+        let object_id = parse_object_id_from_path(uri.path()).ok_or(AuthError::BadRequest(
+            "Cannot parse path for pre-signed URL",
+        ))?;
+        let object_key = object_id.key;
+        let usecase = object_id.context.usecase.clone();
+        let scopes_vec: Vec<(String, StringOrWildcard)> = object_id
+            .context
+            .scopes
+            .iter()
+            .map(|scope: &objectstore_types::scope::Scope| {
+                (
+                    scope.name().to_string(),
+                    StringOrWildcard::String(scope.value().to_string()),
+                )
+            })
+            .collect();
+        let scopes = scopes_vec.iter().cloned().collect();
+
+        Ok(AuthContext {
+            usecase,
+            scopes,
+            scopes_vec,
+            permissions: HashSet::from([Permission::ObjectRead]),
+            object_key: Some(object_key),
         })
     }
 
@@ -249,6 +336,7 @@ impl AuthContext {
 mod tests {
     use super::*;
     use crate::auth::PublicKeyConfig;
+    use ed25519_dalek::pkcs8::DecodePublicKey;
     use jsonwebtoken::DecodingKey;
     use objectstore_types::scope::{Scope, Scopes};
     use serde_json::json;
@@ -273,6 +361,9 @@ mod tests {
     fn test_key_config(max_permissions: HashSet<Permission>) -> PublicKeyDirectory {
         let public_key = PublicKeyConfig {
             key_versions: vec![DecodingKey::from_ed_pem(TEST_EDDSA_PUBKEY.as_bytes()).unwrap()],
+            verifying_keys: vec![
+                ed25519_dalek::VerifyingKey::from_public_key_pem(&TEST_EDDSA_PUBKEY).unwrap(),
+            ],
             max_permissions,
         };
         PublicKeyDirectory {
@@ -337,8 +428,7 @@ mod tests {
 
         // Create test config with max permissions
         let test_config = test_key_config(max_permission());
-        let auth_context =
-            AuthContext::from_encoded_jwt(Some(encoded_token.as_str()), &test_config)?;
+        let auth_context = AuthContext::from_encoded_jwt(encoded_token.as_str(), &test_config)?;
 
         // Ensure the key is correctly verified and deserialized
         let expected = sample_auth_context("123", "456", max_permission());
@@ -356,8 +446,7 @@ mod tests {
         // Assign read-only permissions to the signing key in config
         let ro_permission = HashSet::from([Permission::ObjectRead]);
         let test_config = test_key_config(ro_permission.clone());
-        let auth_context =
-            AuthContext::from_encoded_jwt(Some(encoded_token.as_str()), &test_config)?;
+        let auth_context = AuthContext::from_encoded_jwt(encoded_token.as_str(), &test_config)?;
 
         // Ensure the key is correctly verified and that the permissions are restricted
         let expected = sample_auth_context("123", "456", ro_permission);
@@ -373,7 +462,7 @@ mod tests {
 
         // Create test config with max permissions
         let test_config = test_key_config(max_permission());
-        let auth_context = AuthContext::from_encoded_jwt(Some(encoded_token), &test_config);
+        let auth_context = AuthContext::from_encoded_jwt(encoded_token, &test_config);
 
         // Ensure the token failed verification
         assert!(matches!(auth_context, Err(AuthError::ValidationFailure(_))));
@@ -392,8 +481,7 @@ MC4CAQAwBQYDK2VwBCIEIKwVoE4TmTfWoqH3HgLVsEcHs9PHNe+ar/Hp6e4To8pK
 
         // Create test config with max permissions
         let test_config = test_key_config(max_permission());
-        let auth_context =
-            AuthContext::from_encoded_jwt(Some(encoded_token.as_str()), &test_config);
+        let auth_context = AuthContext::from_encoded_jwt(encoded_token.as_str(), &test_config);
 
         // Ensure the token failed verification
         assert!(matches!(auth_context, Err(AuthError::VerificationFailure)));
@@ -412,8 +500,7 @@ MC4CAQAwBQYDK2VwBCIEIKwVoE4TmTfWoqH3HgLVsEcHs9PHNe+ar/Hp6e4To8pK
 
         // Create test config with max permissions
         let test_config = test_key_config(max_permission());
-        let auth_context =
-            AuthContext::from_encoded_jwt(Some(encoded_token.as_str()), &test_config);
+        let auth_context = AuthContext::from_encoded_jwt(encoded_token.as_str(), &test_config);
 
         // Ensure the token failed verification
         let Err(AuthError::ValidationFailure(error)) = auth_context else {

--- a/objectstore-server/src/auth/context.rs
+++ b/objectstore-server/src/auth/context.rs
@@ -333,6 +333,25 @@ impl AuthContext {
 }
 
 #[cfg(test)]
+impl AuthContext {
+    pub(crate) fn usecase(&self) -> &str {
+        &self.usecase
+    }
+
+    pub(crate) fn scopes(&self) -> &BTreeMap<String, StringOrWildcard> {
+        &self.scopes
+    }
+
+    pub(crate) fn permissions(&self) -> &HashSet<Permission> {
+        &self.permissions
+    }
+
+    pub(crate) fn object_key(&self) -> Option<&str> {
+        self.object_key.as_deref()
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::auth::PublicKeyConfig;

--- a/objectstore-server/src/auth/key_directory.rs
+++ b/objectstore-server/src/auth/key_directory.rs
@@ -2,14 +2,20 @@ use std::collections::{BTreeMap, HashSet};
 use std::path::Path;
 
 use anyhow::Context;
+use ed25519_dalek::pkcs8::DecodePublicKey;
 use jsonwebtoken::DecodingKey;
 use objectstore_types::auth::Permission;
 
 use crate::config::{AuthZ, AuthZVerificationKey};
 
-fn read_key_from_file(filename: &Path) -> anyhow::Result<DecodingKey> {
+fn read_key_from_file(
+    filename: &Path,
+) -> anyhow::Result<(DecodingKey, ed25519_dalek::VerifyingKey)> {
     let key_content = std::fs::read_to_string(filename).context("reading key")?;
-    DecodingKey::from_ed_pem(key_content.as_bytes()).context("parsing key")
+    let decoding_key = DecodingKey::from_ed_pem(key_content.as_bytes()).context("parsing key")?;
+    let verifying_key = ed25519_dalek::VerifyingKey::from_public_key_pem(&key_content)
+        .context("parsing Ed25519 public key")?;
+    Ok((decoding_key, verifying_key))
 }
 
 /// Configures the EdDSA public key(s) and permissions used to verify tokens from a single `kid`.
@@ -24,6 +30,12 @@ pub struct PublicKeyConfig {
     /// rolling out. Otherwise, this should only contain the most recent version of a key.
     pub key_versions: Vec<DecodingKey>,
 
+    /// Ed25519 verifying keys for pre-signed URL signature verification.
+    ///
+    /// These are parsed from the same PEM files as `key_versions`, but expose the raw
+    /// Ed25519 public key for use outside of JWT verification.
+    pub verifying_keys: Vec<ed25519_dalek::VerifyingKey>,
+
     /// The maximum set of permissions that this key's signer is authorized to grant.
     ///
     /// If a request's auth token grants full permission but it was signed by a key that
@@ -36,13 +48,18 @@ impl TryFrom<&AuthZVerificationKey> for PublicKeyConfig {
     type Error = anyhow::Error;
 
     fn try_from(key_config: &AuthZVerificationKey) -> Result<Self, anyhow::Error> {
+        let (key_versions, verifying_keys) = key_config
+            .key_files
+            .iter()
+            .map(|filename| read_key_from_file(filename))
+            .collect::<anyhow::Result<Vec<_>>>()?
+            .into_iter()
+            .unzip();
+
         Ok(Self {
             max_permissions: key_config.max_permissions.clone(),
-            key_versions: key_config
-                .key_files
-                .iter()
-                .map(|filename| read_key_from_file(filename))
-                .collect::<anyhow::Result<Vec<DecodingKey>>>()?,
+            key_versions,
+            verifying_keys,
         })
     }
 }

--- a/objectstore-server/src/auth/mod.rs
+++ b/objectstore-server/src/auth/mod.rs
@@ -4,7 +4,7 @@
 mod context;
 mod error;
 mod key_directory;
-pub(crate) mod presigned;
+mod presigned;
 mod service;
 mod util;
 

--- a/objectstore-server/src/auth/mod.rs
+++ b/objectstore-server/src/auth/mod.rs
@@ -4,6 +4,7 @@
 mod context;
 mod error;
 mod key_directory;
+pub(crate) mod presigned;
 mod service;
 mod util;
 

--- a/objectstore-server/src/auth/presigned.rs
+++ b/objectstore-server/src/auth/presigned.rs
@@ -139,16 +139,16 @@ mod tests {
         let (uri, params) = sign_url(path, future_expires());
 
         let ctx = AuthContext::from_presigned_url(&params, &http::Method::GET, &uri, &dir).unwrap();
-        assert_eq!(ctx.usecase, "attachments");
-        assert!(ctx.permissions.contains(&Permission::ObjectRead));
-        assert_eq!(ctx.permissions.len(), 1);
-        assert_eq!(ctx.object_key.as_deref(), Some("my-key"));
+        assert_eq!(ctx.usecase(), "attachments");
+        assert!(ctx.permissions().contains(&Permission::ObjectRead));
+        assert_eq!(ctx.permissions().len(), 1);
+        assert_eq!(ctx.object_key(), Some("my-key"));
         assert_eq!(
-            ctx.scopes.get("org"),
+            ctx.scopes().get("org"),
             Some(&crate::auth::util::StringOrWildcard::String("123".into()))
         );
         assert_eq!(
-            ctx.scopes.get("project"),
+            ctx.scopes().get("project"),
             Some(&crate::auth::util::StringOrWildcard::String("456".into()))
         );
     }
@@ -228,9 +228,9 @@ mod tests {
         let (uri, params) = sign_url(path, future_expires());
 
         let ctx = AuthContext::from_presigned_url(&params, &http::Method::GET, &uri, &dir).unwrap();
-        assert_eq!(ctx.usecase, "attachments");
-        assert!(ctx.scopes.is_empty());
-        assert_eq!(ctx.object_key.as_deref(), Some("my-key"));
+        assert_eq!(ctx.usecase(), "attachments");
+        assert!(ctx.scopes().is_empty());
+        assert_eq!(ctx.object_key(), Some("my-key"));
     }
 
     #[test]

--- a/objectstore-server/src/auth/presigned.rs
+++ b/objectstore-server/src/auth/presigned.rs
@@ -1,0 +1,250 @@
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use objectstore_shared::presign::{PARAM_EXPIRES, PARAM_KEY_ID, PARAM_SIGNATURE, percent_decode};
+
+/// Pre-signed URL parameters extracted from the query string.
+#[derive(Debug)]
+pub struct PreSignedParams {
+    pub expires: u64,
+    pub key_id: String,
+    pub signature: Vec<u8>,
+}
+
+/// Attempt to extract pre-signed URL parameters from a URI's query string.
+///
+/// Returns `Some` only if all three required parameters (`X-Os-Expires`, `X-Os-KeyId`,
+/// `X-Os-Signature`) are present and parseable. Returns `None` if any are missing,
+/// indicating this is not a pre-signed URL request.
+pub fn extract_presigned_params(uri: &http::Uri) -> Option<PreSignedParams> {
+    let query = uri.query()?;
+
+    let mut expires: Option<u64> = None;
+    let mut key_id: Option<String> = None;
+    let mut signature: Option<Vec<u8>> = None;
+
+    for pair in query.split('&') {
+        let Some((k, v)) = pair.split_once('=') else {
+            continue;
+        };
+        let k = percent_decode(k);
+        let v = percent_decode(v);
+        match k.as_str() {
+            PARAM_EXPIRES => expires = Some(v.parse().ok()?),
+            PARAM_KEY_ID => key_id = Some(v),
+            PARAM_SIGNATURE => signature = Some(URL_SAFE_NO_PAD.decode(v.as_bytes()).ok()?),
+            _ => {}
+        }
+    }
+
+    Some(PreSignedParams {
+        expires: expires?,
+        key_id: key_id?,
+        signature: signature?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::collections::HashSet;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+
+    use ed25519_dalek::pkcs8::{DecodePrivateKey, DecodePublicKey};
+    use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
+    use jsonwebtoken::DecodingKey;
+    use objectstore_shared::presign::canonical_presigned_request;
+    use objectstore_types::auth::Permission;
+
+    use crate::auth::context::AuthContext;
+    use crate::auth::error::AuthError;
+    use crate::auth::key_directory::{PublicKeyConfig, PublicKeyDirectory};
+    use objectstore_test::server::{TEST_EDDSA_KID, TEST_EDDSA_PRIVKEY, TEST_EDDSA_PUBKEY};
+
+    fn test_key_directory() -> PublicKeyDirectory {
+        let public_key = PublicKeyConfig {
+            key_versions: vec![DecodingKey::from_ed_pem(TEST_EDDSA_PUBKEY.as_bytes()).unwrap()],
+            verifying_keys: vec![VerifyingKey::from_public_key_pem(&TEST_EDDSA_PUBKEY).unwrap()],
+            max_permissions: HashSet::from([
+                Permission::ObjectRead,
+                Permission::ObjectWrite,
+                Permission::ObjectDelete,
+            ]),
+        };
+        PublicKeyDirectory {
+            keys: BTreeMap::from([(TEST_EDDSA_KID.to_string(), public_key)]),
+        }
+    }
+
+    fn sign_url(path: &str, expires: u64) -> (http::Uri, PreSignedParams) {
+        let signing_key = SigningKey::from_pkcs8_pem(&TEST_EDDSA_PRIVKEY).unwrap();
+
+        let query_without_sig =
+            format!("{PARAM_EXPIRES}={expires}&{PARAM_KEY_ID}={TEST_EDDSA_KID}");
+        let canonical = canonical_presigned_request(path, Some(&query_without_sig));
+        let signature = signing_key.sign(canonical.as_bytes());
+        let sig_b64 = URL_SAFE_NO_PAD.encode(signature.to_bytes());
+
+        let uri: http::Uri = format!("{path}?{query_without_sig}&{PARAM_SIGNATURE}={sig_b64}")
+            .parse()
+            .unwrap();
+
+        let params = extract_presigned_params(&uri).unwrap();
+        (uri, params)
+    }
+
+    fn future_expires() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 300
+    }
+
+    fn past_expires() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            - 100
+    }
+
+    #[test]
+    fn test_extract_presigned_params_all_present() {
+        let uri: http::Uri = "/path?X-Os-Expires=1234&X-Os-KeyId=kid&X-Os-Signature=AAAA"
+            .parse()
+            .unwrap();
+        let params = extract_presigned_params(&uri).unwrap();
+        assert_eq!(params.expires, 1234);
+        assert_eq!(params.key_id, "kid");
+    }
+
+    #[test]
+    fn test_extract_presigned_params_missing_param() {
+        let uri: http::Uri = "/path?X-Os-Expires=1234&X-Os-KeyId=kid".parse().unwrap();
+        assert!(extract_presigned_params(&uri).is_none());
+    }
+
+    #[test]
+    fn test_extract_presigned_params_no_query() {
+        let uri: http::Uri = "/path".parse().unwrap();
+        assert!(extract_presigned_params(&uri).is_none());
+    }
+
+    #[test]
+    fn test_from_presigned_url_valid() {
+        let dir = test_key_directory();
+        let path = "/v1/objects/attachments/org=123;project=456/my-key";
+        let (uri, params) = sign_url(path, future_expires());
+
+        let ctx = AuthContext::from_presigned_url(&params, &http::Method::GET, &uri, &dir).unwrap();
+        assert_eq!(ctx.usecase, "attachments");
+        assert!(ctx.permissions.contains(&Permission::ObjectRead));
+        assert_eq!(ctx.permissions.len(), 1);
+        assert_eq!(ctx.object_key.as_deref(), Some("my-key"));
+        assert_eq!(
+            ctx.scopes.get("org"),
+            Some(&crate::auth::util::StringOrWildcard::String("123".into()))
+        );
+        assert_eq!(
+            ctx.scopes.get("project"),
+            Some(&crate::auth::util::StringOrWildcard::String("456".into()))
+        );
+    }
+
+    #[test]
+    fn test_from_presigned_url_expired() {
+        let dir = test_key_directory();
+        let path = "/v1/objects/attachments/org=123/my-key";
+        let (uri, params) = sign_url(path, past_expires());
+
+        let result = AuthContext::from_presigned_url(&params, &http::Method::GET, &uri, &dir);
+        assert!(matches!(result, Err(AuthError::BadRequest(_))));
+    }
+
+    #[test]
+    fn test_from_presigned_url_tampered_path() {
+        let dir = test_key_directory();
+        let path = "/v1/objects/attachments/org=123/my-key";
+        let (_, params) = sign_url(path, future_expires());
+
+        let tampered_uri: http::Uri = format!(
+            "/v1/objects/attachments/org=999/my-key?{PARAM_EXPIRES}={}&{PARAM_KEY_ID}={TEST_EDDSA_KID}&{PARAM_SIGNATURE}={}",
+            params.expires,
+            URL_SAFE_NO_PAD.encode(&params.signature),
+        )
+        .parse()
+        .unwrap();
+
+        let result =
+            AuthContext::from_presigned_url(&params, &http::Method::GET, &tampered_uri, &dir);
+        assert!(matches!(result, Err(AuthError::VerificationFailure)));
+    }
+
+    #[test]
+    fn test_from_presigned_url_unknown_key_id() {
+        let dir = test_key_directory();
+        let signing_key = SigningKey::from_pkcs8_pem(&TEST_EDDSA_PRIVKEY).unwrap();
+
+        let path = "/v1/objects/attachments/org=123/key";
+        let expires = future_expires();
+        let query = format!("{PARAM_EXPIRES}={expires}&{PARAM_KEY_ID}=unknown-kid");
+        let canonical = canonical_presigned_request(path, Some(&query));
+        let sig = signing_key.sign(canonical.as_bytes());
+        let sig_b64 = URL_SAFE_NO_PAD.encode(sig.to_bytes());
+
+        let uri: http::Uri = format!("{path}?{query}&{PARAM_SIGNATURE}={sig_b64}")
+            .parse()
+            .unwrap();
+        let params = extract_presigned_params(&uri).unwrap();
+
+        let result = AuthContext::from_presigned_url(&params, &http::Method::GET, &uri, &dir);
+        assert!(matches!(result, Err(AuthError::InternalError(_))));
+    }
+
+    #[test]
+    fn test_from_presigned_url_key_without_read_permission() {
+        let public_key = PublicKeyConfig {
+            key_versions: vec![DecodingKey::from_ed_pem(TEST_EDDSA_PUBKEY.as_bytes()).unwrap()],
+            verifying_keys: vec![VerifyingKey::from_public_key_pem(&TEST_EDDSA_PUBKEY).unwrap()],
+            max_permissions: HashSet::from([Permission::ObjectWrite]),
+        };
+        let dir = PublicKeyDirectory {
+            keys: BTreeMap::from([(TEST_EDDSA_KID.to_string(), public_key)]),
+        };
+
+        let path = "/v1/objects/attachments/org=123/key";
+        let (uri, params) = sign_url(path, future_expires());
+
+        let result = AuthContext::from_presigned_url(&params, &http::Method::GET, &uri, &dir);
+        assert!(matches!(result, Err(AuthError::NotPermitted)));
+    }
+
+    #[test]
+    fn test_from_presigned_url_empty_scopes() {
+        let dir = test_key_directory();
+        let path = "/v1/objects/attachments/_/my-key";
+        let (uri, params) = sign_url(path, future_expires());
+
+        let ctx = AuthContext::from_presigned_url(&params, &http::Method::GET, &uri, &dir).unwrap();
+        assert_eq!(ctx.usecase, "attachments");
+        assert!(ctx.scopes.is_empty());
+        assert_eq!(ctx.object_key.as_deref(), Some("my-key"));
+    }
+
+    #[test]
+    fn test_from_presigned_url_rejects_non_read_methods() {
+        let dir = test_key_directory();
+        let path = "/v1/objects/attachments/org=123/key";
+        let (uri, params) = sign_url(path, future_expires());
+
+        for method in [http::Method::PUT, http::Method::POST, http::Method::DELETE] {
+            let result = AuthContext::from_presigned_url(&params, &method, &uri, &dir);
+            assert!(
+                matches!(result, Err(AuthError::BadRequest(_))),
+                "expected rejection for {method}"
+            );
+        }
+    }
+}

--- a/objectstore-server/src/auth/service.rs
+++ b/objectstore-server/src/auth/service.rs
@@ -79,8 +79,8 @@ impl AuthAwareService {
 
     /// Checks whether the request is authorized for the given permission on the given context.
     ///
-    /// Object-bound auth contexts are rejected here because they must not be widened into
-    /// context-level authorization.
+    /// Object-bound auth contexts, such as pre-signed URLs, are rejected here because they must
+    /// not be widened into context-level authorization.
     pub fn check_context_permission(
         &self,
         perm: Permission,

--- a/objectstore-server/src/auth/service.rs
+++ b/objectstore-server/src/auth/service.rs
@@ -79,8 +79,8 @@ impl AuthAwareService {
 
     /// Checks whether the request is authorized for the given permission on the given context.
     ///
-    /// Object-bound auth contexts, such as pre-signed URLs, are rejected here because they must
-    /// not be widened into context-level authorization.
+    /// Object-bound auth contexts are rejected here because they must not be widened into
+    /// context-level authorization.
     pub fn check_context_permission(
         &self,
         perm: Permission,

--- a/objectstore-server/src/extractors/id.rs
+++ b/objectstore-server/src/extractors/id.rs
@@ -5,6 +5,7 @@ use axum::extract::{FromRequestParts, Path};
 use axum::http::request::Parts;
 use axum::response::{IntoResponse, Response};
 use objectstore_service::id::{ObjectContext, ObjectId};
+use objectstore_shared::presign::percent_decode;
 use objectstore_types::scope::{EMPTY_SCOPES, Scope, Scopes};
 use serde::{Deserialize, de};
 
@@ -50,8 +51,13 @@ impl FromRequestParts<ServiceState> for Xt<ObjectId> {
         parts: &mut Parts,
         state: &ServiceState,
     ) -> Result<Self, Self::Rejection> {
-        let Path(params) = Path::<ObjectParams>::from_request_parts(parts, state).await?;
-        let id = ObjectId::from_parts(params.usecase, params.scopes, params.key);
+        let id = match parse_object_id_from_path(parts.uri.path()) {
+            Some(id) => id,
+            None => {
+                let Path(params) = Path::<ObjectParams>::from_request_parts(parts, state).await?;
+                ObjectId::from_parts(params.usecase, params.scopes, params.key)
+            }
+        };
 
         populate_sentry_context(id.context());
         sentry::configure_scope(|s| s.set_extra("key", id.key().into()));
@@ -87,6 +93,46 @@ struct ObjectParams {
     key: String,
 }
 
+/// Parses an [`ObjectContext`] from an HTTP request path matching the object endpoint shape.
+///
+/// This accepts paths with arbitrary prefixes as long as they contain an `/objects/` segment,
+/// such as `/v1/objects/{usecase}/{scopes}` or `/v1/objects/{usecase}/{scopes}/{key}`.
+pub(crate) fn parse_object_context_from_path(path: &str) -> Option<ObjectContext> {
+    let (usecase, scopes, _key) = parse_object_path_parts(path)?;
+    Some(ObjectContext { usecase, scopes })
+}
+
+/// Parses an [`ObjectId`] from an HTTP request path matching the object endpoint shape.
+///
+/// This accepts paths with arbitrary prefixes as long as they contain an `/objects/` segment,
+/// such as `/v1/objects/{usecase}/{scopes}/{key}`.
+pub(crate) fn parse_object_id_from_path(path: &str) -> Option<ObjectId> {
+    let (usecase, scopes, key) = parse_object_path_parts(path)?;
+    let key = key?;
+    if key.is_empty() {
+        return None;
+    }
+
+    Some(ObjectId::from_parts(usecase, scopes, key))
+}
+
+fn parse_object_path_parts(path: &str) -> Option<(String, Scopes, Option<String>)> {
+    let rest = path
+        .find("/objects/")
+        .map(|i| &path[i + "/objects/".len()..])?;
+
+    let mut parts = rest.splitn(3, '/');
+    let usecase = percent_decode(parts.next()?);
+    let scopes = parse_scopes_str(&percent_decode(parts.next()?)).ok()?;
+    let key = parts.next().map(percent_decode);
+
+    if usecase.is_empty() {
+        return None;
+    }
+
+    Some((usecase, scopes, key))
+}
+
 /// Deserializes a `Scopes` instance from a string representation.
 ///
 /// The string representation is a semicolon-separated list of `key=value` pairs, following the
@@ -96,22 +142,24 @@ where
     D: de::Deserializer<'de>,
 {
     let s = Cow::<str>::deserialize(deserializer)?;
-    if s == EMPTY_SCOPES {
+    parse_scopes_str(&s).map_err(de::Error::custom)
+}
+
+fn parse_scopes_str(scopes_str: &str) -> Result<Scopes, String> {
+    if scopes_str == EMPTY_SCOPES {
         return Ok(Scopes::empty());
     }
 
-    let scopes = s
+    scopes_str
         .split(';')
         .map(|s| {
             let (key, value) = s
                 .split_once("=")
-                .ok_or_else(|| de::Error::custom("scope must be 'key=value'"))?;
+                .ok_or_else(|| "scope must be 'key=value'".to_string())?;
 
-            Scope::create(key, value).map_err(de::Error::custom)
+            Scope::create(key, value).map_err(|err| err.to_string())
         })
-        .collect::<Result<_, _>>()?;
-
-    Ok(scopes)
+        .collect()
 }
 
 impl FromRequestParts<ServiceState> for Xt<ObjectContext> {
@@ -121,10 +169,15 @@ impl FromRequestParts<ServiceState> for Xt<ObjectContext> {
         parts: &mut Parts,
         state: &ServiceState,
     ) -> Result<Self, Self::Rejection> {
-        let Path(params) = Path::<ContextParams>::from_request_parts(parts, state).await?;
-        let context = ObjectContext {
-            usecase: params.usecase,
-            scopes: params.scopes,
+        let context = match parse_object_context_from_path(parts.uri.path()) {
+            Some(context) => context,
+            None => {
+                let Path(params) = Path::<ContextParams>::from_request_parts(parts, state).await?;
+                ObjectContext {
+                    usecase: params.usecase,
+                    scopes: params.scopes,
+                }
+            }
         };
 
         populate_sentry_context(&context);
@@ -216,6 +269,40 @@ mod tests {
     fn parse_empty_key_or_value() {
         assert!(deser_scopes("=value").is_err());
         assert!(deser_scopes("key=").is_err());
+    }
+
+    #[test]
+    fn parse_object_id_from_path_with_prefix() {
+        let id = parse_object_id_from_path("/api/prefix/v1/objects/myusecase/org=1;project=2/a/b")
+            .unwrap();
+
+        assert_eq!(id.usecase(), "myusecase");
+        assert_eq!(id.scopes().get_value("org"), Some("1"));
+        assert_eq!(id.scopes().get_value("project"), Some("2"));
+        assert_eq!(id.key(), "a/b");
+    }
+
+    #[test]
+    fn parse_object_id_from_path_rejects_missing_key() {
+        assert!(parse_object_id_from_path("/v1/objects/myusecase/org=1/").is_none());
+    }
+
+    #[test]
+    fn parse_object_context_from_path_accepts_collection_path() {
+        let context =
+            parse_object_context_from_path("/api/prefix/v1/objects/myusecase/org=1;project=2/")
+                .unwrap();
+
+        assert_eq!(context.usecase, "myusecase");
+        assert_eq!(context.scopes.get_value("org"), Some("1"));
+        assert_eq!(context.scopes.get_value("project"), Some("2"));
+    }
+
+    #[test]
+    fn parse_object_id_from_path_decodes_percent_encoded_key() {
+        let id = parse_object_id_from_path("/v1/objects/myusecase/_/folder%2Ffile.txt").unwrap();
+
+        assert_eq!(id.key(), "folder/file.txt");
     }
 
     // --- Extractor integration tests ---

--- a/objectstore-server/src/extractors/mod.rs
+++ b/objectstore-server/src/extractors/mod.rs
@@ -3,7 +3,7 @@
 pub mod batch;
 pub mod body;
 pub mod downstream_service;
-mod id;
+pub(crate) mod id;
 mod service;
 
 /// An extractor for a remote type.

--- a/objectstore-server/src/extractors/service.rs
+++ b/objectstore-server/src/extractors/service.rs
@@ -1,7 +1,8 @@
-use axum::extract::FromRequestParts;
-use axum::http::{header, request::Parts};
+use axum::extract::{FromRequestParts, OriginalUri};
+use axum::http::{Uri, header, request::Parts};
 
-use crate::auth::{AuthAwareService, AuthContext};
+use crate::auth::presigned::extract_presigned_params;
+use crate::auth::{AuthAwareService, AuthContext, AuthError};
 use crate::endpoints::common::ApiError;
 use crate::state::ServiceState;
 
@@ -20,19 +21,36 @@ impl FromRequestParts<ServiceState> for AuthAwareService {
         parts: &mut Parts,
         state: &ServiceState,
     ) -> Result<Self, Self::Rejection> {
-        let encoded_token = parts
+        let enforce = state.config.auth.enforce;
+        let request_uri = request_uri_for_auth(parts);
+
+        let encoded_jwt = parts
             .headers
             .get(OBJECTSTORE_AUTH_HEADER)
             .or_else(|| parts.headers.get(header::AUTHORIZATION))
             .and_then(|v| v.to_str().ok())
             .and_then(strip_bearer);
 
-        let enforce = state.config.auth.enforce;
-        // Attempt to decode / verify the JWT, logging failure
-        let auth_result = AuthContext::from_encoded_jwt(encoded_token, &state.key_directory)
-            .inspect_err(|err| err.log(None, None, enforce));
+        let presigned_params = extract_presigned_params(&request_uri);
 
-        // If auth enforcement is enabled, `from_encoded_jwt()` must have succeeded.
+        let auth_result = match (presigned_params, encoded_jwt) {
+            // Pre-signed URL params take precedence
+            (Some(ref params), _) => AuthContext::from_presigned_url(
+                params,
+                &parts.method,
+                &request_uri,
+                &state.key_directory,
+            ),
+            // Fall back to header-based JWT auth
+            (None, Some(jwt)) => AuthContext::from_encoded_jwt(jwt, &state.key_directory),
+            (None, None) => Err(AuthError::BadRequest("No authorization provided")),
+        };
+
+        if let Err(err) = &auth_result {
+            err.log(None, None, enforce);
+        }
+
+        // If auth enforcement is enabled, `auth_context` must be `Ok(context)`.
         // If auth enforcement is disabled, we'll pass the context along if it succeeded but will
         // still proceed with `None` if it failed.
         let auth_context = match enforce {
@@ -48,6 +66,14 @@ impl FromRequestParts<ServiceState> for AuthAwareService {
     }
 }
 
+fn request_uri_for_auth(parts: &Parts) -> Uri {
+    parts
+        .extensions
+        .get::<OriginalUri>()
+        .map(|original| original.0.clone())
+        .unwrap_or_else(|| parts.uri.clone())
+}
+
 fn strip_bearer(header_value: &str) -> Option<&str> {
     let (prefix, tail) = header_value.split_at_checked(BEARER_PREFIX.len())?;
     if prefix.eq_ignore_ascii_case(BEARER_PREFIX) {
@@ -60,6 +86,7 @@ fn strip_bearer(header_value: &str) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::http::Request;
 
     #[test]
     fn test_strip_bearer() {
@@ -74,5 +101,36 @@ mod tests {
 
         // No character boundary at end of expected prefix
         assert_eq!(strip_bearer("Bearer⚠️tokenvalue"), None);
+    }
+
+    #[test]
+    fn request_uri_uses_original_uri_extension() {
+        let request = Request::builder()
+            .uri("/objects/test/_/key?X-Os-Expires=1")
+            .body(())
+            .unwrap();
+        let (mut parts, _) = request.into_parts();
+        parts.extensions.insert(OriginalUri(
+            "/v1/objects/test/_/key?X-Os-Expires=1".parse().unwrap(),
+        ));
+
+        assert_eq!(
+            request_uri_for_auth(&parts),
+            Uri::from_static("/v1/objects/test/_/key?X-Os-Expires=1"),
+        );
+    }
+
+    #[test]
+    fn request_uri_falls_back_to_parts_uri() {
+        let request = Request::builder()
+            .uri("/v1/objects/test/_/key?X-Os-Expires=1")
+            .body(())
+            .unwrap();
+        let (parts, _) = request.into_parts();
+
+        assert_eq!(
+            request_uri_for_auth(&parts),
+            Uri::from_static("/v1/objects/test/_/key?X-Os-Expires=1"),
+        );
     }
 }

--- a/objectstore-shared/Cargo.toml
+++ b/objectstore-shared/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "objectstore-shared"
+authors = ["Sentry <oss@sentry.io>"]
+description = "Shared utilities for the Objectstore client and server"
+homepage = "https://getsentry.github.io/objectstore/"
+repository = "https://github.com/getsentry/objectstore"
+license-file = "../LICENSE.md"
+version = "0.1.0"
+edition = "2024"
+publish = true
+
+[dependencies]
+percent-encoding = { workspace = true }

--- a/objectstore-shared/src/lib.rs
+++ b/objectstore-shared/src/lib.rs
@@ -1,0 +1,3 @@
+//! Shared utilities for the Objectstore client and server.
+
+pub mod presign;

--- a/objectstore-shared/src/presign.rs
+++ b/objectstore-shared/src/presign.rs
@@ -1,0 +1,133 @@
+//! Constants and functions for canonical form computation for pre-signed URLs.
+
+/// Query parameters used for pre-signed URLs.
+pub const PARAM_KEY_ID: &str = "X-Os-KeyId";
+pub const PARAM_EXPIRES: &str = "X-Os-Expires";
+pub const PARAM_SIGNATURE: &str = "X-Os-Signature";
+
+/// Build the canonical request string for pre-signed URL signing/verification.
+///
+/// The canonical form is:
+/// ```text
+/// GET\n{canonical_path}\n{canonical_query}
+/// ```
+///
+/// - Method is always `GET` (HEAD maps to GET).
+/// - Path uses the encoded URI path as received by the service.
+/// - Percent-encoded octets are normalized to uppercase hex digits.
+/// - Query params use the encoded keys and optional values from the URI,
+///   excluding `X-Os-Signature`, sorted by encoded key.
+pub fn canonical_presigned_request(path: &str, query: Option<&str>) -> String {
+    let canonical_path = normalize_percent_encoding(path);
+
+    let mut params: Vec<(String, Option<String>)> = query
+        .unwrap_or("")
+        .split('&')
+        .filter(|s| !s.is_empty())
+        .filter_map(|pair| {
+            let (k, v) = match pair.split_once('=') {
+                Some((k, v)) => (k, Some(normalize_percent_encoding(v))),
+                None => (pair, None),
+            };
+            let canonical_key = normalize_percent_encoding(k);
+            if canonical_key == PARAM_SIGNATURE {
+                return None;
+            }
+            Some((canonical_key, v))
+        })
+        .collect();
+
+    params.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+
+    let query_str = params
+        .iter()
+        .map(|(k, v)| match v {
+            Some(v) => format!("{k}={v}"),
+            None => k.clone(),
+        })
+        .collect::<Vec<_>>()
+        .join("&");
+
+    format!("GET\n{canonical_path}\n{query_str}")
+}
+
+/// Percent-decode a string, interpreting the result as UTF-8.
+pub fn percent_decode(input: &str) -> String {
+    percent_encoding::percent_decode_str(input)
+        .decode_utf8_lossy()
+        .into_owned()
+}
+
+/// Normalize percent-encoded octets to use uppercase hex digits.
+///
+/// The input is expected to be a URI path or query component and therefore ASCII.
+fn normalize_percent_encoding(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut normalized = String::with_capacity(input.len());
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] == b'%'
+            && i + 2 < bytes.len()
+            && bytes[i + 1].is_ascii_hexdigit()
+            && bytes[i + 2].is_ascii_hexdigit()
+        {
+            normalized.push('%');
+            normalized.push(char::from(bytes[i + 1].to_ascii_uppercase()));
+            normalized.push(char::from(bytes[i + 2].to_ascii_uppercase()));
+            i += 3;
+        } else {
+            normalized.push(char::from(bytes[i]));
+            i += 1;
+        }
+    }
+
+    normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_canonical_form_basic() {
+        let canonical = canonical_presigned_request(
+            "/v1/objects/attachments/org=123;project=456/my-key",
+            Some("X-Os-Expires=1712668800&X-Os-KeyId=relay-prod&X-Os-Signature=abc123"),
+        );
+        assert_eq!(
+            canonical,
+            "GET\n/v1/objects/attachments/org=123;project=456/my-key\nX-Os-Expires=1712668800&X-Os-KeyId=relay-prod"
+        );
+    }
+
+    #[test]
+    fn test_canonical_form_lowercase_hex() {
+        let canonical_upper = canonical_presigned_request(
+            "/v1/objects/test/org%3D1/key",
+            Some("X-Os-Expires=1000&X-Os-KeyId=test"),
+        );
+        let canonical_lower = canonical_presigned_request(
+            "/v1/objects/test/org%3d1/key",
+            Some("X-Os-Expires=1000&X-Os-KeyId=test"),
+        );
+        assert_eq!(canonical_upper, canonical_lower);
+    }
+
+    #[test]
+    fn test_canonical_form_reordered_params() {
+        let c1 = canonical_presigned_request("/path", Some("X-Os-KeyId=test&X-Os-Expires=1000"));
+        let c2 = canonical_presigned_request("/path", Some("X-Os-Expires=1000&X-Os-KeyId=test"));
+        assert_eq!(c1, c2);
+    }
+
+    #[test]
+    fn test_canonical_form_bare_query_params() {
+        let canonical =
+            canonical_presigned_request("/path", Some("y&X-Os-KeyId=test&x=1&X-Os-Expires=1000&z"));
+        assert_eq!(
+            canonical,
+            "GET\n/path\nX-Os-Expires=1000&X-Os-KeyId=test&x=1&y&z"
+        );
+    }
+}


### PR DESCRIPTION
Implements pre-signed URLs that grant time-limited access to specific objects, as an alternative to providing a JWT header.
We will need this for frontend components that rely on Objectstore to provide files (currently only snapshot images and diffs) and we could also use it for e.g. attachments downloads.

Pre-signed URLs are of the form:
```
/v1/objects/{usecase}/{scopes}/{key}?X-Os-Expires={unix_ts}&X-Os-KeyId={kid}&X-Os-Signature={base64url_sig}
```

- The signature is a Ed25519 signature of the path portion of the URL and query parameters. The signature is computed on a canonicalized combination of path and query params, to ensure that signature computation and verification are consistent.
- Pre-signed URLs are only supported for GET and HEAD requests for now. The rationale for that is to solve the immediate problem of GET requests coming from browsers, and avoid expanding the scope to PUT/POST which would have a more complex implementation (implementing those correctly would require signing (part of) the request headers).

Clients expose a `presign_url` utility which takes a private key and creates pre-signed URLs with a customizable TTL, 5 minutes by default.

Introduces a new `objectstore-shared` crate to house the shared signing logic and constants between the client and server crate. We already have `objectstore-types` that's similarly shared, but these are not really types, so I think a separate crate is warranted.