### PR TITLE
feat(server): Read X-Os-Auth from query params

### DIFF
--- a/objectstore-server/docs/architecture.md
+++ b/objectstore-server/docs/architecture.md
@@ -41,8 +41,9 @@ A request flows through several layers before reaching the storage service:
 2. **Extractors**: path parameters are parsed into an
    [`ObjectId`](objectstore_service::id::ObjectId) or
    [`ObjectContext`](objectstore_service::id::ObjectContext). The auth token is
-   read from the `X-Os-Auth` header (preferred) or the standard
-   `Authorization` header (fallback), then validated and decoded into an
+   read from the `X-Os-Auth` header (preferred), the `X-Os-Auth` query
+   parameter, or the standard `Authorization` header (fallback), then
+   validated and decoded into an
    [`AuthContext`](auth::AuthContext).
    The optional `x-downstream-service` header is extracted for killswitch
    matching.

--- a/objectstore-server/src/auth/key_directory.rs
+++ b/objectstore-server/src/auth/key_directory.rs
@@ -49,8 +49,9 @@ impl TryFrom<&AuthZVerificationKey> for PublicKeyConfig {
 
 /// Directory of keys that may be used to verify a request's auth token.
 ///
-/// The auth token is read from the `X-Os-Auth` header (preferred) or the
-/// standard `Authorization` header (fallback). This directory contains a map keyed
+/// The auth token is read from the `X-Os-Auth` header (preferred), the
+/// `X-Os-Auth` query parameter, or the standard `Authorization` header
+/// (fallback). This directory contains a map keyed
 /// on a key's ID. When verifying a JWT, the `kid` field should be read from the
 /// JWT header and used to index into this directory to select the appropriate key.
 #[derive(Debug)]

--- a/objectstore-server/src/config.rs
+++ b/objectstore-server/src/config.rs
@@ -343,8 +343,9 @@ pub struct AuthZ {
 
     /// Keys that may be used to verify a request's auth token.
     ///
-    /// The auth token is read from the `X-Os-Auth` header (preferred)
-    /// or the standard `Authorization` header (fallback). This field is a
+    /// The auth token is read from the `X-Os-Auth` header (preferred),
+    /// the `X-Os-Auth` query parameter, or the standard `Authorization`
+    /// header (fallback). This field is a
     /// container keyed on a key's ID. When verifying a JWT, the `kid` field
     /// should be read from the JWT header and used to index into this map to
     /// select the appropriate key.
@@ -445,7 +446,8 @@ pub struct Config {
     /// Content-based authorization configuration.
     ///
     /// Controls the verification and enforcement of content-based access control based on the
-    /// JWT in a request's `X-Os-Auth` or `Authorization` header.
+    /// JWT in a request's `X-Os-Auth` header, `X-Os-Auth` query parameter, or `Authorization`
+    /// header.
     pub auth: AuthZ,
 
     /// A list of matchers for requests to discard without processing.

--- a/objectstore-server/src/extractors/service.rs
+++ b/objectstore-server/src/extractors/service.rs
@@ -72,9 +72,7 @@ fn strip_bearer(header_value: &str) -> Option<&str> {
 
 fn extract_query_param_value<'a>(query: Option<&'a str>, param: &str) -> Option<&'a str> {
     query?.split('&').find_map(|pair| {
-        let Some((key, value)) = pair.split_once('=') else {
-            return None;
-        };
+        let (key, value) = pair.split_once('=')?;
         (key == param && !value.is_empty()).then_some(value)
     })
 }

--- a/objectstore-server/src/extractors/service.rs
+++ b/objectstore-server/src/extractors/service.rs
@@ -31,7 +31,7 @@ impl FromRequestParts<ServiceState> for AuthAwareService {
             .get(OBJECTSTORE_AUTH_HEADER)
             .and_then(|v| v.to_str().ok())
             .and_then(strip_bearer)
-            .or_else(|| extract_query_param(parts.uri.query(), OBJECTSTORE_AUTH_QUERY_PARAM))
+            .or_else(|| extract_query_param_value(parts.uri.query(), OBJECTSTORE_AUTH_QUERY_PARAM))
             .or_else(|| {
                 parts
                     .headers
@@ -70,18 +70,13 @@ fn strip_bearer(header_value: &str) -> Option<&str> {
     }
 }
 
-/// Extracts the value of a query parameter by name from a raw query string.
-///
-/// Returns `None` if the query string is absent, the parameter is not present,
-/// or the parameter has no value.
-fn extract_query_param<'a>(query: Option<&'a str>, param: &str) -> Option<&'a str> {
-    query?
-        .split('&')
-        .find_map(|pair| {
-            let (key, value) = pair.split_once('=')?;
-            (key == param).then_some(value)
-        })
-        .filter(|v| !v.is_empty())
+fn extract_query_param_value<'a>(query: Option<&'a str>, param: &str) -> Option<&'a str> {
+    query?.split('&').find_map(|pair| {
+        let Some((key, value)) = pair.split_once('=') else {
+            return None;
+        };
+        (key == param && !value.is_empty()).then_some(value)
+    })
 }
 
 #[cfg(test)]
@@ -104,25 +99,36 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_query_param() {
-        assert_eq!(extract_query_param(None, "X-Os-Auth"), None);
-        assert_eq!(extract_query_param(Some(""), "X-Os-Auth"), None);
-        assert_eq!(extract_query_param(Some("other=val"), "X-Os-Auth"), None);
+    fn test_extract_query_param_value() {
+        assert_eq!(extract_query_param_value(None, "X-Os-Auth"), None);
+        assert_eq!(extract_query_param_value(Some(""), "X-Os-Auth"), None);
         assert_eq!(
-            extract_query_param(Some("X-Os-Auth=mytoken"), "X-Os-Auth"),
+            extract_query_param_value(Some("other=val"), "X-Os-Auth"),
+            None
+        );
+
+        assert_eq!(
+            extract_query_param_value(Some("X-Os-Auth=mytoken"), "X-Os-Auth"),
             Some("mytoken")
         );
         assert_eq!(
-            extract_query_param(Some("foo=bar&X-Os-Auth=mytoken"), "X-Os-Auth"),
+            extract_query_param_value(Some("foo=bar&X-Os-Auth=mytoken"), "X-Os-Auth"),
             Some("mytoken")
         );
         assert_eq!(
-            extract_query_param(Some("X-Os-Auth=mytoken&foo=bar"), "X-Os-Auth"),
+            extract_query_param_value(Some("X-Os-Auth=mytoken&foo=bar"), "X-Os-Auth"),
             Some("mytoken")
         );
+
         // Empty value
-        assert_eq!(extract_query_param(Some("X-Os-Auth="), "X-Os-Auth"), None);
+        assert_eq!(
+            extract_query_param_value(Some("X-Os-Auth="), "X-Os-Auth"),
+            None
+        );
         // No `=` sign
-        assert_eq!(extract_query_param(Some("X-Os-Auth"), "X-Os-Auth"), None);
+        assert_eq!(
+            extract_query_param_value(Some("X-Os-Auth"), "X-Os-Auth"),
+            None
+        );
     }
 }

--- a/objectstore-server/src/extractors/service.rs
+++ b/objectstore-server/src/extractors/service.rs
@@ -13,6 +13,11 @@ const BEARER_PREFIX: &str = "Bearer ";
 /// this header.
 const OBJECTSTORE_AUTH_HEADER: &str = "x-os-auth";
 
+/// Query parameter name for Objectstore authentication. Used as a fallback when
+/// headers cannot be set (e.g. browser-initiated requests). The value should be
+/// the raw JWT without a `Bearer` prefix.
+const OBJECTSTORE_AUTH_QUERY_PARAM: &str = "X-Os-Auth";
+
 impl FromRequestParts<ServiceState> for AuthAwareService {
     type Rejection = ApiError;
 
@@ -20,12 +25,20 @@ impl FromRequestParts<ServiceState> for AuthAwareService {
         parts: &mut Parts,
         state: &ServiceState,
     ) -> Result<Self, Self::Rejection> {
+        // Precedence: X-Os-Auth header > X-Os-Auth query param > Authorization header.
         let encoded_token = parts
             .headers
             .get(OBJECTSTORE_AUTH_HEADER)
-            .or_else(|| parts.headers.get(header::AUTHORIZATION))
             .and_then(|v| v.to_str().ok())
-            .and_then(strip_bearer);
+            .and_then(strip_bearer)
+            .or_else(|| extract_query_param(parts.uri.query(), OBJECTSTORE_AUTH_QUERY_PARAM))
+            .or_else(|| {
+                parts
+                    .headers
+                    .get(header::AUTHORIZATION)
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(strip_bearer)
+            });
 
         let enforce = state.config.auth.enforce;
         // Attempt to decode / verify the JWT, logging failure
@@ -57,6 +70,20 @@ fn strip_bearer(header_value: &str) -> Option<&str> {
     }
 }
 
+/// Extracts the value of a query parameter by name from a raw query string.
+///
+/// Returns `None` if the query string is absent, the parameter is not present,
+/// or the parameter has no value.
+fn extract_query_param<'a>(query: Option<&'a str>, param: &str) -> Option<&'a str> {
+    query?
+        .split('&')
+        .find_map(|pair| {
+            let (key, value) = pair.split_once('=')?;
+            (key == param).then_some(value)
+        })
+        .filter(|v| !v.is_empty())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -74,5 +101,28 @@ mod tests {
 
         // No character boundary at end of expected prefix
         assert_eq!(strip_bearer("Bearer⚠️tokenvalue"), None);
+    }
+
+    #[test]
+    fn test_extract_query_param() {
+        assert_eq!(extract_query_param(None, "X-Os-Auth"), None);
+        assert_eq!(extract_query_param(Some(""), "X-Os-Auth"), None);
+        assert_eq!(extract_query_param(Some("other=val"), "X-Os-Auth"), None);
+        assert_eq!(
+            extract_query_param(Some("X-Os-Auth=mytoken"), "X-Os-Auth"),
+            Some("mytoken")
+        );
+        assert_eq!(
+            extract_query_param(Some("foo=bar&X-Os-Auth=mytoken"), "X-Os-Auth"),
+            Some("mytoken")
+        );
+        assert_eq!(
+            extract_query_param(Some("X-Os-Auth=mytoken&foo=bar"), "X-Os-Auth"),
+            Some("mytoken")
+        );
+        // Empty value
+        assert_eq!(extract_query_param(Some("X-Os-Auth="), "X-Os-Auth"), None);
+        // No `=` sign
+        assert_eq!(extract_query_param(Some("X-Os-Auth"), "X-Os-Auth"), None);
     }
 }


### PR DESCRIPTION
This change is needed for https://github.com/getsentry/sentry/pull/113030.
It allows frontend pages that use standard image components to slap `?X-Os-Auth=<token>` to the URLs they retrieve images from, as opposed to needing custom logic to add it as a header whenever the image is known to be stored in Objectstore.

This is the final piece of the puzzle that will allow us to enable auth enforcement and unblock Emerge for EA of Snapshots.

The proper solution would be pre-signed URLs, but that needs design and is significantly more complex. We don't want that to be a blocker for Snapshots.
Moreover, only the frontend will use this way of authenticating, so we can always change it relatively easily.

The only thing we cannot change is old versions of CLI. CLI currently fetches a token from the backend and puts it in the `X-Os-Auth` header. Now that's a JWT, but in the future it could be something else, we just need to change the semantics of what we return from the backend.