### PR TITLE
chore(gocd): Rename s4s region to s4s2 for soak-time stage

### DIFF
--- a/gocd/templates/pipelines/objectstore.libsonnet
+++ b/gocd/templates/pipelines/objectstore.libsonnet
@@ -73,7 +73,7 @@ local deploy_canary(region) =
     [];
 
 local soak_time(region) =
-  if region == 's4s' then
+  if region == 's4s2' then
     [
       {
         'soak-time': {


### PR DESCRIPTION
Point the post-rollout soak-time stage at `s4s2` instead of `s4s`, since s4s has been removed in favor of s4s2.

The soak-time stage (introduced in #218) runs Sentry error-rate and new-issue checks after a full rollout to s4s, before rolling out to prod.