### PR TITLE
feat(server): Temporarily add allocator metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,6 +731,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2002,6 +2008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
 dependencies = [
  "cc",
+ "cty",
  "libc",
 ]
 
@@ -2554,6 +2561,7 @@ dependencies = [
  "humantime",
  "humantime-serde",
  "jsonwebtoken",
+ "libmimalloc-sys",
  "mimalloc",
  "nix",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ http = "1.3.1"
 humantime = "2.2.0"
 humantime-serde = "1.1.1"
 jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
+libmimalloc-sys = { version = "0.1.44", features = ["extended"] }
 mimalloc = { version = "0.1.48", features = ["v3", "override"] }
 rand = "0.9.3"
 regex = "1.12.3"

--- a/objectstore-server/Cargo.toml
+++ b/objectstore-server/Cargo.toml
@@ -26,6 +26,7 @@ http = { workspace = true }
 humantime = { workspace = true }
 humantime-serde = { workspace = true }
 jsonwebtoken = { workspace = true }
+libmimalloc-sys = { workspace = true }
 mimalloc = { workspace = true }
 num_cpus = "1.17.0"
 objectstore-log = { workspace = true, features = ["init", "sentry"] }

--- a/objectstore-server/src/state.rs
+++ b/objectstore-server/src/state.rs
@@ -131,7 +131,7 @@ async fn track_runtime_metrics(interval: Duration) {
             "runtime.num_io_driver_fds" = registered_fds - deregistered_fds
         );
 
-        // TODO(lcian): Temporary metrics
+        // TODO(lcian): Remove these or refactor in a better place
         let mut _elapsed_msecs = 0usize;
         let mut _user_msecs = 0usize;
         let mut _system_msecs = 0usize;

--- a/objectstore-server/src/state.rs
+++ b/objectstore-server/src/state.rs
@@ -130,5 +130,33 @@ async fn track_runtime_metrics(interval: Duration) {
         objectstore_metrics::gauge!(
             "runtime.num_io_driver_fds" = registered_fds - deregistered_fds
         );
+
+        // TODO(lcian): Temporary metrics
+        let mut _elapsed_msecs = 0usize;
+        let mut _user_msecs = 0usize;
+        let mut _system_msecs = 0usize;
+        let mut current_rss = 0usize;
+        let mut peak_rss = 0usize;
+        let mut current_commit = 0usize;
+        let mut peak_commit = 0usize;
+        let mut page_faults = 0usize;
+        // SAFETY: `mi_process_info` only writes to the eight out-parameters.
+        unsafe {
+            libmimalloc_sys::mi_process_info(
+                &mut _elapsed_msecs,
+                &mut _user_msecs,
+                &mut _system_msecs,
+                &mut current_rss,
+                &mut peak_rss,
+                &mut current_commit,
+                &mut peak_commit,
+                &mut page_faults,
+            );
+        }
+        objectstore_metrics::gauge!("allocator.rss_bytes" = current_rss);
+        objectstore_metrics::gauge!("allocator.rss_peak_bytes" = peak_rss);
+        objectstore_metrics::gauge!("allocator.commit_bytes" = current_commit);
+        objectstore_metrics::gauge!("allocator.commit_peak_bytes" = peak_commit);
+        objectstore_metrics::gauge!("allocator.page_faults" = page_faults);
     }
 }


### PR DESCRIPTION
Adds gauges reporting mimalloc's process-level stats (`rss_bytes`, `rss_peak_bytes`, `commit_bytes`, `commit_peak_bytes`, `page_faults`) alongside the existing runtime metrics, sourced from `libmimalloc_sys::mi_process_info`.

These are temporary instrumentation to investigate a potential memory leak in the server. Once the investigation concludes, the metrics and the `libmimalloc-sys` dependency should be removed.