### PR TITLE
feat: Move to jemalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,13 +415,13 @@ dependencies = [
  "bytes",
  "bytesize",
  "futures-util",
- "mimalloc",
  "objectstore-service",
  "objectstore-types",
  "rand 0.9.4",
  "rand_distr",
  "rustls",
  "sketches-ddsketch",
+ "tikv-jemallocator",
  "tokio",
  "tokio-util",
  "yansi",
@@ -729,12 +729,6 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
-
-[[package]]
-name = "cty"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "curve25519-dalek"
@@ -2002,17 +1996,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
-dependencies = [
- "cc",
- "cty",
- "libc",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2121,15 +2104,6 @@ dependencies = [
  "rand 0.9.4",
  "rand_xoshiro",
  "sketches-ddsketch",
-]
-
-[[package]]
-name = "mimalloc"
-version = "0.1.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
-dependencies = [
- "libmimalloc-sys",
 ]
 
 [[package]]
@@ -2561,8 +2535,6 @@ dependencies = [
  "humantime",
  "humantime-serde",
  "jsonwebtoken",
- "libmimalloc-sys",
- "mimalloc",
  "nix",
  "num_cpus",
  "objectstore-log",
@@ -2582,6 +2554,7 @@ dependencies = [
  "stresstest",
  "tempfile",
  "thiserror 2.0.18",
+ "tikv-jemallocator",
  "tokio",
  "tower",
  "tower-http",
@@ -4113,13 +4086,13 @@ dependencies = [
  "futures",
  "humantime-serde",
  "indicatif",
- "mimalloc",
  "objectstore-client",
  "rand 0.9.4",
  "rand_distr",
  "serde",
  "serde_yaml",
  "sketches-ddsketch",
+ "tikv-jemallocator",
  "tokio",
  "tokio-util",
  "yansi",
@@ -4255,6 +4228,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,6 @@ http = "1.3.1"
 humantime = "2.2.0"
 humantime-serde = "1.1.1"
 jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
-libmimalloc-sys = { version = "0.1.44", features = ["extended"] }
-mimalloc = { version = "0.1.48", features = ["v3", "override"] }
 rand = "0.9.3"
 regex = "1.12.3"
 reqwest = { version = "0.12.22" }
@@ -50,6 +48,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 tempfile = "3.20.0"
 thiserror = "2.0.17"
+tikv-jemallocator = { version = "0.6.1", features = ["background_threads", "override_allocator_on_supported_platforms"] }
 tokio = "1.47.0"
 tokio-util = { version = "0.7.15", features = ["rt"] }
 tracing = "0.1.41"

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -4,7 +4,7 @@ FROM rust:slim-bookworm
 RUN dpkg --add-architecture amd64 \
     && apt-get update -qq \
     && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev pkg-config git libssl-dev:amd64 gcc-x86-64-linux-gnu g++-x86-64-linux-gnu \
+    && apt-get install -y --no-install-recommends make protobuf-compiler libprotobuf-dev pkg-config git libssl-dev:amd64 gcc-x86-64-linux-gnu g++-x86-64-linux-gnu \
     && rm -rf /var/lib/apt/lists/*
 
 RUN rustup target add x86_64-unknown-linux-gnu

--- a/bigtable-bench/Cargo.toml
+++ b/bigtable-bench/Cargo.toml
@@ -15,13 +15,13 @@ argh = "0.1.13"
 bytes = { workspace = true }
 bytesize = "2.0.1"
 futures-util = { workspace = true }
-mimalloc = { workspace = true }
 objectstore-service = { workspace = true }
 objectstore-types = { workspace = true }
 rand = { workspace = true, features = ["small_rng"] }
 rand_distr = "0.5.1"
 rustls = { version = "0.23", default-features = false }
 sketches-ddsketch = "0.3.0"
+tikv-jemallocator = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync", "macros", "signal"] }
 tokio-util = { workspace = true }
 yansi = "1.0.1"

--- a/bigtable-bench/src/main.rs
+++ b/bigtable-bench/src/main.rs
@@ -63,7 +63,7 @@ struct Args {
 }
 
 #[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/objectstore-server/Cargo.toml
+++ b/objectstore-server/Cargo.toml
@@ -26,8 +26,6 @@ http = { workspace = true }
 humantime = { workspace = true }
 humantime-serde = { workspace = true }
 jsonwebtoken = { workspace = true }
-libmimalloc-sys = { workspace = true }
-mimalloc = { workspace = true }
 num_cpus = "1.17.0"
 objectstore-log = { workspace = true, features = ["init", "sentry"] }
 objectstore-metrics = { workspace = true }
@@ -45,6 +43,7 @@ secrecy = { version = "0.10.3", features = ["serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tikv-jemallocator = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tower = { version = "0.5.2" }
 tower-http = { version = "0.6.6", default-features = false, features = [

--- a/objectstore-server/src/main.rs
+++ b/objectstore-server/src/main.rs
@@ -9,7 +9,7 @@
 use objectstore_server::cli;
 
 #[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 fn main() {
     match cli::execute() {

--- a/objectstore-server/src/state.rs
+++ b/objectstore-server/src/state.rs
@@ -130,33 +130,5 @@ async fn track_runtime_metrics(interval: Duration) {
         objectstore_metrics::gauge!(
             "runtime.num_io_driver_fds" = registered_fds - deregistered_fds
         );
-
-        // TODO(lcian): Remove these or refactor in a better place
-        let mut _elapsed_msecs = 0usize;
-        let mut _user_msecs = 0usize;
-        let mut _system_msecs = 0usize;
-        let mut current_rss = 0usize;
-        let mut peak_rss = 0usize;
-        let mut current_commit = 0usize;
-        let mut peak_commit = 0usize;
-        let mut page_faults = 0usize;
-        // SAFETY: `mi_process_info` only writes to the eight out-parameters.
-        unsafe {
-            libmimalloc_sys::mi_process_info(
-                &mut _elapsed_msecs,
-                &mut _user_msecs,
-                &mut _system_msecs,
-                &mut current_rss,
-                &mut peak_rss,
-                &mut current_commit,
-                &mut peak_commit,
-                &mut page_faults,
-            );
-        }
-        objectstore_metrics::gauge!("allocator.rss_bytes" = current_rss);
-        objectstore_metrics::gauge!("allocator.rss_peak_bytes" = peak_rss);
-        objectstore_metrics::gauge!("allocator.commit_bytes" = current_commit);
-        objectstore_metrics::gauge!("allocator.commit_peak_bytes" = peak_commit);
-        objectstore_metrics::gauge!("allocator.page_faults" = page_faults);
     }
 }

--- a/stresstest/Cargo.toml
+++ b/stresstest/Cargo.toml
@@ -16,13 +16,13 @@ bytesize = { version = "2.0.1", features = ["serde"] }
 futures = { workspace = true }
 humantime-serde = { workspace = true }
 indicatif = "0.18.0"
-mimalloc = { workspace = true }
 objectstore-client = { workspace = true }
 rand = { workspace = true, features = ["small_rng"] }
 rand_distr = "0.5.1"
 serde = { workspace = true }
 serde_yaml = "0.9.34-deprecated"
 sketches-ddsketch = "0.3.0"
+tikv-jemallocator = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync", "macros"] }
 tokio-util = { workspace = true }
 yansi = "1.0.1"

--- a/stresstest/src/main.rs
+++ b/stresstest/src/main.rs
@@ -37,7 +37,7 @@ pub struct Args {
 }
 
 #[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {


### PR DESCRIPTION
For some unknown reasons, mimalloc seems to be unfit for Objectstore.
We've been observing constant memory growth over every single instance's lifetime.

This leads to overprovisioning, as the autoscaler unnecessarily creates more pods.
Moreover, it creates extra work for the oncall, who needs to respond to the alerts by restarting pods in the affected environment.

I ran some tests locally and in sandbox, and jemalloc seems to release memory as expected, so let's move to it.

Some other things I've tried:
- Running Objectstore with a heap profiler (https://github.com/nnethercote/dhat-rs): this confirmed we have no memory leak, at least when running against emulators
- Calling mimalloc's `mi_collect` API periodically on a background task, or playing around with mimalloc's config, all to no result.