### PR TITLE
test(s3): Add MinIO for S3-compatible backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,15 @@ jobs:
             -e GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME=test-bucket \
             gcr.io/cloud-devrel-public-resources/storage-testbench:latest
 
+      - name: Start MinIO
+        run: |
+          docker run -d \
+            --name minio \
+            -p 8089:9000 \
+            --entrypoint /run-minio.sh \
+            -v $PWD/devservices/run-minio.sh:/run-minio.sh \
+            minio/minio
+
       - name: Install Rust Toolchain
         run: |
           rustup toolchain install stable --profile minimal --no-self-update

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ the required images and configuration, such as port mapping.
 column families.
  - For **Google Cloud Storage** (GCS), a test bucket is already configured in
   the dev container.
+ - For **MinIO** (S3-compatible), a public test bucket is created on startup.
 
 The emulators example config is pre-configured with a tiered configuration using
 both backends. To use it:

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -9,10 +9,12 @@ x-sentry-service-config:
       description: Google Cloud BigTable emulator
     gcs:
       description: Google Cloud Storage emulator
+    minio:
+      description: MinIO server
   modes:
     default: []
     containerized: [objectstore]
-    full: [bigtable, gcs]
+    full: [bigtable, gcs, minio]
 
 x-programs:
   devserver:
@@ -70,6 +72,23 @@ services:
       retries: 5
     ports:
       - 127.0.0.1:8087:9000
+    networks:
+      - devservices
+    labels:
+      - orchestrator=devservices
+    restart: unless-stopped
+  minio:
+    image: minio/minio
+    entrypoint: /run-minio.sh
+    healthcheck:
+      test: mc ready local
+      interval: 5s
+      timeout: 1s
+      retries: 5
+    ports:
+      - 127.0.0.1:8089:9000
+    volumes:
+      - ./run-minio.sh:/run-minio.sh
     networks:
       - devservices
     labels:

--- a/devservices/run-minio.sh
+++ b/devservices/run-minio.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+mkdir -p /data/test-bucket
+
+minio server /data --address :9000 &
+MINIO_PID=$!
+
+for _ in {1..4}; do
+    mc alias set local http://localhost:9000 minioadmin minioadmin >/dev/null 2>&1 && break
+    sleep 1
+done
+
+mc anonymous set public local/test-bucket
+
+wait $MINIO_PID

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -339,3 +339,41 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use objectstore_types::scope::{Scope, Scopes};
+
+    use super::*;
+    use crate::backend::common::Backend;
+    use crate::id::ObjectContext;
+
+    // NB: To run these tests, you need to have a MinIO server running. This is done
+    // automatically in CI.
+    //
+    // Refer to the readme for how to set up MinIO via devservices.
+
+    fn create_test_backend() -> S3CompatibleBackend<NoToken> {
+        S3CompatibleBackend::without_token(S3CompatibleConfig {
+            endpoint: "http://localhost:8089".into(),
+            bucket: "test-bucket".into(),
+        })
+    }
+
+    fn make_id() -> ObjectId {
+        ObjectId::random(ObjectContext {
+            usecase: "testing".into(),
+            scopes: Scopes::from_iter([Scope::create("testing", "value").unwrap()]),
+        })
+    }
+
+    #[tokio::test]
+    async fn test_get_metadata_nonexistent() -> Result<()> {
+        let backend = create_test_backend();
+        let id = make_id();
+        let result = backend.get_metadata(&id).await?;
+        assert!(result.is_none());
+        Ok(())
+    }
+}


### PR DESCRIPTION
Adds MinIO in devservices and CI, plus a simple test in the S3-compatible backend that exercises it.
This will be used to test the multipart upload protocol implementation.