### PR TITLE
chore(deps): Bump bigtable_rs to latest rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,7 +430,7 @@ dependencies = [
 [[package]]
 name = "bigtable_rs"
 version = "0.2.19"
-source = "git+https://github.com/getsentry/bigtable_rs.git?rev=90a1770db0adb8fb084d458b9a44214c42282949#90a1770db0adb8fb084d458b9a44214c42282949"
+source = "git+https://github.com/getsentry/bigtable_rs.git?rev=4cb75bc5e5f87204363973f6302107768e64972e#4cb75bc5e5f87204363973f6302107768e64972e"
 dependencies = [
  "futures-util",
  "gcp_auth",

--- a/objectstore-service/Cargo.toml
+++ b/objectstore-service/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-bigtable_rs = { git = "https://github.com/getsentry/bigtable_rs.git", rev = "90a1770db0adb8fb084d458b9a44214c42282949" }
+bigtable_rs = { git = "https://github.com/getsentry/bigtable_rs.git", rev = "4cb75bc5e5f87204363973f6302107768e64972e" }
 chrono = "0.4"
 bytes = { workspace = true }
 futures-util = { workspace = true }


### PR DESCRIPTION
Includes https://github.com/getsentry/bigtable_rs/pull/8.
I noticed sometimes we were getting keepalive timeouts in prod, so maybe this improves things as we will ping more often.