### PR TITLE
feat(service): Add MultipartUploadBackend trait and related types

### DIFF
--- a/objectstore-service/src/backend/common.rs
+++ b/objectstore-service/src/backend/common.rs
@@ -8,6 +8,10 @@ use bytes::Bytes;
 
 use crate::error::Result;
 use crate::id::ObjectId;
+use crate::multipart::{
+    AbortMultipartResponse, CompleteMultipartResponse, CompletedPart, InitiateMultipartResponse,
+    ListPartsResponse, PartNumber, UploadId, UploadPartResponse,
+};
 use crate::stream::{ClientStream, PayloadStream};
 
 /// User agent string used for outgoing requests.
@@ -58,6 +62,52 @@ pub trait Backend: fmt::Debug + Send + Sync + 'static {
     /// (such as [`TieredStorage`](super::tiered::TieredStorage)) should override this
     /// to wait for those tasks to complete.
     async fn join(&self) {}
+}
+
+/// Trait for backends that support our S3-style multipart upload protocol.
+#[async_trait::async_trait]
+pub trait MultipartUploadBackend: Backend + fmt::Debug + Send + Sync + 'static {
+    /// Initiates a new multipart upload at `id` with the given metadata.
+    async fn initiate_multipart(
+        &self,
+        id: &ObjectId,
+        metadata: &Metadata,
+    ) -> Result<InitiateMultipartResponse>;
+
+    /// Uploads a single part of the upload identified by `(id, upload_id)`.
+    async fn upload_part(
+        &self,
+        id: &ObjectId,
+        upload_id: &UploadId,
+        part_number: PartNumber,
+        content_length: u64,
+        body: ClientStream,
+    ) -> Result<UploadPartResponse>;
+
+    /// Lists the parts uploaded so far for `(id, upload_id)`.
+    async fn list_parts(
+        &self,
+        id: &ObjectId,
+        upload_id: &UploadId,
+        max_parts: Option<u32>,
+        part_number_marker: Option<PartNumber>,
+    ) -> Result<ListPartsResponse>;
+
+    /// Aborts the upload identified by `(id, upload_id)`.
+    async fn abort_multipart(
+        &self,
+        id: &ObjectId,
+        upload_id: &UploadId,
+    ) -> Result<AbortMultipartResponse>;
+
+    /// Finalizes the upload identified by `(id, upload_id)` with the given
+    /// ordered list of parts.
+    async fn complete_multipart(
+        &self,
+        id: &ObjectId,
+        upload_id: &UploadId,
+        parts: Vec<CompletedPart>,
+    ) -> Result<CompleteMultipartResponse>;
 }
 
 /// Trait for backends that support tombstone-conditional operations.

--- a/objectstore-service/src/lib.rs
+++ b/objectstore-service/src/lib.rs
@@ -7,6 +7,7 @@ mod concurrency;
 pub mod error;
 mod gcp_auth;
 pub mod id;
+pub mod multipart;
 pub mod service;
 pub mod stream;
 pub mod streaming;

--- a/objectstore-service/src/multipart.rs
+++ b/objectstore-service/src/multipart.rs
@@ -1,0 +1,66 @@
+//! Shared types for Objectstore's multipart upload protocol.
+
+use std::time::SystemTime;
+
+/// Identifier for an in-progress multipart upload.
+pub type UploadId = String;
+/// 1-indexed position of a part within its multipart upload.
+pub type PartNumber = u32;
+/// Opaque per-part identifier returned by the backend after a successful part upload.
+pub type ETag = String;
+
+/// Description of one part in the response to
+/// [`MultipartUploadBackend::list_parts`](crate::backend::common::MultipartUploadBackend::list_parts).
+#[derive(Clone, Debug)]
+pub struct PartInfo {
+    /// 1-indexed position of this part within the upload.
+    pub part_number: PartNumber,
+    /// Identifier returned when the part was uploaded.
+    pub etag: ETag,
+    /// Server-recorded time at which the part was uploaded.
+    pub last_modified: SystemTime,
+    /// Size of the part in bytes.
+    pub size: u64,
+}
+
+/// Pair of (part number, ETag) that the client provides on
+/// [`MultipartUploadBackend::complete_multipart`](crate::backend::common::MultipartUploadBackend::complete_multipart)
+/// to identify the parts in order.
+#[derive(Clone, Debug)]
+pub struct CompletedPart {
+    /// 1-indexed position of this part within the upload.
+    pub part_number: PartNumber,
+    /// Identifier returned when the part was uploaded.
+    pub etag: ETag,
+}
+
+/// Response from
+/// [`MultipartUploadBackend::list_parts`](crate::backend::common::MultipartUploadBackend::list_parts).
+#[derive(Clone, Debug)]
+pub struct ListedParts {
+    /// Parts uploaded so far, in `part_number` order.
+    pub parts: Vec<PartInfo>,
+    /// Set when the listing was truncated and more parts can be fetched
+    /// using [`Self::next_part_number_marker`] as the next
+    /// `part_number_marker`.
+    pub is_truncated: bool,
+    /// Marker to pass as the next `part_number_marker` when
+    /// [`Self::is_truncated`] is `true`.
+    pub next_part_number_marker: Option<PartNumber>,
+}
+
+/// Backend response for
+/// [`MultipartUploadBackend::initiate_multipart`](crate::backend::common::MultipartUploadBackend::initiate_multipart).
+pub type InitiateMultipartResponse = UploadId;
+/// Backend response for
+/// [`MultipartUploadBackend::upload_part`](crate::backend::common::MultipartUploadBackend::upload_part).
+pub type UploadPartResponse = ETag;
+/// Backend response for
+/// [`MultipartUploadBackend::list_parts`](crate::backend::common::MultipartUploadBackend::list_parts).
+pub type ListPartsResponse = ListedParts;
+/// Backend response for
+/// [`MultipartUploadBackend::abort_multipart`](crate::backend::common::MultipartUploadBackend::abort_multipart).
+pub type AbortMultipartResponse = ();
+/// Backend response for
+/// [`MultipartUploadBackend::complete_multipart`](crate::backend::common::MultipartUploadBackend::complete_multipart).
+pub type CompleteMultipartResponse = ();


### PR DESCRIPTION
⚠️ Stacked on https://github.com/getsentry/objectstore/pull/442

Adds a trait defining `MultipartUploadBackend` and its associated types according to the [design doc](https://www.notion.so/sentry/Design-Multipart-uploads-3438b10e4b5d8009aeedcd8db91122ea?source=copy_link).

The next PR will implement `MultipartUploadBackend` on the `s3_compatible` backend.
After that and implementations for `GCS` and `TieredStorage` land, we will change `TieredStorage` to require a `MultipartUploadBackend` in its `long_term` slot, as opposed to just a `Backend`.