### PR TITLE
feat(s3): Add auth configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,10 +293,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "attohttpc"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
+dependencies = [
+ "base64",
+ "http 1.4.0",
+ "log",
+ "native-tls",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-creds"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3b85155d265df828f84e53886ed9e427aed979dd8a39f5b8b2162c77e142d7"
+dependencies = [
+ "attohttpc",
+ "home",
+ "log",
+ "quick-xml",
+ "rust-ini",
+ "serde",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
 
 [[package]]
 name = "aws-lc-rs"
@@ -318,6 +350,15 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
+]
+
+[[package]]
+name = "aws-region"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "838b36c8dc927b6db1b6c6b8f5d05865f2213550b9e83bf92fa99ed6525472c0"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -385,7 +426,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -564,7 +605,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -633,6 +674,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "convert_case"
@@ -707,6 +768,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -886,6 +953,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,7 +1107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1366,6 +1442,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1465,6 +1547,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "hostname"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,7 +1563,7 @@ checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1633,7 +1724,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1653,7 +1744,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2050,6 +2141,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "maybe-async"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+
+[[package]]
 name = "mediatype"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2222,12 +2330,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2408,6 +2525,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2579,6 +2706,7 @@ dependencies = [
  "objectstore-types",
  "regex",
  "reqwest 0.12.28",
+ "rust-s3",
  "sentry",
  "serde",
  "serde_json",
@@ -2680,6 +2808,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "os_info"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2749,7 +2887,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3076,6 +3214,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3088,7 +3236,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3126,9 +3274,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3460,6 +3608,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
+
+[[package]]
+name = "rust-s3"
+version = "0.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4af74047374528b627109d579ce86b23ccf6ffba7ff363c807126c1aff69e1bb"
+dependencies = [
+ "async-trait",
+ "aws-creds",
+ "aws-region",
+ "base64",
+ "bytes",
+ "cfg-if",
+ "futures-util",
+ "hex",
+ "hmac",
+ "http 1.4.0",
+ "log",
+ "maybe-async",
+ "md5",
+ "percent-encoding",
+ "quick-xml",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha2",
+ "sysinfo",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "url",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3490,7 +3682,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3549,7 +3741,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3684,7 +3876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4142,6 +4334,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4178,7 +4384,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4279,6 +4485,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -4996,7 +5211,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5006,6 +5221,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5013,9 +5263,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -5042,9 +5303,25 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-registry"
@@ -5052,9 +5329,18 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5063,7 +5349,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5072,7 +5367,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5126,7 +5421,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5181,7 +5476,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -5190,6 +5485,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2707,6 +2707,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "rust-s3",
+ "secrecy",
  "sentry",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3752,9 +3752,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
 rand = "0.9.3"
 regex = "1.12.3"
 reqwest = { version = "0.12.22" }
+secrecy = { version = "0.10.3", features = ["serde"] }
 sentry = { version = "0.45.0" }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"

--- a/objectstore-server/Cargo.toml
+++ b/objectstore-server/Cargo.toml
@@ -39,7 +39,7 @@ sentry = { workspace = true, features = [
     "tracing",
     "logs",
 ] }
-secrecy = { version = "0.10.3", features = ["serde"] }
+secrecy = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/objectstore-server/src/config.rs
+++ b/objectstore-server/src/config.rs
@@ -585,8 +585,8 @@ mod tests {
             jail.set_env("OS__STORAGE__TYPE", "s3compatible");
             jail.set_env("OS__STORAGE__ENDPOINT", "http://localhost:8888");
             jail.set_env("OS__STORAGE__BUCKET", "whatever");
-            jail.set_env("OS__STORAGE__AUTH__ACCESS_KEY_ID", "testkey");
-            jail.set_env("OS__STORAGE__AUTH__SECRET_ACCESS_KEY", "testsecret");
+            jail.set_env("OS__STORAGE__ACCESS_KEY_ID", "testkey");
+            jail.set_env("OS__STORAGE__SECRET_ACCESS_KEY", "testsecret");
             jail.set_env("OS__METRICS__TAGS__FOO", "bar");
             jail.set_env("OS__METRICS__TAGS__BAZ", "qux");
             jail.set_env("OS__SENTRY__DSN", "abcde");
@@ -630,9 +630,8 @@ mod tests {
                 type: s3compatible
                 endpoint: http://localhost:8888
                 bucket: whatever
-                auth:
-                    access_key_id: testkey
-                    secret_access_key: testsecret
+                access_key_id: testkey
+                secret_access_key: testsecret
             sentry:
                 dsn: abcde
                 environment: production
@@ -675,9 +674,8 @@ mod tests {
                 type: s3compatible
                 endpoint: http://localhost:8888
                 bucket: whatever
-                auth:
-                    access_key_id: testkey
-                    secret_access_key: testsecret
+                access_key_id: testkey
+                secret_access_key: testsecret
             "#,
             )
             .unwrap();

--- a/objectstore-server/src/config.rs
+++ b/objectstore-server/src/config.rs
@@ -585,6 +585,8 @@ mod tests {
             jail.set_env("OS__STORAGE__TYPE", "s3compatible");
             jail.set_env("OS__STORAGE__ENDPOINT", "http://localhost:8888");
             jail.set_env("OS__STORAGE__BUCKET", "whatever");
+            jail.set_env("OS__STORAGE__AUTH__ACCESS_KEY_ID", "testkey");
+            jail.set_env("OS__STORAGE__AUTH__SECRET_ACCESS_KEY", "testsecret");
             jail.set_env("OS__METRICS__TAGS__FOO", "bar");
             jail.set_env("OS__METRICS__TAGS__BAZ", "qux");
             jail.set_env("OS__SENTRY__DSN", "abcde");
@@ -628,6 +630,9 @@ mod tests {
                 type: s3compatible
                 endpoint: http://localhost:8888
                 bucket: whatever
+                auth:
+                    access_key_id: testkey
+                    secret_access_key: testsecret
             sentry:
                 dsn: abcde
                 environment: production
@@ -670,6 +675,9 @@ mod tests {
                 type: s3compatible
                 endpoint: http://localhost:8888
                 bucket: whatever
+                auth:
+                    access_key_id: testkey
+                    secret_access_key: testsecret
             "#,
             )
             .unwrap();

--- a/objectstore-server/src/config.rs
+++ b/objectstore-server/src/config.rs
@@ -33,7 +33,6 @@
 
 use std::borrow::Cow;
 use std::collections::{BTreeMap, HashSet};
-use std::fmt;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -41,8 +40,9 @@ use std::time::Duration;
 use anyhow::Result;
 use figment::providers::{Env, Format, Serialized, Yaml};
 use objectstore_service::backend::local_fs::FileSystemConfig;
+use objectstore_service::secret::ConfigSecret;
 use objectstore_types::auth::Permission;
-use secrecy::{CloneableSecret, SecretBox, SerializableSecret, zeroize::Zeroize};
+use secrecy::SecretBox;
 use serde::{Deserialize, Serialize};
 
 pub use objectstore_log::{LevelFilter, LogFormat, LoggingConfig};
@@ -54,46 +54,6 @@ use crate::usecases::UseCases;
 
 /// Environment variable prefix for all configuration options.
 const ENV_PREFIX: &str = "OS__";
-
-/// Newtype around `String` that may protect against accidental
-/// logging of secrets in our configuration struct. Use with
-/// [`secrecy::SecretBox`].
-#[derive(Clone, Default, Serialize, Deserialize, PartialEq)]
-pub struct ConfigSecret(String);
-
-impl ConfigSecret {
-    /// Returns the secret value as a string slice.
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
-    }
-}
-
-impl From<&str> for ConfigSecret {
-    fn from(str: &str) -> Self {
-        ConfigSecret(str.to_string())
-    }
-}
-
-impl std::ops::Deref for ConfigSecret {
-    type Target = str;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl fmt::Debug for ConfigSecret {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "[redacted]")
-    }
-}
-
-impl CloneableSecret for ConfigSecret {}
-impl SerializableSecret for ConfigSecret {}
-impl Zeroize for ConfigSecret {
-    fn zeroize(&mut self) {
-        self.0.zeroize();
-    }
-}
 
 /// Runtime configuration for the Tokio async runtime.
 ///

--- a/objectstore-service/Cargo.toml
+++ b/objectstore-service/Cargo.toml
@@ -29,6 +29,7 @@ reqwest = { workspace = true, features = [
     "multipart",
     "json",
 ] }
+rust-s3 = { version = "0.37.1", default-features = false, features = ["tokio-native-tls", "fail-on-err"] }
 sentry = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/objectstore-service/Cargo.toml
+++ b/objectstore-service/Cargo.toml
@@ -30,6 +30,7 @@ reqwest = { workspace = true, features = [
     "json",
 ] }
 rust-s3 = { version = "0.37.1", default-features = false, features = ["tokio-native-tls", "fail-on-err"] }
+secrecy = { workspace = true }
 sentry = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/objectstore-service/docs/architecture.md
+++ b/objectstore-service/docs/architecture.md
@@ -149,6 +149,11 @@ capabilities. For example, BigTable has built-in TTL via garbage collection
 policies, and GCS supports object lifecycle management. The service does not
 perform active garbage collection.
 
+Backends without native lifecycle support — currently the
+[filesystem](backend::local_fs) and [S3-compatible](backend::s3_compatible)
+backends — accept and persist expiration policies on objects but require an
+external cleanup job to actually remove expired data.
+
 # Backpressure
 
 The service applies backpressure to protect backends from overload. Rather than

--- a/objectstore-service/src/backend/common.rs
+++ b/objectstore-service/src/backend/common.rs
@@ -8,6 +8,10 @@ use bytes::Bytes;
 
 use crate::error::Result;
 use crate::id::ObjectId;
+use crate::multipart::{
+    AbortMultipartResponse, CompleteMultipartResponse, CompletedPart, InitiateMultipartResponse,
+    ListPartsResponse, PartNumber, UploadId, UploadPartResponse,
+};
 use crate::stream::{ClientStream, PayloadStream};
 
 /// User agent string used for outgoing requests.
@@ -58,6 +62,52 @@ pub trait Backend: fmt::Debug + Send + Sync + 'static {
     /// (such as [`TieredStorage`](super::tiered::TieredStorage)) should override this
     /// to wait for those tasks to complete.
     async fn join(&self) {}
+}
+
+/// Trait for backends that support our S3-style multipart upload protocol.
+#[async_trait::async_trait]
+pub trait MultipartUploadBackend: Backend + fmt::Debug + Send + Sync + 'static {
+    /// Initiates a new multipart upload at `id` with the given metadata.
+    async fn initiate_multipart(
+        &self,
+        id: &ObjectId,
+        metadata: &Metadata,
+    ) -> Result<InitiateMultipartResponse>;
+
+    /// Uploads a single part of the upload identified by `(id, upload_id)`.
+    async fn upload_part(
+        &self,
+        id: &ObjectId,
+        upload_id: &UploadId,
+        part_number: PartNumber,
+        content_length: u64,
+        body: ClientStream,
+    ) -> Result<UploadPartResponse>;
+
+    /// Lists the parts uploaded so far for `(id, upload_id)`.
+    async fn list_parts(
+        &self,
+        id: &ObjectId,
+        upload_id: &UploadId,
+        max_parts: Option<u32>,
+        part_number_marker: Option<PartNumber>,
+    ) -> Result<ListPartsResponse>;
+
+    /// Aborts the upload identified by `(id, upload_id)`.
+    async fn abort_multipart(
+        &self,
+        id: &ObjectId,
+        upload_id: &UploadId,
+    ) -> Result<AbortMultipartResponse>;
+
+    /// Finalizes the upload identified by `(id, upload_id)` with the given
+    /// ordered list of parts.
+    async fn complete_multipart(
+        &self,
+        id: &ObjectId,
+        upload_id: &UploadId,
+        parts: Vec<CompletedPart>,
+    ) -> Result<CompleteMultipartResponse>;
 }
 
 /// Trait for backends that support tombstone-conditional operations.

--- a/objectstore-service/src/backend/mod.rs
+++ b/objectstore-service/src/backend/mod.rs
@@ -75,7 +75,7 @@ async fn from_leaf_config(config: StorageConfig) -> Result<Box<dyn common::Backe
     Ok(match config {
         StorageConfig::FileSystem(c) => Box::new(local_fs::LocalFsBackend::new(c)),
         StorageConfig::S3Compatible(c) => {
-            Box::new(s3_compatible::S3CompatibleBackend::without_token(c))
+            Box::new(s3_compatible::S3CompatibleBackend::without_token(c)?)
         }
         StorageConfig::Gcs(c) => Box::new(gcs::GcsBackend::new(c).await?),
         StorageConfig::BigTable(c) => Box::new(bigtable::BigTableBackend::new(c).await?),

--- a/objectstore-service/src/backend/mod.rs
+++ b/objectstore-service/src/backend/mod.rs
@@ -74,9 +74,7 @@ pub async fn from_config(config: StorageConfig) -> Result<Box<dyn common::Backen
 async fn from_leaf_config(config: StorageConfig) -> Result<Box<dyn common::Backend>> {
     Ok(match config {
         StorageConfig::FileSystem(c) => Box::new(local_fs::LocalFsBackend::new(c)),
-        StorageConfig::S3Compatible(c) => {
-            Box::new(s3_compatible::S3CompatibleBackend::without_token(c)?)
-        }
+        StorageConfig::S3Compatible(c) => Box::new(s3_compatible::S3CompatibleBackend::new(c)?),
         StorageConfig::Gcs(c) => Box::new(gcs::GcsBackend::new(c).await?),
         StorageConfig::BigTable(c) => Box::new(bigtable::BigTableBackend::new(c).await?),
         StorageConfig::Tiered(_) => anyhow::bail!("nested tiered storage is not supported"),

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -13,6 +13,7 @@ use s3::error::S3Error;
 use s3::region::Region;
 use s3::request::Request as _;
 use s3::request::tokio_backend::ReqwestRequest;
+use serde::{Deserialize, Serialize};
 use tokio_util::io::StreamReader;
 
 use crate::backend::common::{Backend, DeleteResponse, GetResponse, MetadataResponse, PutResponse};
@@ -39,8 +40,10 @@ use crate::stream::{self, ClientStream};
 ///   bucket: my-bucket
 ///   region: us-east-1
 ///   use_path_style: false
+///   metadata_prefix: x-amz-meta-
+///   custom_time_header: x-amz-meta-expiry
 /// ```
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct S3CompatibleConfig {
     /// S3 endpoint URL.
     ///

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -42,6 +42,7 @@ use crate::stream::{self, ClientStream};
 ///   use_path_style: false
 ///   metadata_prefix: x-amz-meta-
 ///   protocol_prefix: x-amz-
+///   custom_time_header: x-amz-meta-expiry
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct S3CompatibleConfig {
@@ -116,6 +117,18 @@ pub struct S3CompatibleConfig {
     /// - `OS__STORAGE__PROTOCOL_PREFIX=x-goog-`
     #[serde(default = "default_protocol_prefix")]
     pub protocol_prefix: String,
+
+    /// Header carrying the object's resolved expiration timestamp.
+    ///
+    /// # Default
+    ///
+    /// `"x-amz-meta-expiry"`
+    ///
+    /// # Environment Variables
+    ///
+    /// - `OS__STORAGE__CUSTOM_TIME_HEADER=x-goog-custom-time`
+    #[serde(default = "default_custom_time_header")]
+    pub custom_time_header: String,
 }
 
 fn default_region() -> String {
@@ -132,6 +145,10 @@ fn default_metadata_prefix() -> String {
 
 fn default_protocol_prefix() -> String {
     "x-amz-".to_owned()
+}
+
+fn default_custom_time_header() -> String {
+    "x-amz-meta-expiry".to_owned()
 }
 
 /// Time to debounce bumping an object with configured TTI.
@@ -201,12 +218,12 @@ fn metadata_from_headers(headers: &HeaderMap, prefix: &str) -> Result<Metadata> 
 impl<T> S3CompatibleBackend<T> {
     /// Creates a new S3-compatible backend bound to the given config and token provider.
     pub fn new(config: S3CompatibleConfig, token_provider: T) -> anyhow::Result<Self> {
-        let mut this = Self::build(config)?;
+        let mut this = Self::from_config(config)?;
         this.token_provider = Some(token_provider);
         Ok(this)
     }
 
-    fn build(config: S3CompatibleConfig) -> anyhow::Result<Self> {
+    fn from_config(config: S3CompatibleConfig) -> anyhow::Result<Self> {
         let credentials = Credentials::default().or_else(|_| Credentials::anonymous())?;
 
         let region = Region::Custom {
@@ -219,14 +236,12 @@ impl<T> S3CompatibleBackend<T> {
             bucket.set_path_style();
         }
 
-        let custom_time_header = format!("{}expiry", config.metadata_prefix);
-
         Ok(Self {
             bucket,
             endpoint: config.endpoint,
             metadata_prefix: config.metadata_prefix,
             protocol_prefix: config.protocol_prefix,
-            custom_time_header,
+            custom_time_header: config.custom_time_header,
             token_provider: None,
         })
     }
@@ -338,7 +353,7 @@ impl<T> S3CompatibleBackend<T> {
 impl S3CompatibleBackend<NoToken> {
     /// Creates a new S3-compatible backend that sends unauthenticated requests.
     pub fn without_token(config: S3CompatibleConfig) -> anyhow::Result<Self> {
-        Self::build(config)
+        Self::from_config(config)
     }
 }
 
@@ -512,6 +527,7 @@ mod tests {
             use_path_style: default_use_path_style(),
             metadata_prefix: default_metadata_prefix(),
             protocol_prefix: default_protocol_prefix(),
+            custom_time_header: default_custom_time_header(),
         })
         .unwrap()
     }

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -108,13 +108,13 @@ pub struct S3CompatibleConfig {
     /// timestamp (via copy-in-place with a metadata-directive REPLACE) when
     /// the recorded expiry is older than `now + tti - TTI_DEBOUNCE`.
     ///
-    /// Defaults to `x-amz-meta-x-os-custom-time`, which results in the
+    /// Defaults to `x-amz-meta-expiry`, which results in the
     /// timestamp being stored as plain user metadata on any S3-compatible
     /// backend.
     ///
     /// # Default
     ///
-    /// `"x-amz-meta-x-os-custom-time"`
+    /// `"x-amz-meta-expiry"`
     ///
     /// # Environment Variables
     ///
@@ -136,7 +136,7 @@ fn default_metadata_prefix() -> String {
 }
 
 fn default_custom_time_header() -> String {
-    "x-amz-meta-x-os-custom-time".to_owned()
+    "x-amz-meta-expiry".to_owned()
 }
 
 /// Time to debounce bumping an object with configured TTI.
@@ -176,7 +176,7 @@ pub struct S3CompatibleBackend<T> {
     endpoint: String,
     token_provider: Option<T>,
     metadata_prefix: String,
-    custom_time_header: Option<String>,
+    custom_time_header: String,
 }
 
 impl<T> S3CompatibleBackend<T> {
@@ -239,9 +239,6 @@ impl<T> S3CompatibleBackend<T> {
         headers: &HeaderMap,
         metadata: &Metadata,
     ) -> Result<()> {
-        let Some(custom_time_header) = &self.custom_time_header else {
-            return Ok(());
-        };
         let ExpirationPolicy::TimeToIdle(tti) = metadata.expiration_policy else {
             return Ok(());
         };
@@ -250,7 +247,7 @@ impl<T> S3CompatibleBackend<T> {
         let access_time = SystemTime::now();
 
         let expire_at = headers
-            .get(custom_time_header.as_str())
+            .get(self.custom_time_header.as_str())
             .and_then(|v| v.to_str().ok())
             .and_then(|s| humantime::parse_rfc3339(s).ok())
             .unwrap_or(access_time);
@@ -302,12 +299,10 @@ impl<T> S3CompatibleBackend<T> {
                 .map_err(|e| map_s3_error(e, "S3: failed to set object metadata"))?;
         }
 
-        if let Some(custom_time_header) = &self.custom_time_header
-            && let Some(expires_in) = metadata.expiration_policy.expires_in()
-        {
+        if let Some(expires_in) = metadata.expiration_policy.expires_in() {
             let expires_at = humantime::format_rfc3339_seconds(SystemTime::now() + expires_in);
             request = request
-                .with_header(custom_time_header, expires_at.to_string())
+                .with_header(self.custom_time_header.as_str(), expires_at.to_string())
                 .map_err(|e| map_s3_error(e, "S3: failed to set custom time header"))?;
         }
 
@@ -428,16 +423,18 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
                 .map_err(|e| map_s3_error(e, "S3: failed to set object metadata"))?;
         }
 
-        if let Some(custom_time_header) = &self.custom_time_header
-            && let Some(expires_in) = metadata.expiration_policy.expires_in()
-        {
+        if let Some(expires_in) = metadata.expiration_policy.expires_in() {
             let expires_at = humantime::format_rfc3339_seconds(SystemTime::now() + expires_in);
-            let name = reqwest::header::HeaderName::try_from(custom_time_header).map_err(|e| {
-                Error::Generic {
-                    context: format!("S3: invalid custom time header name: {custom_time_header:?}"),
-                    cause: Some(Box::new(e)),
-                }
-            })?;
+            let name =
+                reqwest::header::HeaderName::try_from(&self.custom_time_header).map_err(|e| {
+                    Error::Generic {
+                        context: format!(
+                            "S3: invalid custom time header name: {:?}",
+                            self.custom_time_header
+                        ),
+                        cause: Some(Box::new(e)),
+                    }
+                })?;
             request = request
                 .with_header(name, expires_at.to_string())
                 .map_err(|e| map_s3_error(e, "S3: failed to set custom time header"))?;

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -1,26 +1,33 @@
-//! S3-compatible backend with generic protocol support.
+//! Backend that can be used with any S3-compatible object store (Amazon S3, MinIO, R2, etc.).
 
-use std::time::{Duration, SystemTime};
 use std::{fmt, io};
 
 use futures_util::{StreamExt, TryStreamExt};
-use objectstore_types::metadata::{ExpirationPolicy, Metadata};
-use reqwest::header::HeaderMap;
-use reqwest::{Body, IntoUrl, Method, RequestBuilder, StatusCode};
+use objectstore_types::metadata::Metadata;
+use reqwest::header::{self, HeaderMap};
+use s3::Bucket;
+use s3::command::Command;
+use s3::creds::Credentials;
+use s3::error::S3Error;
+use s3::region::Region;
+use s3::request::Request as _;
+use s3::request::tokio_backend::ReqwestRequest;
+use tokio_util::io::StreamReader;
 
-use crate::backend::common::{
-    self, Backend, DeleteResponse, GetResponse, MetadataResponse, PutResponse,
-};
+use crate::backend::common::{Backend, DeleteResponse, GetResponse, MetadataResponse, PutResponse};
 use crate::error::{Error, Result};
 use crate::id::ObjectId;
 use crate::stream::{self, ClientStream};
 
 /// Configuration for [`S3CompatibleBackend`].
 ///
-/// Supports [Amazon S3] and other S3-compatible services. Authentication is handled via
-/// environment variables (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`) or IAM roles.
+/// Supports [Amazon S3] and other S3-compatible services such as MinIO. AWS
+/// credentials are resolved via the standard [SDK chain] (env vars, profile,
+/// STS web identity, ECS container, EC2 IMDS); if no credentials can be
+/// resolved, the backend falls back to anonymous (unauthenticated) requests.
 ///
 /// [Amazon S3]: https://aws.amazon.com/s3/
+/// [SDK chain]: https://docs.rs/aws-creds/0.39.1/aws_creds/credentials/struct.Credentials.html
 ///
 /// # Example
 ///
@@ -29,6 +36,8 @@ use crate::stream::{self, ClientStream};
 ///   type: s3compatible
 ///   endpoint: https://s3.amazonaws.com
 ///   bucket: my-bucket
+///   region: us-east-1
+///   use_path_style: false
 /// ```
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct S3CompatibleConfig {
@@ -50,19 +59,59 @@ pub struct S3CompatibleConfig {
     ///
     /// - `OS__STORAGE__BUCKET=my-bucket`
     pub bucket: String,
+
+    /// Region label sent in SigV4 signatures.
+    ///
+    /// On AWS this must match the bucket's actual region. MinIO and most other
+    /// S3-compatible services accept any value.
+    ///
+    /// # Default
+    ///
+    /// `"us-east-1"`
+    ///
+    /// # Environment Variables
+    ///
+    /// - `OS__STORAGE__REGION=us-west-2`
+    #[serde(default = "default_region")]
+    pub region: String,
+
+    /// Whether to use path-style addressing (`https://host/bucket/key`)
+    /// instead of virtual-hosted-style (`https://bucket.host/key`).
+    ///
+    /// # Default
+    ///
+    /// `true`
+    ///
+    /// # Environment Variables
+    ///
+    /// - `OS__STORAGE__USE_PATH_STYLE=false`
+    #[serde(default = "default_use_path_style")]
+    pub use_path_style: bool,
+
+    /// Prefix used for custom object metadata on the wire.
+    ///
+    /// # Default
+    ///
+    /// `"x-amz-meta-"`
+    ///
+    /// # Environment Variables
+    ///
+    /// - `OS__STORAGE__METADATA_PREFIX=x-goog-meta-`
+    #[serde(default = "default_metadata_prefix")]
+    pub metadata_prefix: String,
 }
 
-/// Prefix used for custom metadata in headers for the GCS backend.
-///
-/// See: <https://cloud.google.com/storage/docs/xml-api/reference-headers#xgoogmeta>
-const GCS_CUSTOM_PREFIX: &str = "x-goog-meta-";
-/// Header used to store the expiration time for GCS using the `daysSinceCustomTime` lifecycle
-/// condition.
-///
-/// See: <https://cloud.google.com/storage/docs/xml-api/reference-headers#xgoogcustomtime>
-const GCS_CUSTOM_TIME: &str = "x-goog-custom-time";
-/// Time to debounce bumping an object with configured TTI.
-const TTI_DEBOUNCE: Duration = Duration::from_secs(24 * 3600); // 1 day
+fn default_region() -> String {
+    "us-east-1".to_owned()
+}
+
+fn default_use_path_style() -> bool {
+    true
+}
+
+fn default_metadata_prefix() -> String {
+    "x-amz-meta-".to_owned()
+}
 
 /// An authentication token that can be passed as a bearer credential.
 pub trait Token: Send + Sync {
@@ -94,171 +143,104 @@ impl Token for NoToken {
 
 /// S3-compatible storage backend with pluggable authentication.
 pub struct S3CompatibleBackend<T> {
-    client: reqwest::Client,
-
+    bucket: Box<Bucket>,
     endpoint: String,
-    bucket: String,
-
     token_provider: Option<T>,
+    metadata_prefix: String,
 }
 
 impl<T> S3CompatibleBackend<T> {
-    /// Creates a new S3-compatible backend bound to the given bucket.
-    pub fn new(endpoint: &str, bucket: &str, token_provider: T) -> Self {
-        Self {
-            client: common::reqwest_client(),
-            endpoint: endpoint.into(),
-            bucket: bucket.into(),
-            token_provider: Some(token_provider),
+    /// Creates a new S3-compatible backend bound to the given config and token provider.
+    pub fn new(config: S3CompatibleConfig, token_provider: T) -> anyhow::Result<Self> {
+        let mut this = Self::build(config)?;
+        this.token_provider = Some(token_provider);
+        Ok(this)
+    }
+
+    fn build(config: S3CompatibleConfig) -> anyhow::Result<Self> {
+        let credentials = Credentials::default().or_else(|_| Credentials::anonymous())?;
+
+        let region = Region::Custom {
+            region: config.region,
+            endpoint: config.endpoint.clone(),
+        };
+
+        let mut bucket = Bucket::new(&config.bucket, region, credentials)?;
+        if config.use_path_style {
+            bucket.set_path_style();
         }
+
+        Ok(Self {
+            bucket,
+            endpoint: config.endpoint,
+            metadata_prefix: config.metadata_prefix,
+            token_provider: None,
+        })
     }
 
-    /// Formats the S3 object URL for the given key.
-    fn object_url(&self, id: &ObjectId) -> String {
-        format!("{}/{}/{}", self.endpoint, self.bucket, id.as_storage_path())
-    }
-}
-
-/// Wraps [`Metadata::to_headers`] with GCS-specific concerns (tombstone + custom-time).
-fn metadata_to_gcs_headers(
-    metadata: &Metadata,
-    prefix: &str,
-) -> Result<HeaderMap, objectstore_types::metadata::Error> {
-    let mut headers = metadata.to_headers(prefix)?;
-    // GCS custom-time for lifecycle expiration
-    if let Some(expires_in) = metadata.expiration_policy.expires_in() {
-        let expires_at =
-            humantime::format_rfc3339_seconds(std::time::SystemTime::now() + expires_in);
-        headers.append(GCS_CUSTOM_TIME, expires_at.to_string().parse()?);
-    }
-    Ok(headers)
-}
-
-impl<T> S3CompatibleBackend<T>
-where
-    T: TokenProvider,
-{
-    /// Creates a request builder with the appropriate authentication.
-    async fn request(&self, method: Method, url: impl IntoUrl) -> Result<RequestBuilder> {
-        let mut builder = self.client.request(method, url);
-        if let Some(provider) = &self.token_provider {
-            builder = builder.bearer_auth(
-                provider
-                    .get_token()
-                    .await
-                    .map_err(|err| Error::Generic {
-                        context: "S3: failed to get authentication token".to_owned(),
-                        cause: Some(err.into()),
-                    })?
-                    .as_str(),
-            );
-        }
-        Ok(builder)
+    fn object_path(&self, id: &ObjectId) -> String {
+        format!("/{}", id.as_storage_path())
     }
 
-    /// Fetches object metadata using the given HTTP method (GET or HEAD),
-    /// bumps TTI if needed, and returns the parsed metadata along with the
-    /// response (so `get_object` can read the body from a GET).
-    async fn request_object(
-        &self,
-        method: Method,
-        id: &ObjectId,
-    ) -> Result<Option<(Metadata, reqwest::Response)>> {
-        let object_url = self.object_url(id);
-
-        let response = self
-            .request(method, &object_url)
-            .await?
-            .send()
+    /// Issues a HEAD request and returns the raw response headers.
+    ///
+    /// `Bucket::head_object` is not sufficient because it only surfaces
+    /// `x-amz-meta-*` keys — it drops any other metadata prefix (e.g.
+    /// `x-goog-meta-*`). We build a `ReqwestRequest` directly so we can
+    /// inspect the full `HeaderMap`.
+    async fn raw_head(&self, path: &str) -> Result<Option<HeaderMap>> {
+        let request = ReqwestRequest::new(&self.bucket, path, Command::HeadObject)
             .await
-            .map_err(|cause| Error::Reqwest {
-                context: "S3: failed to send request".to_string(),
-                cause,
-            })?;
+            .map_err(|e| map_s3_error(e, "S3: failed to build head request"))?;
 
-        if response.status() == StatusCode::NOT_FOUND {
-            objectstore_log::debug!("Object not found");
-            return Ok(None);
-        }
-
-        let response = response
-            .error_for_status()
-            .map_err(|cause| Error::Reqwest {
-                context: "S3: failed to get object".to_string(),
-                cause,
-            })?;
-
-        let headers = response.headers();
-        let mut metadata = Metadata::from_headers(headers, GCS_CUSTOM_PREFIX)?;
-        metadata.size = response.content_length().map(|len| len as usize);
-
-        // TODO: Schedule into background persistently so this doesn't get lost on restarts
-        if let ExpirationPolicy::TimeToIdle(tti) = metadata.expiration_policy {
-            // TODO: Inject the access time from the request.
-            let access_time = SystemTime::now();
-
-            let expire_at = headers
-                .get(GCS_CUSTOM_TIME)
-                .and_then(|s| s.to_str().ok())
-                .and_then(|s| humantime::parse_rfc3339(s).ok())
-                .unwrap_or(access_time);
-
-            if expire_at < access_time + tti - TTI_DEBOUNCE {
-                self.update_metadata(id, &metadata).await?;
+        match request.response_header().await {
+            Ok((headers, _)) => Ok(Some(headers)),
+            Err(ref e) if is_not_found(e) => {
+                objectstore_log::debug!("Object not found");
+                Ok(None)
             }
+            Err(e) => Err(map_s3_error(e, "S3: failed to head object")),
         }
-
-        Ok(Some((metadata, response)))
-    }
-
-    /// Issues a request to update the metadata for the given object.
-    async fn update_metadata(&self, id: &ObjectId, metadata: &Metadata) -> Result<()> {
-        // NB: Meta updates require copy + REPLACE along with *all* metadata. See
-        // https://cloud.google.com/storage/docs/xml-api/put-object-copy
-        self.request(Method::PUT, self.object_url(id))
-            .await?
-            .header(
-                "x-goog-copy-source",
-                format!("/{}/{}", self.bucket, id.as_storage_path()),
-            )
-            .header("x-goog-metadata-directive", "REPLACE")
-            .headers(metadata_to_gcs_headers(metadata, GCS_CUSTOM_PREFIX)?)
-            .send()
-            .await
-            .map_err(|cause| Error::Reqwest {
-                context: "S3: failed to send TTI update request".to_string(),
-                cause,
-            })?
-            .error_for_status()
-            .map_err(|cause| Error::Reqwest {
-                context: "S3: failed to update expiration time for object with TTI".to_string(),
-                cause,
-            })?;
-
-        Ok(())
-    }
-}
-
-impl<T> fmt::Debug for S3CompatibleBackend<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("S3Compatible")
-            .field("client", &self.client)
-            .field("endpoint", &self.endpoint)
-            .field("bucket", &self.bucket)
-            .finish_non_exhaustive()
     }
 }
 
 impl S3CompatibleBackend<NoToken> {
     /// Creates a new S3-compatible backend that sends unauthenticated requests.
-    pub fn without_token(config: S3CompatibleConfig) -> Self {
-        Self {
-            client: common::reqwest_client(),
-            endpoint: config.endpoint,
-            bucket: config.bucket,
-            token_provider: None,
-        }
+    pub fn without_token(config: S3CompatibleConfig) -> anyhow::Result<Self> {
+        Self::build(config)
     }
+}
+
+impl<T> fmt::Debug for S3CompatibleBackend<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("S3CompatibleBackend")
+            .field("bucket", &self.bucket)
+            .field("endpoint", &self.endpoint)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Maps an [`S3Error`] to our [`Error`] type with the given context.
+fn map_s3_error(error: S3Error, context: &str) -> Error {
+    Error::Generic {
+        context: context.to_owned(),
+        cause: Some(Box::new(error)),
+    }
+}
+
+/// Parses a response [`HeaderMap`] into our [`Metadata`], delegating the
+/// prefix-stripping logic to [`Metadata::from_headers`].
+fn metadata_from_headers(headers: &HeaderMap, prefix: &str) -> Result<Metadata> {
+    let mut metadata = Metadata::from_headers(headers, prefix)?;
+    metadata.size = headers
+        .get(header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok()?.parse::<usize>().ok());
+    Ok(metadata)
+}
+
+/// Returns `true` if `error` is an HTTP 404 from rust-s3.
+fn is_not_found(error: &S3Error) -> bool {
+    matches!(error, S3Error::HttpFailWithBody(404, _))
 }
 
 #[async_trait::async_trait]
@@ -275,19 +257,51 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
         stream: ClientStream,
     ) -> Result<PutResponse> {
         objectstore_log::debug!("Writing to s3_compatible backend");
-        self.request(Method::PUT, self.object_url(id))
-            .await?
-            .headers(metadata_to_gcs_headers(metadata, GCS_CUSTOM_PREFIX)?)
-            .body(Body::wrap_stream(stream))
-            .send()
+        let path = self.object_path(id);
+
+        let mut request = self
+            .bucket
+            .put_object_stream_builder(&path)
+            .with_content_type(metadata.content_type.as_ref());
+
+        if let Some(compression) = metadata.compression {
+            request = request
+                .with_content_encoding(compression.as_str())
+                .map_err(|e| map_s3_error(e, "S3: failed to set content-encoding"))?;
+        }
+
+        // All non-standard fields are emitted with the configured metadata
+        // prefix (e.g. `x-amz-meta-` or `x-goog-meta-`) via `with_header`.
+        // `with_metadata` is not used here because it hardcodes the S3
+        // prefix. Standard headers (Content-Type, Content-Encoding) are
+        // handled above.
+        let headers = metadata
+            .to_headers(&self.metadata_prefix)
+            .map_err(Error::Metadata)?;
+        for (name, value) in &headers {
+            if name == header::CONTENT_TYPE || name == header::CONTENT_ENCODING {
+                continue;
+            }
+            let value_str = value.to_str().map_err(|e| Error::Generic {
+                context: format!("S3: non-ascii metadata header value for {name}"),
+                cause: Some(Box::new(e)),
+            })?;
+            request = request
+                .with_header(name.clone(), value_str)
+                .map_err(|e| map_s3_error(e, "S3: failed to set object metadata"))?;
+        }
+
+        let mut reader = StreamReader::new(stream.map_err(io::Error::other));
+
+        request
+            .execute_stream(&mut reader)
             .await
-            .and_then(|response| response.error_for_status())
-            .map_err(|cause| match stream::unpack_client_error(&cause) {
-                Some(ce) => Error::Client(ce),
-                _ => Error::Reqwest {
-                    context: "S3: failed to put object".to_string(),
-                    cause,
+            .map_err(|cause| match &cause {
+                S3Error::Io(io_err) => match stream::unpack_client_error(io_err) {
+                    Some(ce) => Error::Client(ce),
+                    None => map_s3_error(cause, "S3: failed to put object"),
                 },
+                _ => map_s3_error(cause, "S3: failed to put object"),
             })?;
 
         Ok(())
@@ -296,58 +310,70 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
     #[tracing::instrument(level = "trace", fields(?id), skip_all)]
     async fn get_object(&self, id: &ObjectId) -> Result<GetResponse> {
         objectstore_log::debug!("Reading from s3_compatible backend");
+        let path = self.object_path(id);
 
-        let Some((metadata, response)) = self.request_object(Method::GET, id).await? else {
+        let Some(headers) = self.raw_head(&path).await? else {
             return Ok(None);
         };
+        let metadata = metadata_from_headers(&headers, &self.metadata_prefix)?;
 
-        let stream = response.bytes_stream().map_err(io::Error::other);
-        Ok(Some((metadata, stream.boxed())))
+        let response = match self.bucket.get_object_stream(&path).await {
+            Ok(response) => response,
+            Err(ref e) if is_not_found(e) => {
+                // Object was deleted between HEAD and GET; treat as missing.
+                objectstore_log::debug!("Object disappeared between head and get");
+                return Ok(None);
+            }
+            Err(e) => return Err(map_s3_error(e, "S3: failed to get object")),
+        };
+
+        let stream = response.bytes.map_err(io::Error::other).boxed();
+        Ok(Some((metadata, stream)))
     }
 
     #[tracing::instrument(level = "trace", fields(?id), skip_all)]
     async fn get_metadata(&self, id: &ObjectId) -> Result<MetadataResponse> {
         objectstore_log::debug!("Reading metadata from s3_compatible backend");
-        let response = self.request_object(Method::HEAD, id).await?;
-        Ok(response.map(|(metadata, _)| metadata))
+        let path = self.object_path(id);
+
+        let Some(headers) = self.raw_head(&path).await? else {
+            return Ok(None);
+        };
+        Ok(Some(metadata_from_headers(
+            &headers,
+            &self.metadata_prefix,
+        )?))
     }
 
     #[tracing::instrument(level = "trace", fields(?id), skip_all)]
     async fn delete_object(&self, id: &ObjectId) -> Result<DeleteResponse> {
         objectstore_log::debug!("Deleting from s3_compatible backend");
-        let response = self
-            .request(Method::DELETE, self.object_url(id))
-            .await?
-            .send()
-            .await
-            .map_err(|cause| Error::Reqwest {
-                context: "S3: failed to send delete request".to_string(),
-                cause,
-            })?;
+        let path = self.object_path(id);
 
-        // Do not error for objects that do not exist.
-        if response.status() != StatusCode::NOT_FOUND {
-            objectstore_log::debug!("Object not found");
-            response
-                .error_for_status()
-                .map_err(|cause| Error::Reqwest {
-                    context: "S3: failed to delete object".to_string(),
-                    cause,
-                })?;
+        match self.bucket.delete_object(&path).await {
+            Ok(_) => Ok(()),
+            Err(ref e) if is_not_found(e) => {
+                objectstore_log::debug!("Object not found");
+                Ok(())
+            }
+            Err(e) => Err(map_s3_error(e, "S3: failed to delete object")),
         }
-
-        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+    use std::time::SystemTime;
+
     use anyhow::Result;
+    use objectstore_types::metadata::{Compression, ExpirationPolicy};
     use objectstore_types::scope::{Scope, Scopes};
 
     use super::*;
     use crate::backend::common::Backend;
     use crate::id::ObjectContext;
+    use crate::stream;
 
     // NB: To run these tests, you need to have a MinIO server running. This is done
     // automatically in CI.
@@ -358,7 +384,11 @@ mod tests {
         S3CompatibleBackend::without_token(S3CompatibleConfig {
             endpoint: "http://localhost:8089".into(),
             bucket: "test-bucket".into(),
+            region: default_region(),
+            use_path_style: default_use_path_style(),
+            metadata_prefix: default_metadata_prefix(),
         })
+        .unwrap()
     }
 
     fn make_id() -> ObjectId {
@@ -369,11 +399,198 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_roundtrip() -> Result<()> {
+        let backend = create_test_backend();
+
+        let id = make_id();
+        let metadata = Metadata {
+            content_type: "text/plain".into(),
+            expiration_policy: ExpirationPolicy::Manual,
+            compression: None,
+            origin: Some("203.0.113.42".into()),
+            custom: BTreeMap::from_iter([("hello".into(), "world".into())]),
+            time_created: Some(SystemTime::now()),
+            time_expires: None,
+            size: None,
+        };
+
+        backend
+            .put_object(&id, &metadata, stream::single("hello, world"))
+            .await?;
+
+        let (meta, stream) = backend.get_object(&id).await?.unwrap();
+
+        let payload = stream::read_to_vec(stream).await?;
+        let str_payload = str::from_utf8(&payload).unwrap();
+        assert_eq!(str_payload, "hello, world");
+        assert_eq!(meta.content_type, metadata.content_type);
+        assert_eq!(meta.origin, metadata.origin);
+        assert_eq!(meta.custom, metadata.custom);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_get_nonexistent() -> Result<()> {
+        let backend = create_test_backend();
+
+        let id = make_id();
+        let result = backend.get_object(&id).await?;
+        assert!(result.is_none());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_delete_nonexistent() -> Result<()> {
+        let backend = create_test_backend();
+
+        let id = make_id();
+        backend.delete_object(&id).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_overwrite() -> Result<()> {
+        let backend = create_test_backend();
+
+        let id = make_id();
+        let metadata = Metadata {
+            custom: BTreeMap::from_iter([("invalid".into(), "invalid".into())]),
+            ..Default::default()
+        };
+
+        backend
+            .put_object(&id, &metadata, stream::single("hello"))
+            .await?;
+
+        let metadata = Metadata {
+            custom: BTreeMap::from_iter([("hello".into(), "world".into())]),
+            ..Default::default()
+        };
+
+        backend
+            .put_object(&id, &metadata, stream::single("world"))
+            .await?;
+
+        let (meta, stream) = backend.get_object(&id).await?.unwrap();
+
+        let payload = stream::read_to_vec(stream).await?;
+        let str_payload = str::from_utf8(&payload).unwrap();
+        assert_eq!(str_payload, "world");
+        assert_eq!(meta.custom, metadata.custom);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_read_after_delete() -> Result<()> {
+        let backend = create_test_backend();
+
+        let id = make_id();
+        let metadata = Metadata::default();
+
+        backend
+            .put_object(&id, &metadata, stream::single("hello, world"))
+            .await?;
+
+        backend.delete_object(&id).await?;
+
+        let result = backend.get_object(&id).await?;
+        assert!(result.is_none());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_get_metadata_returns_metadata() -> Result<()> {
+        let backend = create_test_backend();
+
+        let id = make_id();
+        let metadata = Metadata {
+            content_type: "text/plain".into(),
+            origin: Some("203.0.113.42".into()),
+            custom: BTreeMap::from_iter([("hello".into(), "world".into())]),
+            ..Default::default()
+        };
+
+        backend
+            .put_object(&id, &metadata, stream::single("hello, world"))
+            .await?;
+
+        let meta = backend.get_metadata(&id).await?.unwrap();
+        assert_eq!(meta.content_type, metadata.content_type);
+        assert_eq!(meta.origin, metadata.origin);
+        assert_eq!(meta.custom, metadata.custom);
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_get_metadata_nonexistent() -> Result<()> {
         let backend = create_test_backend();
+
         let id = make_id();
         let result = backend.get_metadata(&id).await?;
         assert!(result.is_none());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_compressed_payload_roundtrip() -> Result<()> {
+        let backend = create_test_backend();
+
+        let plaintext = b"hello, world (but compressed with zstd)";
+        let compressed = zstd::encode_all(&plaintext[..], 3)?;
+
+        let id = make_id();
+        let metadata = Metadata {
+            content_type: "text/plain".into(),
+            compression: Some(Compression::Zstd),
+            ..Default::default()
+        };
+
+        backend
+            .put_object(&id, &metadata, stream::single(compressed.clone()))
+            .await?;
+
+        let (meta, stream) = backend.get_object(&id).await?.unwrap();
+        let payload = stream::read_to_vec(stream).await?;
+
+        assert_eq!(meta.compression, Some(Compression::Zstd));
+        assert_eq!(
+            payload, compressed,
+            "Payload should be returned still compressed, not auto-decompressed"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_streaming_multipart_upload() -> Result<()> {
+        // rust-s3 dispatches to multipart uploads when the stream exceeds the
+        // 8 MiB chunk size. Use 20 MiB to ensure multiple parts are uploaded.
+        let backend = create_test_backend();
+
+        let id = make_id();
+        let metadata = Metadata::default();
+
+        let chunk = bytes::Bytes::from(vec![0xab; 1024 * 1024]); // 1 MiB
+        let stream =
+            futures_util::stream::iter(std::iter::repeat_with(move || Ok(chunk.clone())).take(20))
+                .boxed();
+
+        backend.put_object(&id, &metadata, stream).await?;
+
+        let (meta, stream) = backend.get_object(&id).await?.unwrap();
+        let payload = stream::read_to_vec(stream).await?;
+
+        assert_eq!(payload.len(), 20 * 1024 * 1024);
+        assert!(payload.iter().all(|&b| b == 0xab));
+        assert_eq!(meta.size, Some(20 * 1024 * 1024));
+
         Ok(())
     }
 }

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -26,8 +26,8 @@ use crate::stream::{self, ClientStream};
 /// Configuration for [`S3CompatibleBackend`].
 ///
 /// Supports [Amazon S3] and other S3-compatible services such as MinIO.
-/// Authentication is configured via static credentials (access key ID and
-/// secret access key) in the [`auth`](Self::auth) field.
+/// Authentication uses static SigV4 credentials ([`access_key_id`](Self::access_key_id)
+/// and [`secret_access_key`](Self::secret_access_key)).
 ///
 /// [Amazon S3]: https://aws.amazon.com/s3/
 ///

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -390,7 +390,7 @@ fn is_not_found(error: &S3Error) -> bool {
 #[async_trait::async_trait]
 impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
     fn name(&self) -> &'static str {
-        "s3-compatible"
+        "s3_compatible"
     }
 
     #[tracing::instrument(level = "trace", fields(?id), skip_all)]

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -1,11 +1,9 @@
 //! Backend that can be used with any S3-compatible object store (Amazon S3, MinIO, R2, etc.).
 
 use std::io;
-use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use futures_util::{StreamExt, TryStreamExt};
-use gcp_auth::TokenProvider as _;
 use objectstore_types::metadata::{ExpirationPolicy, Metadata};
 use reqwest::header::{self, HeaderMap, HeaderName};
 use s3::Bucket;
@@ -21,20 +19,17 @@ use tokio_util::io::StreamReader;
 
 use crate::backend::common::{Backend, DeleteResponse, GetResponse, MetadataResponse, PutResponse};
 use crate::error::{Error, Result};
-use crate::gcp_auth::PrefetchingTokenProvider;
 use crate::id::ObjectId;
 use crate::secret::ConfigSecret;
 use crate::stream::{self, ClientStream};
 
 /// Configuration for [`S3CompatibleBackend`].
 ///
-/// Supports [Amazon S3] and other S3-compatible services such as MinIO. AWS
-/// credentials are resolved via the standard [SDK chain] (env vars, profile,
-/// STS web identity, ECS container, EC2 IMDS); if no credentials can be
-/// resolved, the backend falls back to anonymous (unauthenticated) requests.
+/// Supports [Amazon S3] and other S3-compatible services such as MinIO.
+/// Authentication is configured via static credentials (access key ID and
+/// secret access key) in the [`auth`](Self::auth) field.
 ///
 /// [Amazon S3]: https://aws.amazon.com/s3/
-/// [SDK chain]: https://docs.rs/aws-creds/0.39.1/aws_creds/credentials/struct.Credentials.html
 ///
 /// # Example
 ///
@@ -47,6 +42,9 @@ use crate::stream::{self, ClientStream};
 ///   use_path_style: false
 ///   metadata_prefix: x-amz-meta-
 ///   protocol_prefix: x-amz-
+///   auth:
+///     access_key_id: AKIAIOSFODNN7EXAMPLE
+///     secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct S3CompatibleConfig {
@@ -139,18 +137,13 @@ pub struct S3CompatibleConfig {
     #[serde(default)]
     pub custom_time_header: Option<String>,
 
-    /// Optional static credentials for S3 SigV4 authentication.
-    ///
-    /// When set, the backend uses these credentials for signing requests
-    /// instead of the default credential chain. When unset, falls back to
-    /// anonymous (unauthenticated) requests.
+    /// Static credentials for S3 SigV4 authentication.
     ///
     /// # Environment Variables
     ///
     /// - `OS__STORAGE__AUTH__ACCESS_KEY_ID=…`
     /// - `OS__STORAGE__AUTH__SECRET_ACCESS_KEY=…`
-    #[serde(default)]
-    pub auth: Option<AuthConfig>,
+    pub auth: AuthConfig,
 }
 
 fn default_region() -> String {
@@ -188,7 +181,6 @@ pub struct S3CompatibleBackend {
     metadata_prefix: String,
     protocol_prefix: String,
     custom_time_header: Option<String>,
-    bearer_auth_provider: Option<Arc<PrefetchingTokenProvider>>,
 }
 
 /// Wraps [`Metadata::to_headers`], additionally echoing `time_expires` under
@@ -231,32 +223,13 @@ fn is_not_found(error: &S3Error) -> bool {
 impl S3CompatibleBackend {
     /// Creates a new S3-compatible backend bound to the given config.
     pub fn new(config: S3CompatibleConfig) -> anyhow::Result<Self> {
-        Self::from_config(config)
-    }
-
-    /// Creates a new S3-compatible backend bound to the given config and bearer auth provider.
-    pub fn new_with_bearer_auth(
-        config: S3CompatibleConfig,
-        bearer_auth_provider: Arc<PrefetchingTokenProvider>,
-    ) -> anyhow::Result<Self> {
-        let mut slf = Self::from_config(config)?;
-        slf.bearer_auth_provider = Some(bearer_auth_provider);
-        Ok(slf)
-    }
-
-    fn from_config(config: S3CompatibleConfig) -> anyhow::Result<Self> {
-        let credentials = config
-            .auth
-            .map(|auth| {
-                Credentials::new(
-                    Some(&auth.access_key_id),
-                    Some(auth.secret_access_key.expose_secret().as_str()),
-                    None,
-                    None,
-                    None,
-                )
-            })
-            .unwrap_or_else(Credentials::anonymous)?;
+        let credentials = Credentials::new(
+            Some(&config.auth.access_key_id),
+            Some(config.auth.secret_access_key.expose_secret().as_str()),
+            None,
+            None,
+            None,
+        )?;
 
         let region = Region::Custom {
             region: config.region,
@@ -273,34 +246,7 @@ impl S3CompatibleBackend {
             metadata_prefix: config.metadata_prefix,
             protocol_prefix: config.protocol_prefix,
             custom_time_header: config.custom_time_header,
-            bearer_auth_provider: None,
         })
-    }
-
-    /// Returns a bucket with a fresh `Authorization: Bearer` header when a
-    /// bearer auth provider is configured.
-    async fn authed_bucket(&self) -> Result<Box<Bucket>> {
-        let Some(provider) = &self.bearer_auth_provider else {
-            return Ok(self.bucket.clone());
-        };
-        let token = provider.token(&[]).await.map_err(|e| Error::Generic {
-            context: "S3: failed to get bearer token".to_owned(),
-            cause: Some(Box::new(e)),
-        })?;
-        let mut headers = self.bucket.extra_headers().clone();
-        headers.insert(
-            header::AUTHORIZATION,
-            format!("Bearer {}", token.as_str()).parse().map_err(
-                |e: header::InvalidHeaderValue| Error::Generic {
-                    context: "S3: invalid bearer token value".to_owned(),
-                    cause: Some(Box::new(e)),
-                },
-            )?,
-        );
-        self.bucket
-            .with_extra_headers(headers)
-            .map(Box::new)
-            .map_err(|e| map_s3_error(e, "S3: failed to set auth headers"))
     }
 
     fn object_path(&self, id: &ObjectId) -> String {
@@ -312,12 +258,7 @@ impl S3CompatibleBackend {
     /// the 1-day debounce window.
     ///
     /// [`TimeToIdle`]: objectstore_types::metadata::ExpirationPolicy::TimeToIdle
-    async fn bump_tti_if_needed(
-        &self,
-        bucket: &Bucket,
-        path: &str,
-        metadata: &Metadata,
-    ) -> Result<()> {
+    async fn bump_tti_if_needed(&self, path: &str, metadata: &Metadata) -> Result<()> {
         let ExpirationPolicy::TimeToIdle(tti) = metadata.expiration_policy else {
             return Ok(());
         };
@@ -334,8 +275,7 @@ impl S3CompatibleBackend {
 
         if bump_amount > TTI_DEBOUNCE {
             // TODO: Schedule into background persistently so this doesn't get lost on restarts.
-            self.update_custom_time(bucket, path, metadata, new_expiry)
-                .await?;
+            self.update_custom_time(path, metadata, new_expiry).await?;
         }
 
         Ok(())
@@ -349,16 +289,16 @@ impl S3CompatibleBackend {
     /// [`custom_time_header`]: S3CompatibleConfig::custom_time_header
     async fn update_custom_time(
         &self,
-        bucket: &Bucket,
         path: &str,
         metadata: &Metadata,
         custom_time: SystemTime,
     ) -> Result<()> {
         let copy_source_header = format!("{}copy-source", self.protocol_prefix);
         let metadata_directive_header = format!("{}metadata-directive", self.protocol_prefix);
-        let copy_source = format!("/{}{}", bucket.name(), path);
+        let copy_source = format!("/{}{}", self.bucket.name(), path);
 
-        let mut request = bucket
+        let mut request = self
+            .bucket
             .put_object_builder(path, &[])
             .with_content_type(metadata.content_type.as_ref())
             .with_header(&copy_source_header, copy_source)
@@ -404,8 +344,8 @@ impl S3CompatibleBackend {
     /// HEADs an object, filters expired entries, and bumps TTI.
     ///
     /// Returns `None` if the object is absent or past its expiry.
-    async fn fetch_live_metadata(&self, bucket: &Bucket, path: &str) -> Result<Option<Metadata>> {
-        let Some(headers) = self.head_object(bucket, path).await? else {
+    async fn fetch_live_metadata(&self, path: &str) -> Result<Option<Metadata>> {
+        let Some(headers) = self.head_object(path).await? else {
             return Ok(None);
         };
         let metadata = metadata_from_headers(&headers, &self.metadata_prefix)?;
@@ -420,7 +360,7 @@ impl S3CompatibleBackend {
             return Ok(None);
         }
 
-        self.bump_tti_if_needed(bucket, path, &metadata).await?;
+        self.bump_tti_if_needed(path, &metadata).await?;
         Ok(Some(metadata))
     }
 
@@ -428,8 +368,8 @@ impl S3CompatibleBackend {
     ///
     /// `Bucket::head_object` is not sufficient because it only surfaces
     /// `x-amz-meta-*` keys, which could be different from `self.metadata_prefix`.
-    async fn head_object(&self, bucket: &Bucket, path: &str) -> Result<Option<HeaderMap>> {
-        let request = ReqwestRequest::new(bucket, path, Command::HeadObject)
+    async fn head_object(&self, path: &str) -> Result<Option<HeaderMap>> {
+        let request = ReqwestRequest::new(&self.bucket, path, Command::HeadObject)
             .await
             .map_err(|e| map_s3_error(e, "S3: failed to build head request"))?;
 
@@ -458,10 +398,10 @@ impl Backend for S3CompatibleBackend {
         stream: ClientStream,
     ) -> Result<PutResponse> {
         objectstore_log::debug!("Writing to s3_compatible backend");
-        let bucket = self.authed_bucket().await?;
         let path = self.object_path(id);
 
-        let mut request = bucket
+        let mut request = self
+            .bucket
             .put_object_stream_builder(&path)
             .with_content_type(metadata.content_type.as_ref());
 
@@ -512,14 +452,13 @@ impl Backend for S3CompatibleBackend {
     #[tracing::instrument(level = "trace", fields(?id), skip_all)]
     async fn get_object(&self, id: &ObjectId) -> Result<GetResponse> {
         objectstore_log::debug!("Reading from s3_compatible backend");
-        let bucket = self.authed_bucket().await?;
         let path = self.object_path(id);
 
-        let Some(metadata) = self.fetch_live_metadata(&bucket, &path).await? else {
+        let Some(metadata) = self.fetch_live_metadata(&path).await? else {
             return Ok(None);
         };
 
-        let response = match bucket.get_object_stream(&path).await {
+        let response = match self.bucket.get_object_stream(&path).await {
             Ok(response) => response,
             Err(ref e) if is_not_found(e) => {
                 // Object was deleted between HEAD and GET; treat as missing.
@@ -536,18 +475,16 @@ impl Backend for S3CompatibleBackend {
     #[tracing::instrument(level = "trace", fields(?id), skip_all)]
     async fn get_metadata(&self, id: &ObjectId) -> Result<MetadataResponse> {
         objectstore_log::debug!("Reading metadata from s3_compatible backend");
-        let bucket = self.authed_bucket().await?;
         let path = self.object_path(id);
-        self.fetch_live_metadata(&bucket, &path).await
+        self.fetch_live_metadata(&path).await
     }
 
     #[tracing::instrument(level = "trace", fields(?id), skip_all)]
     async fn delete_object(&self, id: &ObjectId) -> Result<DeleteResponse> {
         objectstore_log::debug!("Deleting from s3_compatible backend");
-        let bucket = self.authed_bucket().await?;
         let path = self.object_path(id);
 
-        match bucket.delete_object(&path).await {
+        match self.bucket.delete_object(&path).await {
             Ok(_) => Ok(()),
             Err(ref e) if is_not_found(e) => {
                 objectstore_log::debug!("Object not found");
@@ -586,7 +523,10 @@ mod tests {
             metadata_prefix: default_metadata_prefix(),
             protocol_prefix: default_protocol_prefix(),
             custom_time_header: None,
-            auth: None,
+            auth: AuthConfig {
+                access_key_id: "minioadmin".into(),
+                secret_access_key: SecretBox::new(Box::new(ConfigSecret::from("minioadmin"))),
+            },
         })
         .unwrap()
     }
@@ -833,7 +773,7 @@ mod tests {
         let path = backend.object_path(&id);
         let old_deadline = SystemTime::now() + tti - TTI_DEBOUNCE - Duration::from_secs(60);
         backend
-            .update_custom_time(&backend.bucket, &path, &metadata, old_deadline)
+            .update_custom_time(&path, &metadata, old_deadline)
             .await?;
 
         // First get_metadata sees the old timestamp and triggers a TTI bump.

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -106,16 +106,22 @@ pub struct S3CompatibleConfig {
     /// When set, the backend writes the resolved expiration time to this
     /// header on PUT, and on reads with a [`TimeToIdle`] policy it bumps the
     /// timestamp (via copy-in-place with a metadata-directive REPLACE) when
-    /// the recorded expiry is older than `now + tti - 1 day`.
+    /// the recorded expiry is older than `now + tti - TTI_DEBOUNCE`.
     ///
-    /// Defaults to `x-goog-custom-time` — the header the [GCS XML API]
-    /// interprets in conjunction with a `daysSinceCustomTime` lifecycle
-    /// rule. AWS S3 has no equivalent mechanism and will ignore the header.
-    /// Set to `None` on those deployments to disable the feature entirely.
+    /// Defaults to `x-amz-meta-x-os-custom-time`, which results in the
+    /// timestamp being stored as plain user metadata on any S3-compatible
+    /// backend. That preserves the TTI bump flow on deployments with no
+    /// native lifecycle mechanism (AWS S3 proper, MinIO) — the expiry is
+    /// persisted and observable, just not acted on by the storage layer.
+    ///
+    /// Override with `x-goog-custom-time` when pointing at the [GCS XML API]
+    /// with a `daysSinceCustomTime` lifecycle configured on the bucket, so
+    /// GCS itself garbage-collects expired objects. Set to `None` to skip
+    /// writing the header entirely.
     ///
     /// # Default
     ///
-    /// `Some("x-goog-custom-time")`
+    /// `Some("x-amz-meta-x-os-custom-time")`
     ///
     /// # Environment Variables
     ///
@@ -140,7 +146,7 @@ fn default_metadata_prefix() -> String {
 }
 
 fn default_custom_time_header() -> Option<String> {
-    Some("x-goog-custom-time".to_owned())
+    Some("x-amz-meta-x-os-custom-time".to_owned())
 }
 
 /// Time to debounce bumping an object with configured TTI.

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -42,7 +42,6 @@ use crate::stream::{self, ClientStream};
 ///   use_path_style: false
 ///   metadata_prefix: x-amz-meta-
 ///   protocol_prefix: x-amz-
-///   custom_time_header: x-amz-meta-expiry
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct S3CompatibleConfig {
@@ -118,17 +117,22 @@ pub struct S3CompatibleConfig {
     #[serde(default = "default_protocol_prefix")]
     pub protocol_prefix: String,
 
-    /// Header carrying the object's resolved expiration timestamp.
+    /// Optional extra header that mirrors the object's resolved expiration
+    /// timestamp, on top of the canonical `x-sn-time-expires`.
+    ///
+    /// Used to interoperate with S3-compatible backends that recognize a
+    /// dedicated header for object lifecycle (such as GCS, which uses
+    /// `x-goog-custom-time`). Leave unset for plain S3.
     ///
     /// # Default
     ///
-    /// `"x-amz-meta-expiry"`
+    /// `None`
     ///
     /// # Environment Variables
     ///
     /// - `OS__STORAGE__CUSTOM_TIME_HEADER=x-goog-custom-time`
-    #[serde(default = "default_custom_time_header")]
-    pub custom_time_header: String,
+    #[serde(default)]
+    pub custom_time_header: Option<String>,
 }
 
 fn default_region() -> String {
@@ -145,10 +149,6 @@ fn default_metadata_prefix() -> String {
 
 fn default_protocol_prefix() -> String {
     "x-amz-".to_owned()
-}
-
-fn default_custom_time_header() -> String {
-    "x-amz-meta-expiry".to_owned()
 }
 
 /// Time to debounce bumping an object with configured TTI.
@@ -189,21 +189,20 @@ pub struct S3CompatibleBackend<T> {
     token_provider: Option<T>,
     metadata_prefix: String,
     protocol_prefix: String,
-    custom_time_header: String,
+    custom_time_header: Option<String>,
 }
 
-/// Wraps [`Metadata::to_headers`] with S3-specific concerns. If `custom_time`
-/// is `Some`, it is written under `custom_time_header`.
+/// Wraps [`Metadata::to_headers`], additionally echoing `time_expires` under
+/// `custom_time_header` when both are set.
 fn metadata_to_s3_headers(
     metadata: &Metadata,
     prefix: &str,
-    custom_time_header: &str,
-    custom_time: Option<SystemTime>,
+    custom_time_header: Option<&str>,
 ) -> Result<HeaderMap, objectstore_types::metadata::Error> {
     let mut headers = metadata.to_headers(prefix)?;
-    if let Some(custom_time) = custom_time {
-        let formatted = humantime::format_rfc3339_seconds(custom_time);
-        let name = HeaderName::try_from(custom_time_header)?;
+    if let (Some(name), Some(time)) = (custom_time_header, metadata.time_expires) {
+        let formatted = humantime::format_rfc3339_seconds(time);
+        let name = HeaderName::try_from(name)?;
         headers.append(name, formatted.to_string().parse()?);
     }
     Ok(headers)
@@ -252,19 +251,12 @@ impl<T> S3CompatibleBackend<T> {
         format!("/{}", id.as_storage_path())
     }
 
-    /// If `metadata` has a [`TimeToIdle`] policy and a
-    /// [`custom_time_header`] is configured, bumps the recorded expiry via a
-    /// metadata-only copy-in-place when it would otherwise fall outside the
-    /// 1-day debounce window.
+    /// If `metadata` has a [`TimeToIdle`] policy, bumps the recorded expiry
+    /// via a metadata-only copy-in-place when it would otherwise fall outside
+    /// the 1-day debounce window.
     ///
     /// [`TimeToIdle`]: objectstore_types::metadata::ExpirationPolicy::TimeToIdle
-    /// [`custom_time_header`]: S3CompatibleConfig::custom_time_header
-    async fn bump_tti_if_needed(
-        &self,
-        path: &str,
-        headers: &HeaderMap,
-        metadata: &Metadata,
-    ) -> Result<()> {
+    async fn bump_tti_if_needed(&self, path: &str, metadata: &Metadata) -> Result<()> {
         let ExpirationPolicy::TimeToIdle(tti) = metadata.expiration_policy else {
             return Ok(());
         };
@@ -272,11 +264,7 @@ impl<T> S3CompatibleBackend<T> {
         // TODO: Inject the access time from the request.
         let access_time = SystemTime::now();
 
-        let current_expiry = headers
-            .get(self.custom_time_header.as_str())
-            .and_then(|v| v.to_str().ok())
-            .and_then(|s| humantime::parse_rfc3339(s).ok())
-            .unwrap_or(access_time);
+        let current_expiry = metadata.time_expires.unwrap_or(access_time);
         let new_expiry = access_time + tti;
 
         let bump_amount = new_expiry
@@ -292,8 +280,9 @@ impl<T> S3CompatibleBackend<T> {
     }
 
     /// Rewrites the object's metadata in place via a copy-with-REPLACE
-    /// request, setting [`custom_time_header`] to `custom_time`. Used to bump
-    /// the expiration time for TTI objects.
+    /// request, setting `time_expires` (and the configured
+    /// [`custom_time_header`], if any) to `custom_time`. Used to bump the
+    /// expiration time for TTI objects.
     ///
     /// [`custom_time_header`]: S3CompatibleConfig::custom_time_header
     async fn update_custom_time(
@@ -321,11 +310,12 @@ impl<T> S3CompatibleBackend<T> {
                 .map_err(|e| map_s3_error(e, "S3: failed to set content-encoding"))?;
         }
 
+        let mut metadata = metadata.clone();
+        metadata.time_expires = Some(custom_time);
         let headers = metadata_to_s3_headers(
-            metadata,
+            &metadata,
             &self.metadata_prefix,
-            &self.custom_time_header,
-            Some(custom_time),
+            self.custom_time_header.as_deref(),
         )
         .map_err(Error::Metadata)?;
         for (name, value) in &headers {
@@ -428,15 +418,14 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
                 .map_err(|e| map_s3_error(e, "S3: failed to set content-encoding"))?;
         }
 
-        let custom_time = metadata
-            .expiration_policy
-            .expires_in()
-            .map(|d| SystemTime::now() + d);
+        let mut metadata = metadata.clone();
+        if let Some(d) = metadata.expiration_policy.expires_in() {
+            metadata.time_expires = Some(SystemTime::now() + d);
+        }
         let headers = metadata_to_s3_headers(
-            metadata,
+            &metadata,
             &self.metadata_prefix,
-            &self.custom_time_header,
-            custom_time,
+            self.custom_time_header.as_deref(),
         )
         .map_err(Error::Metadata)?;
         for (name, value) in &headers {
@@ -476,7 +465,17 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
             return Ok(None);
         };
         let metadata = metadata_from_headers(&headers, &self.metadata_prefix)?;
-        self.bump_tti_if_needed(&path, &headers, &metadata).await?;
+
+        // Filter already expired objects but leave them to garbage collection.
+        let access_time = SystemTime::now();
+        if metadata.expiration_policy.is_timeout()
+            && metadata.time_expires.is_some_and(|ts| ts < access_time)
+        {
+            objectstore_log::debug!("Object found but past expiry");
+            return Ok(None);
+        }
+
+        self.bump_tti_if_needed(&path, &metadata).await?;
 
         let response = match self.bucket.get_object_stream(&path).await {
             Ok(response) => response,
@@ -501,7 +500,17 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
             return Ok(None);
         };
         let metadata = metadata_from_headers(&headers, &self.metadata_prefix)?;
-        self.bump_tti_if_needed(&path, &headers, &metadata).await?;
+
+        // Filter already expired objects but leave them to garbage collection.
+        let access_time = SystemTime::now();
+        if metadata.expiration_policy.is_timeout()
+            && metadata.time_expires.is_some_and(|ts| ts < access_time)
+        {
+            objectstore_log::debug!("Object found but past expiry");
+            return Ok(None);
+        }
+
+        self.bump_tti_if_needed(&path, &metadata).await?;
         Ok(Some(metadata))
     }
 
@@ -548,7 +557,7 @@ mod tests {
             use_path_style: default_use_path_style(),
             metadata_prefix: default_metadata_prefix(),
             protocol_prefix: default_protocol_prefix(),
-            custom_time_header: default_custom_time_header(),
+            custom_time_header: None,
         })
         .unwrap()
     }

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -41,6 +41,7 @@ use crate::stream::{self, ClientStream};
 ///   region: us-east-1
 ///   use_path_style: false
 ///   metadata_prefix: x-amz-meta-
+///   protocol_prefix: x-amz-
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct S3CompatibleConfig {
@@ -105,9 +106,6 @@ pub struct S3CompatibleConfig {
 
     /// Protocol-level header prefix used for non-metadata request headers
     /// like `{prefix}copy-source` and `{prefix}metadata-directive`.
-    ///
-    /// Override alongside [`metadata_prefix`](Self::metadata_prefix) when
-    /// targeting GCS's XML API (`x-goog-`).
     ///
     /// # Default
     ///
@@ -272,7 +270,7 @@ impl<T> S3CompatibleBackend<T> {
     }
 
     /// Rewrites the object's metadata in place via a copy-with-REPLACE
-    /// request. Used to bump the custom-time header for TTI objects.
+    /// request. Used to bump the expiration time header for TTI objects.
     async fn update_metadata(&self, path: &str, metadata: &Metadata) -> Result<()> {
         let copy_source_header = format!("{}copy-source", self.protocol_prefix);
         let metadata_directive_header = format!("{}metadata-directive", self.protocol_prefix);
@@ -320,10 +318,8 @@ impl<T> S3CompatibleBackend<T> {
     /// Issues a HEAD request and returns the raw response headers.
     ///
     /// `Bucket::head_object` is not sufficient because it only surfaces
-    /// `x-amz-meta-*` keys — it drops any other metadata prefix (e.g.
-    /// `x-goog-meta-*`). We build a `ReqwestRequest` directly so we can
-    /// inspect the full `HeaderMap`.
-    async fn raw_head(&self, path: &str) -> Result<Option<HeaderMap>> {
+    /// `x-amz-meta-*` keys, which could be different from `self.metadata_prefix`.
+    async fn head_object(&self, path: &str) -> Result<Option<HeaderMap>> {
         let request = ReqwestRequest::new(&self.bucket, path, Command::HeadObject)
             .await
             .map_err(|e| map_s3_error(e, "S3: failed to build head request"))?;
@@ -437,7 +433,7 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
         objectstore_log::debug!("Reading from s3_compatible backend");
         let path = self.object_path(id);
 
-        let Some(headers) = self.raw_head(&path).await? else {
+        let Some(headers) = self.head_object(&path).await? else {
             return Ok(None);
         };
         let metadata = metadata_from_headers(&headers, &self.metadata_prefix)?;
@@ -462,7 +458,7 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
         objectstore_log::debug!("Reading metadata from s3_compatible backend");
         let path = self.object_path(id);
 
-        let Some(headers) = self.raw_head(&path).await? else {
+        let Some(headers) = self.head_object(&path).await? else {
             return Ok(None);
         };
         let metadata = metadata_from_headers(&headers, &self.metadata_prefix)?;

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -110,27 +110,17 @@ pub struct S3CompatibleConfig {
     ///
     /// Defaults to `x-amz-meta-x-os-custom-time`, which results in the
     /// timestamp being stored as plain user metadata on any S3-compatible
-    /// backend. That preserves the TTI bump flow on deployments with no
-    /// native lifecycle mechanism (AWS S3 proper, MinIO) — the expiry is
-    /// persisted and observable, just not acted on by the storage layer.
-    ///
-    /// Override with `x-goog-custom-time` when pointing at the [GCS XML API]
-    /// with a `daysSinceCustomTime` lifecycle configured on the bucket, so
-    /// GCS itself garbage-collects expired objects. Set to `None` to skip
-    /// writing the header entirely.
+    /// backend.
     ///
     /// # Default
     ///
-    /// `Some("x-amz-meta-x-os-custom-time")`
+    /// `"x-amz-meta-x-os-custom-time"`
     ///
     /// # Environment Variables
     ///
     /// - `OS__STORAGE__CUSTOM_TIME_HEADER=x-goog-custom-time`
-    ///
-    /// [`TimeToIdle`]: objectstore_types::metadata::ExpirationPolicy::TimeToIdle
-    /// [GCS XML API]: https://docs.cloud.google.com/storage/docs/xml-api/reference-headers#xgoogcustomtime
     #[serde(default = "default_custom_time_header")]
-    pub custom_time_header: Option<String>,
+    pub custom_time_header: String,
 }
 
 fn default_region() -> String {
@@ -145,8 +135,8 @@ fn default_metadata_prefix() -> String {
     "x-amz-meta-".to_owned()
 }
 
-fn default_custom_time_header() -> Option<String> {
-    Some("x-amz-meta-x-os-custom-time".to_owned())
+fn default_custom_time_header() -> String {
+    "x-amz-meta-x-os-custom-time".to_owned()
 }
 
 /// Time to debounce bumping an object with configured TTI.

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -829,7 +829,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_metadata_does_not_bump_fresh_tti() -> Result<()> {
-        let backend = create_test_backend().await?;
+        let backend = create_test_backend();
 
         let id = make_id();
         // TTI must exceed TTI_DEBOUNCE (1 day) for the bump condition to be reachable.

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -5,7 +5,7 @@ use std::{fmt, io};
 
 use futures_util::{StreamExt, TryStreamExt};
 use objectstore_types::metadata::{ExpirationPolicy, Metadata};
-use reqwest::header::{self, HeaderMap};
+use reqwest::header::{self, HeaderMap, HeaderName};
 use s3::Bucket;
 use s3::command::Command;
 use s3::creds::Credentials;
@@ -286,9 +286,9 @@ impl<T> S3CompatibleBackend<T> {
                 .map_err(|e| map_s3_error(e, "S3: failed to set content-encoding"))?;
         }
 
-        let headers = metadata
-            .to_headers(&self.metadata_prefix)
-            .map_err(Error::Metadata)?;
+        let headers =
+            metadata_to_s3_headers(metadata, &self.metadata_prefix, &self.custom_time_header)
+                .map_err(Error::Metadata)?;
         for (name, value) in &headers {
             if name == header::CONTENT_TYPE || name == header::CONTENT_ENCODING {
                 continue;
@@ -300,13 +300,6 @@ impl<T> S3CompatibleBackend<T> {
             request = request
                 .with_header(name.as_str(), value_str)
                 .map_err(|e| map_s3_error(e, "S3: failed to set object metadata"))?;
-        }
-
-        if let Some(expires_in) = metadata.expiration_policy.expires_in() {
-            let expires_at = humantime::format_rfc3339_seconds(SystemTime::now() + expires_in);
-            request = request
-                .with_header(self.custom_time_header.as_str(), expires_at.to_string())
-                .map_err(|e| map_s3_error(e, "S3: failed to set custom time header"))?;
         }
 
         request
@@ -373,6 +366,23 @@ fn metadata_from_headers(headers: &HeaderMap, prefix: &str) -> Result<Metadata> 
     Ok(metadata)
 }
 
+/// Wraps [`Metadata::to_headers`] with S3-specific concerns: appends the
+/// `custom_time_header` carrying the resolved expiration timestamp when the
+/// object has a TTL or TTI policy.
+fn metadata_to_s3_headers(
+    metadata: &Metadata,
+    prefix: &str,
+    custom_time_header: &str,
+) -> Result<HeaderMap, objectstore_types::metadata::Error> {
+    let mut headers = metadata.to_headers(prefix)?;
+    if let Some(expires_in) = metadata.expiration_policy.expires_in() {
+        let expires_at = humantime::format_rfc3339_seconds(SystemTime::now() + expires_in);
+        let name = HeaderName::try_from(custom_time_header)?;
+        headers.append(name, expires_at.to_string().parse()?);
+    }
+    Ok(headers)
+}
+
 /// Returns `true` if `error` is an HTTP 404 from rust-s3.
 fn is_not_found(error: &S3Error) -> bool {
     matches!(error, S3Error::HttpFailWithBody(404, _))
@@ -410,9 +420,9 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
         // `with_metadata` is not used here because it hardcodes the S3
         // prefix. Standard headers (Content-Type, Content-Encoding) are
         // handled above.
-        let headers = metadata
-            .to_headers(&self.metadata_prefix)
-            .map_err(Error::Metadata)?;
+        let headers =
+            metadata_to_s3_headers(metadata, &self.metadata_prefix, &self.custom_time_header)
+                .map_err(Error::Metadata)?;
         for (name, value) in &headers {
             if name == header::CONTENT_TYPE || name == header::CONTENT_ENCODING {
                 continue;
@@ -424,23 +434,6 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
             request = request
                 .with_header(name.clone(), value_str)
                 .map_err(|e| map_s3_error(e, "S3: failed to set object metadata"))?;
-        }
-
-        if let Some(expires_in) = metadata.expiration_policy.expires_in() {
-            let expires_at = humantime::format_rfc3339_seconds(SystemTime::now() + expires_in);
-            let name =
-                reqwest::header::HeaderName::try_from(&self.custom_time_header).map_err(|e| {
-                    Error::Generic {
-                        context: format!(
-                            "S3: invalid custom time header name: {:?}",
-                            self.custom_time_header
-                        ),
-                        cause: Some(Box::new(e)),
-                    }
-                })?;
-            request = request
-                .with_header(name, expires_at.to_string())
-                .map_err(|e| map_s3_error(e, "S3: failed to set custom time header"))?;
         }
 
         let mut reader = StreamReader::new(stream.map_err(io::Error::other));

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -192,17 +192,19 @@ pub struct S3CompatibleBackend<T> {
     custom_time_header: String,
 }
 
-/// Wraps [`Metadata::to_headers`] with S3-specific concerns.
+/// Wraps [`Metadata::to_headers`] with S3-specific concerns. If `custom_time`
+/// is `Some`, it is written under `custom_time_header`.
 fn metadata_to_s3_headers(
     metadata: &Metadata,
     prefix: &str,
     custom_time_header: &str,
+    custom_time: Option<SystemTime>,
 ) -> Result<HeaderMap, objectstore_types::metadata::Error> {
     let mut headers = metadata.to_headers(prefix)?;
-    if let Some(expires_in) = metadata.expiration_policy.expires_in() {
-        let expires_at = humantime::format_rfc3339_seconds(SystemTime::now() + expires_in);
+    if let Some(custom_time) = custom_time {
+        let formatted = humantime::format_rfc3339_seconds(custom_time);
         let name = HeaderName::try_from(custom_time_header)?;
-        headers.append(name, expires_at.to_string().parse()?);
+        headers.append(name, formatted.to_string().parse()?);
     }
     Ok(headers)
 }
@@ -283,15 +285,23 @@ impl<T> S3CompatibleBackend<T> {
 
         if bump_amount > TTI_DEBOUNCE {
             // TODO: Schedule into background persistently so this doesn't get lost on restarts.
-            self.update_metadata(path, metadata).await?;
+            self.update_custom_time(path, metadata, new_expiry).await?;
         }
 
         Ok(())
     }
 
     /// Rewrites the object's metadata in place via a copy-with-REPLACE
-    /// request. Used to bump the expiration time header for TTI objects.
-    async fn update_metadata(&self, path: &str, metadata: &Metadata) -> Result<()> {
+    /// request, setting [`custom_time_header`] to `custom_time`. Used to bump
+    /// the expiration time for TTI objects.
+    ///
+    /// [`custom_time_header`]: S3CompatibleConfig::custom_time_header
+    async fn update_custom_time(
+        &self,
+        path: &str,
+        metadata: &Metadata,
+        custom_time: SystemTime,
+    ) -> Result<()> {
         let copy_source_header = format!("{}copy-source", self.protocol_prefix);
         let metadata_directive_header = format!("{}metadata-directive", self.protocol_prefix);
         let copy_source = format!("/{}{}", self.bucket.name(), path);
@@ -311,9 +321,13 @@ impl<T> S3CompatibleBackend<T> {
                 .map_err(|e| map_s3_error(e, "S3: failed to set content-encoding"))?;
         }
 
-        let headers =
-            metadata_to_s3_headers(metadata, &self.metadata_prefix, &self.custom_time_header)
-                .map_err(Error::Metadata)?;
+        let headers = metadata_to_s3_headers(
+            metadata,
+            &self.metadata_prefix,
+            &self.custom_time_header,
+            Some(custom_time),
+        )
+        .map_err(Error::Metadata)?;
         for (name, value) in &headers {
             if name == header::CONTENT_TYPE || name == header::CONTENT_ENCODING {
                 continue;
@@ -330,7 +344,7 @@ impl<T> S3CompatibleBackend<T> {
         request
             .execute()
             .await
-            .map_err(|e| map_s3_error(e, "S3: failed to update object metadata"))?;
+            .map_err(|e| map_s3_error(e, "S3: failed to update custom_time"))?;
 
         Ok(())
     }
@@ -414,9 +428,17 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
                 .map_err(|e| map_s3_error(e, "S3: failed to set content-encoding"))?;
         }
 
-        let headers =
-            metadata_to_s3_headers(metadata, &self.metadata_prefix, &self.custom_time_header)
-                .map_err(Error::Metadata)?;
+        let custom_time = metadata
+            .expiration_policy
+            .expires_in()
+            .map(|d| SystemTime::now() + d);
+        let headers = metadata_to_s3_headers(
+            metadata,
+            &self.metadata_prefix,
+            &self.custom_time_header,
+            custom_time,
+        )
+        .map_err(Error::Metadata)?;
         for (name, value) in &headers {
             if name == header::CONTENT_TYPE || name == header::CONTENT_ENCODING {
                 continue;
@@ -505,7 +527,7 @@ mod tests {
     use std::time::SystemTime;
 
     use anyhow::Result;
-    use objectstore_types::metadata::{Compression, ExpirationPolicy};
+    use objectstore_types::metadata::ExpirationPolicy;
     use objectstore_types::scope::{Scope, Scopes};
 
     use super::*;
@@ -652,39 +674,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_overwrite() -> Result<()> {
-        let backend = create_test_backend();
-
-        let id = make_id();
-        let metadata = Metadata {
-            custom: BTreeMap::from_iter([("invalid".into(), "invalid".into())]),
-            ..Default::default()
-        };
-
-        backend
-            .put_object(&id, &metadata, stream::single("hello"))
-            .await?;
-
-        let metadata = Metadata {
-            custom: BTreeMap::from_iter([("hello".into(), "world".into())]),
-            ..Default::default()
-        };
-
-        backend
-            .put_object(&id, &metadata, stream::single("world"))
-            .await?;
-
-        let (meta, stream) = backend.get_object(&id).await?.unwrap();
-
-        let payload = stream::read_to_vec(stream).await?;
-        let str_payload = str::from_utf8(&payload).unwrap();
-        assert_eq!(str_payload, "world");
-        assert_eq!(meta.custom, metadata.custom);
-
-        Ok(())
-    }
-
-    #[tokio::test]
     async fn test_read_after_delete() -> Result<()> {
         let backend = create_test_backend();
 
@@ -803,9 +792,11 @@ mod tests {
 
         // Manually set custom_time to just inside the bump window.
         // The bump condition is: expire_at < now + tti - TTI_DEBOUNCE.
-        let object_url = backend.object_url(&id)?;
+        let path = backend.object_path(&id);
         let old_deadline = SystemTime::now() + tti - TTI_DEBOUNCE - Duration::from_secs(60);
-        backend.update_custom_time(object_url, old_deadline).await?;
+        backend
+            .update_custom_time(&path, &metadata, old_deadline)
+            .await?;
 
         // First get_metadata sees the old timestamp and triggers a TTI bump.
         let pre_meta = backend.get_metadata(&id).await?.unwrap();

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -102,6 +102,22 @@ pub struct S3CompatibleConfig {
     /// - `OS__STORAGE__METADATA_PREFIX=x-goog-meta-`
     #[serde(default = "default_metadata_prefix")]
     pub metadata_prefix: String,
+
+    /// Protocol-level header prefix used for non-metadata request headers
+    /// like `{prefix}copy-source` and `{prefix}metadata-directive`.
+    ///
+    /// Override alongside [`metadata_prefix`](Self::metadata_prefix) when
+    /// targeting GCS's XML API (`x-goog-`).
+    ///
+    /// # Default
+    ///
+    /// `"x-amz-"`
+    ///
+    /// # Environment Variables
+    ///
+    /// - `OS__STORAGE__PROTOCOL_PREFIX=x-goog-`
+    #[serde(default = "default_protocol_prefix")]
+    pub protocol_prefix: String,
 }
 
 fn default_region() -> String {
@@ -114,6 +130,10 @@ fn default_use_path_style() -> bool {
 
 fn default_metadata_prefix() -> String {
     "x-amz-meta-".to_owned()
+}
+
+fn default_protocol_prefix() -> String {
+    "x-amz-".to_owned()
 }
 
 /// Time to debounce bumping an object with configured TTI.
@@ -153,6 +173,7 @@ pub struct S3CompatibleBackend<T> {
     endpoint: String,
     token_provider: Option<T>,
     metadata_prefix: String,
+    protocol_prefix: String,
     custom_time_header: String,
 }
 
@@ -206,6 +227,7 @@ impl<T> S3CompatibleBackend<T> {
             bucket,
             endpoint: config.endpoint,
             metadata_prefix: config.metadata_prefix,
+            protocol_prefix: config.protocol_prefix,
             custom_time_header,
             token_provider: None,
         })
@@ -213,19 +235,6 @@ impl<T> S3CompatibleBackend<T> {
 
     fn object_path(&self, id: &ObjectId) -> String {
         format!("/{}", id.as_storage_path())
-    }
-
-    /// Protocol-level header prefix corresponding to [`metadata_prefix`].
-    ///
-    /// Strips the trailing `meta-` suffix: `x-amz-meta-` → `x-amz-`,
-    /// `x-goog-meta-` → `x-goog-`. Used to build request-level headers like
-    /// `{prefix}copy-source` and `{prefix}metadata-directive`.
-    ///
-    /// [`metadata_prefix`]: S3CompatibleConfig::metadata_prefix
-    fn protocol_prefix(&self) -> &str {
-        self.metadata_prefix
-            .strip_suffix("meta-")
-            .unwrap_or(&self.metadata_prefix)
     }
 
     /// If `metadata` has a [`TimeToIdle`] policy and a
@@ -265,9 +274,8 @@ impl<T> S3CompatibleBackend<T> {
     /// Rewrites the object's metadata in place via a copy-with-REPLACE
     /// request. Used to bump the custom-time header for TTI objects.
     async fn update_metadata(&self, path: &str, metadata: &Metadata) -> Result<()> {
-        let protocol_prefix = self.protocol_prefix();
-        let copy_source_header = format!("{protocol_prefix}copy-source");
-        let metadata_directive_header = format!("{protocol_prefix}metadata-directive");
+        let copy_source_header = format!("{}copy-source", self.protocol_prefix);
+        let metadata_directive_header = format!("{}metadata-directive", self.protocol_prefix);
         let copy_source = format!("/{}{}", self.bucket.name(), path);
 
         let mut request = self
@@ -504,6 +512,7 @@ mod tests {
             region: default_region(),
             use_path_style: default_use_path_style(),
             metadata_prefix: default_metadata_prefix(),
+            protocol_prefix: default_protocol_prefix(),
         })
         .unwrap()
     }

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -414,11 +414,6 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
                 .map_err(|e| map_s3_error(e, "S3: failed to set content-encoding"))?;
         }
 
-        // All non-standard fields are emitted with the configured metadata
-        // prefix (e.g. `x-amz-meta-` or `x-goog-meta-`) via `with_header`.
-        // `with_metadata` is not used here because it hardcodes the S3
-        // prefix. Standard headers (Content-Type, Content-Encoding) are
-        // handled above.
         let headers =
             metadata_to_s3_headers(metadata, &self.metadata_prefix, &self.custom_time_header)
                 .map_err(Error::Metadata)?;
@@ -431,12 +426,11 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
                 cause: Some(Box::new(e)),
             })?;
             request = request
-                .with_header(name.clone(), value_str)
+                .with_header(name, value_str)
                 .map_err(|e| map_s3_error(e, "S3: failed to set object metadata"))?;
         }
 
         let mut reader = StreamReader::new(stream.map_err(io::Error::other));
-
         request
             .execute_stream(&mut reader)
             .await
@@ -572,6 +566,7 @@ mod tests {
         assert_eq!(meta.content_type, metadata.content_type);
         assert_eq!(meta.origin, metadata.origin);
         assert_eq!(meta.custom, metadata.custom);
+        assert!(metadata.time_created.is_some());
 
         Ok(())
     }
@@ -631,6 +626,65 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_streaming_upload() -> Result<()> {
+        let backend = create_test_backend();
+
+        let id = make_id();
+        let metadata = Metadata::default();
+
+        // rust-s3 dispatches to multipart uploads when the stream exceeds the
+        // 8 MiB chunk size. Use 20 MiB to ensure multiple parts are uploaded.
+        let chunk = bytes::Bytes::from(vec![0xab; 1024 * 1024]); // 1 MiB
+        let stream =
+            futures_util::stream::iter(std::iter::repeat_with(move || Ok(chunk.clone())).take(20))
+                .boxed();
+
+        backend.put_object(&id, &metadata, stream).await?;
+
+        let (meta, stream) = backend.get_object(&id).await?.unwrap();
+        let payload = stream::read_to_vec(stream).await?;
+
+        assert_eq!(payload.len(), 20 * 1024 * 1024);
+        assert!(payload.iter().all(|&b| b == 0xab));
+        assert_eq!(meta.size, Some(20 * 1024 * 1024));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_overwrite() -> Result<()> {
+        let backend = create_test_backend();
+
+        let id = make_id();
+        let metadata = Metadata {
+            custom: BTreeMap::from_iter([("invalid".into(), "invalid".into())]),
+            ..Default::default()
+        };
+
+        backend
+            .put_object(&id, &metadata, stream::single("hello"))
+            .await?;
+
+        let metadata = Metadata {
+            custom: BTreeMap::from_iter([("hello".into(), "world".into())]),
+            ..Default::default()
+        };
+
+        backend
+            .put_object(&id, &metadata, stream::single("world"))
+            .await?;
+
+        let (meta, stream) = backend.get_object(&id).await?.unwrap();
+
+        let payload = stream::read_to_vec(stream).await?;
+        let str_payload = str::from_utf8(&payload).unwrap();
+        assert_eq!(str_payload, "world");
+        assert_eq!(meta.custom, metadata.custom);
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_read_after_delete() -> Result<()> {
         let backend = create_test_backend();
 
@@ -642,6 +696,52 @@ mod tests {
             .await?;
 
         backend.delete_object(&id).await?;
+
+        let result = backend.get_object(&id).await?;
+        assert!(result.is_none());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_ttl_immediate() -> Result<()> {
+        // NB: We create a TTL that immediately expires in this tests. This might be optimized away
+        // in a future implementation, so we will have to update this test accordingly.
+
+        let backend = create_test_backend();
+
+        let id = make_id();
+        let metadata = Metadata {
+            expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_secs(0)),
+            ..Default::default()
+        };
+
+        backend
+            .put_object(&id, &metadata, stream::single("hello, world"))
+            .await?;
+
+        let result = backend.get_object(&id).await?;
+        assert!(result.is_none());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_tti_immediate() -> Result<()> {
+        // NB: We create a TTI that immediately expires in this tests. This might be optimized away
+        // in a future implementation, so we will have to update this test accordingly.
+
+        let backend = create_test_backend();
+
+        let id = make_id();
+        let metadata = Metadata {
+            expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_secs(0)),
+            ..Default::default()
+        };
+
+        backend
+            .put_object(&id, &metadata, stream::single("hello, world"))
+            .await?;
 
         let result = backend.get_object(&id).await?;
         assert!(result.is_none());
@@ -685,7 +785,85 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_metadata_bumps_tti() -> Result<()> {
+        let backend = create_test_backend();
+
+        let id = make_id();
+        // TTI must exceed TTI_DEBOUNCE (1 day) for the bump condition to be reachable.
+        let tti = Duration::from_secs(2 * 24 * 3600); // 2 days
+        let metadata = Metadata {
+            content_type: "text/plain".into(),
+            expiration_policy: ExpirationPolicy::TimeToIdle(tti),
+            ..Default::default()
+        };
+
+        backend
+            .put_object(&id, &metadata, stream::single("hello, world"))
+            .await?;
+
+        // Manually set custom_time to just inside the bump window.
+        // The bump condition is: expire_at < now + tti - TTI_DEBOUNCE.
+        let object_url = backend.object_url(&id)?;
+        let old_deadline = SystemTime::now() + tti - TTI_DEBOUNCE - Duration::from_secs(60);
+        backend.update_custom_time(object_url, old_deadline).await?;
+
+        // First get_metadata sees the old timestamp and triggers a TTI bump.
+        let pre_meta = backend.get_metadata(&id).await?.unwrap();
+        let pre_expiry = pre_meta.time_expires.unwrap();
+
+        // Second get_metadata sees the bumped timestamp.
+        let post_meta = backend.get_metadata(&id).await?.unwrap();
+        let post_expiry = post_meta.time_expires.unwrap();
+        assert!(
+            post_expiry > pre_expiry,
+            "TTI bump should have extended the expiry: {pre_expiry:?} -> {post_expiry:?}"
+        );
+
+        // Verify the payload is still intact after the bump.
+        let (_, stream) = backend.get_object(&id).await?.unwrap();
+        let payload = stream::read_to_vec(stream).await?;
+        assert_eq!(&payload, b"hello, world");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_get_metadata_does_not_bump_fresh_tti() -> Result<()> {
+        let backend = create_test_backend().await?;
+
+        let id = make_id();
+        // TTI must exceed TTI_DEBOUNCE (1 day) for the bump condition to be reachable.
+        let tti = Duration::from_secs(2 * 24 * 3600); // 2 days
+        let metadata = Metadata {
+            content_type: "text/plain".into(),
+            expiration_policy: ExpirationPolicy::TimeToIdle(tti),
+            ..Default::default()
+        };
+
+        backend
+            .put_object(&id, &metadata, stream::single("hello, world"))
+            .await?;
+
+        // A freshly written object has time_expires ≈ now + 2d, which is well outside
+        // the bump window (now + 2d - 1d = now + 1d). No bump should occur.
+        let first = backend.get_metadata(&id).await?.unwrap();
+        let first_expiry = first.time_expires.unwrap();
+
+        let second = backend.get_metadata(&id).await?.unwrap();
+        let second_expiry = second.time_expires.unwrap();
+
+        assert_eq!(
+            first_expiry, second_expiry,
+            "Fresh TTI object should not have its expiry bumped"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_compressed_payload_roundtrip() -> Result<()> {
+        use objectstore_types::metadata::Compression;
+
         let backend = create_test_backend();
 
         let plaintext = b"hello, world (but compressed with zstd)";
@@ -710,32 +888,6 @@ mod tests {
             payload, compressed,
             "Payload should be returned still compressed, not auto-decompressed"
         );
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_streaming_multipart_upload() -> Result<()> {
-        // rust-s3 dispatches to multipart uploads when the stream exceeds the
-        // 8 MiB chunk size. Use 20 MiB to ensure multiple parts are uploaded.
-        let backend = create_test_backend();
-
-        let id = make_id();
-        let metadata = Metadata::default();
-
-        let chunk = bytes::Bytes::from(vec![0xab; 1024 * 1024]); // 1 MiB
-        let stream =
-            futures_util::stream::iter(std::iter::repeat_with(move || Ok(chunk.clone())).take(20))
-                .boxed();
-
-        backend.put_object(&id, &metadata, stream).await?;
-
-        let (meta, stream) = backend.get_object(&id).await?.unwrap();
-        let payload = stream::read_to_vec(stream).await?;
-
-        assert_eq!(payload.len(), 20 * 1024 * 1024);
-        assert!(payload.iter().all(|&b| b == 0xab));
-        assert_eq!(meta.size, Some(20 * 1024 * 1024));
 
         Ok(())
     }

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -42,9 +42,8 @@ use crate::stream::{self, ClientStream};
 ///   use_path_style: false
 ///   metadata_prefix: x-amz-meta-
 ///   protocol_prefix: x-amz-
-///   auth:
-///     access_key_id: AKIAIOSFODNN7EXAMPLE
-///     secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+///   access_key_id: AKIAIOSFODNN7EXAMPLE
+///   secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct S3CompatibleConfig {
@@ -137,13 +136,19 @@ pub struct S3CompatibleConfig {
     #[serde(default)]
     pub custom_time_header: Option<String>,
 
-    /// Static credentials for S3 SigV4 authentication.
+    /// AWS access key ID (or equivalent for S3-compatible services).
     ///
     /// # Environment Variables
     ///
-    /// - `OS__STORAGE__AUTH__ACCESS_KEY_ID=…`
-    /// - `OS__STORAGE__AUTH__SECRET_ACCESS_KEY=…`
-    pub auth: AuthConfig,
+    /// - `OS__STORAGE__ACCESS_KEY_ID=…`
+    pub access_key_id: String,
+
+    /// AWS secret access key (or equivalent for S3-compatible services).
+    ///
+    /// # Environment Variables
+    ///
+    /// - `OS__STORAGE__SECRET_ACCESS_KEY=…`
+    pub secret_access_key: SecretBox<ConfigSecret>,
 }
 
 fn default_region() -> String {
@@ -160,15 +165,6 @@ fn default_metadata_prefix() -> String {
 
 fn default_protocol_prefix() -> String {
     "x-amz-".to_owned()
-}
-
-/// Static AWS-style credentials for S3 SigV4 authentication.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AuthConfig {
-    /// AWS access key ID (or equivalent for S3-compatible services).
-    pub access_key_id: String,
-    /// AWS secret access key (or equivalent for S3-compatible services).
-    pub secret_access_key: SecretBox<ConfigSecret>,
 }
 
 /// Time to debounce bumping an object with configured TTI.
@@ -224,8 +220,8 @@ impl S3CompatibleBackend {
     /// Creates a new S3-compatible backend bound to the given config.
     pub fn new(config: S3CompatibleConfig) -> anyhow::Result<Self> {
         let credentials = Credentials::new(
-            Some(&config.auth.access_key_id),
-            Some(config.auth.secret_access_key.expose_secret().as_str()),
+            Some(&config.access_key_id),
+            Some(config.secret_access_key.expose_secret().as_str()),
             None,
             None,
             None,
@@ -523,10 +519,8 @@ mod tests {
             metadata_prefix: default_metadata_prefix(),
             protocol_prefix: default_protocol_prefix(),
             custom_time_header: None,
-            auth: AuthConfig {
-                access_key_id: "minioadmin".into(),
-                secret_access_key: SecretBox::new(Box::new(ConfigSecret::from("minioadmin"))),
-            },
+            access_key_id: "minioadmin".into(),
+            secret_access_key: SecretBox::new(Box::new(ConfigSecret::from("minioadmin"))),
         })
         .unwrap()
     }

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -1,9 +1,11 @@
 //! Backend that can be used with any S3-compatible object store (Amazon S3, MinIO, R2, etc.).
 
+use std::io;
+use std::sync::Arc;
 use std::time::{Duration, SystemTime};
-use std::{fmt, io};
 
 use futures_util::{StreamExt, TryStreamExt};
+use gcp_auth::TokenProvider as _;
 use objectstore_types::metadata::{ExpirationPolicy, Metadata};
 use reqwest::header::{self, HeaderMap, HeaderName};
 use s3::Bucket;
@@ -13,12 +15,15 @@ use s3::error::S3Error;
 use s3::region::Region;
 use s3::request::Request as _;
 use s3::request::tokio_backend::ReqwestRequest;
+use secrecy::{ExposeSecret, SecretBox};
 use serde::{Deserialize, Serialize};
 use tokio_util::io::StreamReader;
 
 use crate::backend::common::{Backend, DeleteResponse, GetResponse, MetadataResponse, PutResponse};
 use crate::error::{Error, Result};
+use crate::gcp_auth::PrefetchingTokenProvider;
 use crate::id::ObjectId;
+use crate::secret::ConfigSecret;
 use crate::stream::{self, ClientStream};
 
 /// Configuration for [`S3CompatibleBackend`].
@@ -133,6 +138,19 @@ pub struct S3CompatibleConfig {
     /// - `OS__STORAGE__CUSTOM_TIME_HEADER=x-goog-custom-time`
     #[serde(default)]
     pub custom_time_header: Option<String>,
+
+    /// Optional static credentials for S3 SigV4 authentication.
+    ///
+    /// When set, the backend uses these credentials for signing requests
+    /// instead of the default credential chain. When unset, falls back to
+    /// anonymous (unauthenticated) requests.
+    ///
+    /// # Environment Variables
+    ///
+    /// - `OS__STORAGE__AUTH__ACCESS_KEY_ID=…`
+    /// - `OS__STORAGE__AUTH__SECRET_ACCESS_KEY=…`
+    #[serde(default)]
+    pub auth: Option<AuthConfig>,
 }
 
 fn default_region() -> String {
@@ -151,45 +169,26 @@ fn default_protocol_prefix() -> String {
     "x-amz-".to_owned()
 }
 
+/// Static AWS-style credentials for S3 SigV4 authentication.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthConfig {
+    /// AWS access key ID (or equivalent for S3-compatible services).
+    pub access_key_id: String,
+    /// AWS secret access key (or equivalent for S3-compatible services).
+    pub secret_access_key: SecretBox<ConfigSecret>,
+}
+
 /// Time to debounce bumping an object with configured TTI.
 const TTI_DEBOUNCE: Duration = Duration::from_secs(24 * 3600); // 1 day
 
-/// An authentication token that can be passed as a bearer credential.
-pub trait Token: Send + Sync {
-    /// Returns the token string.
-    fn as_str(&self) -> &str;
-}
-
-/// Provides authentication tokens for S3-compatible requests.
-pub trait TokenProvider: Send + Sync + 'static {
-    /// Returns a fresh token, fetching or refreshing it as needed.
-    fn get_token(&self) -> impl Future<Output = anyhow::Result<impl Token>> + Send;
-}
-
-/// Placeholder [`TokenProvider`] for unauthenticated backends.
+/// S3-compatible storage backend.
 #[derive(Debug)]
-pub struct NoToken;
-
-impl TokenProvider for NoToken {
-    #[allow(refining_impl_trait)]
-    async fn get_token(&self) -> anyhow::Result<NoToken> {
-        unimplemented!()
-    }
-}
-impl Token for NoToken {
-    fn as_str(&self) -> &str {
-        unimplemented!()
-    }
-}
-
-/// S3-compatible storage backend with pluggable authentication.
-pub struct S3CompatibleBackend<T> {
+pub struct S3CompatibleBackend {
     bucket: Box<Bucket>,
-    endpoint: String,
-    token_provider: Option<T>,
     metadata_prefix: String,
     protocol_prefix: String,
     custom_time_header: Option<String>,
+    bearer_auth_provider: Option<Arc<PrefetchingTokenProvider>>,
 }
 
 /// Wraps [`Metadata::to_headers`], additionally echoing `time_expires` under
@@ -216,16 +215,48 @@ fn metadata_from_headers(headers: &HeaderMap, prefix: &str) -> Result<Metadata> 
     Ok(metadata)
 }
 
-impl<T> S3CompatibleBackend<T> {
-    /// Creates a new S3-compatible backend bound to the given config and token provider.
-    pub fn new(config: S3CompatibleConfig, token_provider: T) -> anyhow::Result<Self> {
-        let mut this = Self::from_config(config)?;
-        this.token_provider = Some(token_provider);
-        Ok(this)
+/// Maps an [`S3Error`] to our [`Error`] type with the given context.
+fn map_s3_error(error: S3Error, context: &str) -> Error {
+    Error::Generic {
+        context: context.to_owned(),
+        cause: Some(Box::new(error)),
+    }
+}
+
+/// Returns `true` if `error` is an HTTP 404 from rust-s3.
+fn is_not_found(error: &S3Error) -> bool {
+    matches!(error, S3Error::HttpFailWithBody(404, _))
+}
+
+impl S3CompatibleBackend {
+    /// Creates a new S3-compatible backend bound to the given config.
+    pub fn new(config: S3CompatibleConfig) -> anyhow::Result<Self> {
+        Self::from_config(config)
+    }
+
+    /// Creates a new S3-compatible backend bound to the given config and bearer auth provider.
+    pub fn new_with_bearer_auth(
+        config: S3CompatibleConfig,
+        bearer_auth_provider: Arc<PrefetchingTokenProvider>,
+    ) -> anyhow::Result<Self> {
+        let mut slf = Self::from_config(config)?;
+        slf.bearer_auth_provider = Some(bearer_auth_provider);
+        Ok(slf)
     }
 
     fn from_config(config: S3CompatibleConfig) -> anyhow::Result<Self> {
-        let credentials = Credentials::default().or_else(|_| Credentials::anonymous())?;
+        let credentials = config
+            .auth
+            .map(|auth| {
+                Credentials::new(
+                    Some(&auth.access_key_id),
+                    Some(auth.secret_access_key.expose_secret().as_str()),
+                    None,
+                    None,
+                    None,
+                )
+            })
+            .unwrap_or_else(Credentials::anonymous)?;
 
         let region = Region::Custom {
             region: config.region,
@@ -239,12 +270,37 @@ impl<T> S3CompatibleBackend<T> {
 
         Ok(Self {
             bucket,
-            endpoint: config.endpoint,
             metadata_prefix: config.metadata_prefix,
             protocol_prefix: config.protocol_prefix,
             custom_time_header: config.custom_time_header,
-            token_provider: None,
+            bearer_auth_provider: None,
         })
+    }
+
+    /// Returns a bucket with a fresh `Authorization: Bearer` header when a
+    /// bearer auth provider is configured.
+    async fn authed_bucket(&self) -> Result<Box<Bucket>> {
+        let Some(provider) = &self.bearer_auth_provider else {
+            return Ok(self.bucket.clone());
+        };
+        let token = provider.token(&[]).await.map_err(|e| Error::Generic {
+            context: "S3: failed to get bearer token".to_owned(),
+            cause: Some(Box::new(e)),
+        })?;
+        let mut headers = self.bucket.extra_headers().clone();
+        headers.insert(
+            header::AUTHORIZATION,
+            format!("Bearer {}", token.as_str()).parse().map_err(
+                |e: header::InvalidHeaderValue| Error::Generic {
+                    context: "S3: invalid bearer token value".to_owned(),
+                    cause: Some(Box::new(e)),
+                },
+            )?,
+        );
+        self.bucket
+            .with_extra_headers(headers)
+            .map(Box::new)
+            .map_err(|e| map_s3_error(e, "S3: failed to set auth headers"))
     }
 
     fn object_path(&self, id: &ObjectId) -> String {
@@ -256,7 +312,12 @@ impl<T> S3CompatibleBackend<T> {
     /// the 1-day debounce window.
     ///
     /// [`TimeToIdle`]: objectstore_types::metadata::ExpirationPolicy::TimeToIdle
-    async fn bump_tti_if_needed(&self, path: &str, metadata: &Metadata) -> Result<()> {
+    async fn bump_tti_if_needed(
+        &self,
+        bucket: &Bucket,
+        path: &str,
+        metadata: &Metadata,
+    ) -> Result<()> {
         let ExpirationPolicy::TimeToIdle(tti) = metadata.expiration_policy else {
             return Ok(());
         };
@@ -273,7 +334,8 @@ impl<T> S3CompatibleBackend<T> {
 
         if bump_amount > TTI_DEBOUNCE {
             // TODO: Schedule into background persistently so this doesn't get lost on restarts.
-            self.update_custom_time(path, metadata, new_expiry).await?;
+            self.update_custom_time(bucket, path, metadata, new_expiry)
+                .await?;
         }
 
         Ok(())
@@ -287,16 +349,16 @@ impl<T> S3CompatibleBackend<T> {
     /// [`custom_time_header`]: S3CompatibleConfig::custom_time_header
     async fn update_custom_time(
         &self,
+        bucket: &Bucket,
         path: &str,
         metadata: &Metadata,
         custom_time: SystemTime,
     ) -> Result<()> {
         let copy_source_header = format!("{}copy-source", self.protocol_prefix);
         let metadata_directive_header = format!("{}metadata-directive", self.protocol_prefix);
-        let copy_source = format!("/{}{}", self.bucket.name(), path);
+        let copy_source = format!("/{}{}", bucket.name(), path);
 
-        let mut request = self
-            .bucket
+        let mut request = bucket
             .put_object_builder(path, &[])
             .with_content_type(metadata.content_type.as_ref())
             .with_header(&copy_source_header, copy_source)
@@ -342,8 +404,8 @@ impl<T> S3CompatibleBackend<T> {
     /// HEADs an object, filters expired entries, and bumps TTI.
     ///
     /// Returns `None` if the object is absent or past its expiry.
-    async fn fetch_live_metadata(&self, path: &str) -> Result<Option<Metadata>> {
-        let Some(headers) = self.head_object(path).await? else {
+    async fn fetch_live_metadata(&self, bucket: &Bucket, path: &str) -> Result<Option<Metadata>> {
+        let Some(headers) = self.head_object(bucket, path).await? else {
             return Ok(None);
         };
         let metadata = metadata_from_headers(&headers, &self.metadata_prefix)?;
@@ -358,7 +420,7 @@ impl<T> S3CompatibleBackend<T> {
             return Ok(None);
         }
 
-        self.bump_tti_if_needed(path, &metadata).await?;
+        self.bump_tti_if_needed(bucket, path, &metadata).await?;
         Ok(Some(metadata))
     }
 
@@ -366,8 +428,8 @@ impl<T> S3CompatibleBackend<T> {
     ///
     /// `Bucket::head_object` is not sufficient because it only surfaces
     /// `x-amz-meta-*` keys, which could be different from `self.metadata_prefix`.
-    async fn head_object(&self, path: &str) -> Result<Option<HeaderMap>> {
-        let request = ReqwestRequest::new(&self.bucket, path, Command::HeadObject)
+    async fn head_object(&self, bucket: &Bucket, path: &str) -> Result<Option<HeaderMap>> {
+        let request = ReqwestRequest::new(bucket, path, Command::HeadObject)
             .await
             .map_err(|e| map_s3_error(e, "S3: failed to build head request"))?;
 
@@ -382,40 +444,8 @@ impl<T> S3CompatibleBackend<T> {
     }
 }
 
-impl S3CompatibleBackend<NoToken> {
-    /// Creates a new S3-compatible backend that sends unauthenticated requests.
-    pub fn without_token(config: S3CompatibleConfig) -> anyhow::Result<Self> {
-        Self::from_config(config)
-    }
-}
-
-impl<T> fmt::Debug for S3CompatibleBackend<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("S3CompatibleBackend")
-            .field("bucket", &self.bucket)
-            .field("endpoint", &self.endpoint)
-            .field("metadata_prefix", &self.metadata_prefix)
-            .field("protocol_prefix", &self.protocol_prefix)
-            .field("custom_time_header", &self.custom_time_header)
-            .finish_non_exhaustive()
-    }
-}
-
-/// Maps an [`S3Error`] to our [`Error`] type with the given context.
-fn map_s3_error(error: S3Error, context: &str) -> Error {
-    Error::Generic {
-        context: context.to_owned(),
-        cause: Some(Box::new(error)),
-    }
-}
-
-/// Returns `true` if `error` is an HTTP 404 from rust-s3.
-fn is_not_found(error: &S3Error) -> bool {
-    matches!(error, S3Error::HttpFailWithBody(404, _))
-}
-
 #[async_trait::async_trait]
-impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
+impl Backend for S3CompatibleBackend {
     fn name(&self) -> &'static str {
         "s3_compatible"
     }
@@ -428,10 +458,10 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
         stream: ClientStream,
     ) -> Result<PutResponse> {
         objectstore_log::debug!("Writing to s3_compatible backend");
+        let bucket = self.authed_bucket().await?;
         let path = self.object_path(id);
 
-        let mut request = self
-            .bucket
+        let mut request = bucket
             .put_object_stream_builder(&path)
             .with_content_type(metadata.content_type.as_ref());
 
@@ -482,13 +512,14 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
     #[tracing::instrument(level = "trace", fields(?id), skip_all)]
     async fn get_object(&self, id: &ObjectId) -> Result<GetResponse> {
         objectstore_log::debug!("Reading from s3_compatible backend");
+        let bucket = self.authed_bucket().await?;
         let path = self.object_path(id);
 
-        let Some(metadata) = self.fetch_live_metadata(&path).await? else {
+        let Some(metadata) = self.fetch_live_metadata(&bucket, &path).await? else {
             return Ok(None);
         };
 
-        let response = match self.bucket.get_object_stream(&path).await {
+        let response = match bucket.get_object_stream(&path).await {
             Ok(response) => response,
             Err(ref e) if is_not_found(e) => {
                 // Object was deleted between HEAD and GET; treat as missing.
@@ -505,16 +536,18 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
     #[tracing::instrument(level = "trace", fields(?id), skip_all)]
     async fn get_metadata(&self, id: &ObjectId) -> Result<MetadataResponse> {
         objectstore_log::debug!("Reading metadata from s3_compatible backend");
+        let bucket = self.authed_bucket().await?;
         let path = self.object_path(id);
-        self.fetch_live_metadata(&path).await
+        self.fetch_live_metadata(&bucket, &path).await
     }
 
     #[tracing::instrument(level = "trace", fields(?id), skip_all)]
     async fn delete_object(&self, id: &ObjectId) -> Result<DeleteResponse> {
         objectstore_log::debug!("Deleting from s3_compatible backend");
+        let bucket = self.authed_bucket().await?;
         let path = self.object_path(id);
 
-        match self.bucket.delete_object(&path).await {
+        match bucket.delete_object(&path).await {
             Ok(_) => Ok(()),
             Err(ref e) if is_not_found(e) => {
                 objectstore_log::debug!("Object not found");
@@ -544,8 +577,8 @@ mod tests {
     //
     // Refer to the readme for how to set up MinIO via devservices.
 
-    fn create_test_backend() -> S3CompatibleBackend<NoToken> {
-        S3CompatibleBackend::without_token(S3CompatibleConfig {
+    fn create_test_backend() -> S3CompatibleBackend {
+        S3CompatibleBackend::new(S3CompatibleConfig {
             endpoint: "http://localhost:8089".into(),
             bucket: "test-bucket".into(),
             region: default_region(),
@@ -553,6 +586,7 @@ mod tests {
             metadata_prefix: default_metadata_prefix(),
             protocol_prefix: default_protocol_prefix(),
             custom_time_header: None,
+            auth: None,
         })
         .unwrap()
     }
@@ -799,7 +833,7 @@ mod tests {
         let path = backend.object_path(&id);
         let old_deadline = SystemTime::now() + tti - TTI_DEBOUNCE - Duration::from_secs(60);
         backend
-            .update_custom_time(&path, &metadata, old_deadline)
+            .update_custom_time(&backend.bucket, &path, &metadata, old_deadline)
             .await?;
 
         // First get_metadata sees the old timestamp and triggers a TTI bump.

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -347,6 +347,9 @@ impl<T> fmt::Debug for S3CompatibleBackend<T> {
         f.debug_struct("S3CompatibleBackend")
             .field("bucket", &self.bucket)
             .field("endpoint", &self.endpoint)
+            .field("metadata_prefix", &self.metadata_prefix)
+            .field("protocol_prefix", &self.protocol_prefix)
+            .field("custom_time_header", &self.custom_time_header)
             .finish_non_exhaustive()
     }
 }

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -270,13 +270,18 @@ impl<T> S3CompatibleBackend<T> {
         // TODO: Inject the access time from the request.
         let access_time = SystemTime::now();
 
-        let expire_at = headers
+        let current_expiry = headers
             .get(self.custom_time_header.as_str())
             .and_then(|v| v.to_str().ok())
             .and_then(|s| humantime::parse_rfc3339(s).ok())
             .unwrap_or(access_time);
+        let new_expiry = access_time + tti;
 
-        if expire_at < access_time + tti - TTI_DEBOUNCE {
+        let bump_amount = new_expiry
+            .duration_since(current_expiry)
+            .unwrap_or_default();
+
+        if bump_amount > TTI_DEBOUNCE {
             // TODO: Schedule into background persistently so this doesn't get lost on restarts.
             self.update_metadata(path, metadata).await?;
         }

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -41,7 +41,6 @@ use crate::stream::{self, ClientStream};
 ///   region: us-east-1
 ///   use_path_style: false
 ///   metadata_prefix: x-amz-meta-
-///   custom_time_header: x-amz-meta-expiry
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct S3CompatibleConfig {
@@ -103,27 +102,6 @@ pub struct S3CompatibleConfig {
     /// - `OS__STORAGE__METADATA_PREFIX=x-goog-meta-`
     #[serde(default = "default_metadata_prefix")]
     pub metadata_prefix: String,
-
-    /// Header used to store the object's expiration timestamp.
-    ///
-    /// When set, the backend writes the resolved expiration time to this
-    /// header on PUT, and on reads with a [`TimeToIdle`] policy it bumps the
-    /// timestamp (via copy-in-place with a metadata-directive REPLACE) when
-    /// the recorded expiry is older than `now + tti - TTI_DEBOUNCE`.
-    ///
-    /// Defaults to `x-amz-meta-expiry`, which results in the
-    /// timestamp being stored as plain user metadata on any S3-compatible
-    /// backend.
-    ///
-    /// # Default
-    ///
-    /// `"x-amz-meta-expiry"`
-    ///
-    /// # Environment Variables
-    ///
-    /// - `OS__STORAGE__CUSTOM_TIME_HEADER=x-goog-custom-time`
-    #[serde(default = "default_custom_time_header")]
-    pub custom_time_header: String,
 }
 
 fn default_region() -> String {
@@ -136,10 +114,6 @@ fn default_use_path_style() -> bool {
 
 fn default_metadata_prefix() -> String {
     "x-amz-meta-".to_owned()
-}
-
-fn default_custom_time_header() -> String {
-    "x-amz-meta-expiry".to_owned()
 }
 
 /// Time to debounce bumping an object with configured TTI.
@@ -182,6 +156,29 @@ pub struct S3CompatibleBackend<T> {
     custom_time_header: String,
 }
 
+/// Wraps [`Metadata::to_headers`] with S3-specific concerns.
+fn metadata_to_s3_headers(
+    metadata: &Metadata,
+    prefix: &str,
+    custom_time_header: &str,
+) -> Result<HeaderMap, objectstore_types::metadata::Error> {
+    let mut headers = metadata.to_headers(prefix)?;
+    if let Some(expires_in) = metadata.expiration_policy.expires_in() {
+        let expires_at = humantime::format_rfc3339_seconds(SystemTime::now() + expires_in);
+        let name = HeaderName::try_from(custom_time_header)?;
+        headers.append(name, expires_at.to_string().parse()?);
+    }
+    Ok(headers)
+}
+
+fn metadata_from_headers(headers: &HeaderMap, prefix: &str) -> Result<Metadata> {
+    let mut metadata = Metadata::from_headers(headers, prefix)?;
+    metadata.size = headers
+        .get(header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok()?.parse::<usize>().ok());
+    Ok(metadata)
+}
+
 impl<T> S3CompatibleBackend<T> {
     /// Creates a new S3-compatible backend bound to the given config and token provider.
     pub fn new(config: S3CompatibleConfig, token_provider: T) -> anyhow::Result<Self> {
@@ -203,11 +200,13 @@ impl<T> S3CompatibleBackend<T> {
             bucket.set_path_style();
         }
 
+        let custom_time_header = format!("{}expiry", config.metadata_prefix);
+
         Ok(Self {
             bucket,
             endpoint: config.endpoint,
             metadata_prefix: config.metadata_prefix,
-            custom_time_header: config.custom_time_header,
+            custom_time_header,
             token_provider: None,
         })
     }
@@ -354,33 +353,6 @@ fn map_s3_error(error: S3Error, context: &str) -> Error {
         context: context.to_owned(),
         cause: Some(Box::new(error)),
     }
-}
-
-/// Parses a response [`HeaderMap`] into our [`Metadata`], delegating the
-/// prefix-stripping logic to [`Metadata::from_headers`].
-fn metadata_from_headers(headers: &HeaderMap, prefix: &str) -> Result<Metadata> {
-    let mut metadata = Metadata::from_headers(headers, prefix)?;
-    metadata.size = headers
-        .get(header::CONTENT_LENGTH)
-        .and_then(|v| v.to_str().ok()?.parse::<usize>().ok());
-    Ok(metadata)
-}
-
-/// Wraps [`Metadata::to_headers`] with S3-specific concerns: appends the
-/// `custom_time_header` carrying the resolved expiration timestamp when the
-/// object has a TTL or TTI policy.
-fn metadata_to_s3_headers(
-    metadata: &Metadata,
-    prefix: &str,
-    custom_time_header: &str,
-) -> Result<HeaderMap, objectstore_types::metadata::Error> {
-    let mut headers = metadata.to_headers(prefix)?;
-    if let Some(expires_in) = metadata.expiration_policy.expires_in() {
-        let expires_at = humantime::format_rfc3339_seconds(SystemTime::now() + expires_in);
-        let name = HeaderName::try_from(custom_time_header)?;
-        headers.append(name, expires_at.to_string().parse()?);
-    }
-    Ok(headers)
 }
 
 /// Returns `true` if `error` is an HTTP 404 from rust-s3.
@@ -532,7 +504,6 @@ mod tests {
             region: default_region(),
             use_path_style: default_use_path_style(),
             metadata_prefix: default_metadata_prefix(),
-            custom_time_header: default_custom_time_header(),
         })
         .unwrap()
     }

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -1,9 +1,10 @@
 //! Backend that can be used with any S3-compatible object store (Amazon S3, MinIO, R2, etc.).
 
+use std::time::{Duration, SystemTime};
 use std::{fmt, io};
 
 use futures_util::{StreamExt, TryStreamExt};
-use objectstore_types::metadata::Metadata;
+use objectstore_types::metadata::{ExpirationPolicy, Metadata};
 use reqwest::header::{self, HeaderMap};
 use s3::Bucket;
 use s3::command::Command;
@@ -99,6 +100,31 @@ pub struct S3CompatibleConfig {
     /// - `OS__STORAGE__METADATA_PREFIX=x-goog-meta-`
     #[serde(default = "default_metadata_prefix")]
     pub metadata_prefix: String,
+
+    /// Header used to store the object's expiration timestamp.
+    ///
+    /// When set, the backend writes the resolved expiration time to this
+    /// header on PUT, and on reads with a [`TimeToIdle`] policy it bumps the
+    /// timestamp (via copy-in-place with a metadata-directive REPLACE) when
+    /// the recorded expiry is older than `now + tti - 1 day`.
+    ///
+    /// Defaults to `x-goog-custom-time` — the header the [GCS XML API]
+    /// interprets in conjunction with a `daysSinceCustomTime` lifecycle
+    /// rule. AWS S3 has no equivalent mechanism and will ignore the header.
+    /// Set to `None` on those deployments to disable the feature entirely.
+    ///
+    /// # Default
+    ///
+    /// `Some("x-goog-custom-time")`
+    ///
+    /// # Environment Variables
+    ///
+    /// - `OS__STORAGE__CUSTOM_TIME_HEADER=x-goog-custom-time`
+    ///
+    /// [`TimeToIdle`]: objectstore_types::metadata::ExpirationPolicy::TimeToIdle
+    /// [GCS XML API]: https://docs.cloud.google.com/storage/docs/xml-api/reference-headers#xgoogcustomtime
+    #[serde(default = "default_custom_time_header")]
+    pub custom_time_header: Option<String>,
 }
 
 fn default_region() -> String {
@@ -112,6 +138,13 @@ fn default_use_path_style() -> bool {
 fn default_metadata_prefix() -> String {
     "x-amz-meta-".to_owned()
 }
+
+fn default_custom_time_header() -> Option<String> {
+    Some("x-goog-custom-time".to_owned())
+}
+
+/// Time to debounce bumping an object with configured TTI.
+const TTI_DEBOUNCE: Duration = Duration::from_secs(24 * 3600); // 1 day
 
 /// An authentication token that can be passed as a bearer credential.
 pub trait Token: Send + Sync {
@@ -147,6 +180,7 @@ pub struct S3CompatibleBackend<T> {
     endpoint: String,
     token_provider: Option<T>,
     metadata_prefix: String,
+    custom_time_header: Option<String>,
 }
 
 impl<T> S3CompatibleBackend<T> {
@@ -174,12 +208,119 @@ impl<T> S3CompatibleBackend<T> {
             bucket,
             endpoint: config.endpoint,
             metadata_prefix: config.metadata_prefix,
+            custom_time_header: config.custom_time_header,
             token_provider: None,
         })
     }
 
     fn object_path(&self, id: &ObjectId) -> String {
         format!("/{}", id.as_storage_path())
+    }
+
+    /// Protocol-level header prefix corresponding to [`metadata_prefix`].
+    ///
+    /// Strips the trailing `meta-` suffix: `x-amz-meta-` → `x-amz-`,
+    /// `x-goog-meta-` → `x-goog-`. Used to build request-level headers like
+    /// `{prefix}copy-source` and `{prefix}metadata-directive`.
+    ///
+    /// [`metadata_prefix`]: S3CompatibleConfig::metadata_prefix
+    fn protocol_prefix(&self) -> &str {
+        self.metadata_prefix
+            .strip_suffix("meta-")
+            .unwrap_or(&self.metadata_prefix)
+    }
+
+    /// If `metadata` has a [`TimeToIdle`] policy and a
+    /// [`custom_time_header`] is configured, bumps the recorded expiry via a
+    /// metadata-only copy-in-place when it would otherwise fall outside the
+    /// 1-day debounce window.
+    ///
+    /// [`TimeToIdle`]: objectstore_types::metadata::ExpirationPolicy::TimeToIdle
+    /// [`custom_time_header`]: S3CompatibleConfig::custom_time_header
+    async fn bump_tti_if_needed(
+        &self,
+        path: &str,
+        headers: &HeaderMap,
+        metadata: &Metadata,
+    ) -> Result<()> {
+        let Some(custom_time_header) = &self.custom_time_header else {
+            return Ok(());
+        };
+        let ExpirationPolicy::TimeToIdle(tti) = metadata.expiration_policy else {
+            return Ok(());
+        };
+
+        // TODO: Inject the access time from the request.
+        let access_time = SystemTime::now();
+
+        let expire_at = headers
+            .get(custom_time_header.as_str())
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| humantime::parse_rfc3339(s).ok())
+            .unwrap_or(access_time);
+
+        if expire_at < access_time + tti - TTI_DEBOUNCE {
+            // TODO: Schedule into background persistently so this doesn't get lost on restarts.
+            self.update_metadata(path, metadata).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Rewrites the object's metadata in place via a copy-with-REPLACE
+    /// request. Used to bump the custom-time header for TTI objects.
+    async fn update_metadata(&self, path: &str, metadata: &Metadata) -> Result<()> {
+        let protocol_prefix = self.protocol_prefix();
+        let copy_source_header = format!("{protocol_prefix}copy-source");
+        let metadata_directive_header = format!("{protocol_prefix}metadata-directive");
+        let copy_source = format!("/{}{}", self.bucket.name(), path);
+
+        let mut request = self
+            .bucket
+            .put_object_builder(path, &[])
+            .with_content_type(metadata.content_type.as_ref())
+            .with_header(&copy_source_header, copy_source)
+            .map_err(|e| map_s3_error(e, "S3: failed to set copy-source header"))?
+            .with_header(&metadata_directive_header, "REPLACE")
+            .map_err(|e| map_s3_error(e, "S3: failed to set metadata-directive header"))?;
+
+        if let Some(compression) = metadata.compression {
+            request = request
+                .with_content_encoding(compression.as_str())
+                .map_err(|e| map_s3_error(e, "S3: failed to set content-encoding"))?;
+        }
+
+        let headers = metadata
+            .to_headers(&self.metadata_prefix)
+            .map_err(Error::Metadata)?;
+        for (name, value) in &headers {
+            if name == header::CONTENT_TYPE || name == header::CONTENT_ENCODING {
+                continue;
+            }
+            let value_str = value.to_str().map_err(|e| Error::Generic {
+                context: format!("S3: non-ascii metadata header value for {name}"),
+                cause: Some(Box::new(e)),
+            })?;
+            request = request
+                .with_header(name.as_str(), value_str)
+                .map_err(|e| map_s3_error(e, "S3: failed to set object metadata"))?;
+        }
+
+        if let Some(custom_time_header) = &self.custom_time_header
+            && let Some(expires_in) = metadata.expiration_policy.expires_in()
+        {
+            let expires_at = humantime::format_rfc3339_seconds(SystemTime::now() + expires_in);
+            request = request
+                .with_header(custom_time_header, expires_at.to_string())
+                .map_err(|e| map_s3_error(e, "S3: failed to set custom time header"))?;
+        }
+
+        request
+            .execute()
+            .await
+            .map_err(|e| map_s3_error(e, "S3: failed to update object metadata"))?;
+
+        Ok(())
     }
 
     /// Issues a HEAD request and returns the raw response headers.
@@ -291,6 +432,21 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
                 .map_err(|e| map_s3_error(e, "S3: failed to set object metadata"))?;
         }
 
+        if let Some(custom_time_header) = &self.custom_time_header
+            && let Some(expires_in) = metadata.expiration_policy.expires_in()
+        {
+            let expires_at = humantime::format_rfc3339_seconds(SystemTime::now() + expires_in);
+            let name = reqwest::header::HeaderName::try_from(custom_time_header).map_err(|e| {
+                Error::Generic {
+                    context: format!("S3: invalid custom time header name: {custom_time_header:?}"),
+                    cause: Some(Box::new(e)),
+                }
+            })?;
+            request = request
+                .with_header(name, expires_at.to_string())
+                .map_err(|e| map_s3_error(e, "S3: failed to set custom time header"))?;
+        }
+
         let mut reader = StreamReader::new(stream.map_err(io::Error::other));
 
         request
@@ -316,6 +472,7 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
             return Ok(None);
         };
         let metadata = metadata_from_headers(&headers, &self.metadata_prefix)?;
+        self.bump_tti_if_needed(&path, &headers, &metadata).await?;
 
         let response = match self.bucket.get_object_stream(&path).await {
             Ok(response) => response,
@@ -339,10 +496,9 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
         let Some(headers) = self.raw_head(&path).await? else {
             return Ok(None);
         };
-        Ok(Some(metadata_from_headers(
-            &headers,
-            &self.metadata_prefix,
-        )?))
+        let metadata = metadata_from_headers(&headers, &self.metadata_prefix)?;
+        self.bump_tti_if_needed(&path, &headers, &metadata).await?;
+        Ok(Some(metadata))
     }
 
     #[tracing::instrument(level = "trace", fields(?id), skip_all)]
@@ -387,6 +543,7 @@ mod tests {
             region: default_region(),
             use_path_style: default_use_path_style(),
             metadata_prefix: default_metadata_prefix(),
+            custom_time_header: default_custom_time_header(),
         })
         .unwrap()
     }

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -339,6 +339,29 @@ impl<T> S3CompatibleBackend<T> {
         Ok(())
     }
 
+    /// HEADs an object, filters expired entries, and bumps TTI.
+    ///
+    /// Returns `None` if the object is absent or past its expiry.
+    async fn fetch_live_metadata(&self, path: &str) -> Result<Option<Metadata>> {
+        let Some(headers) = self.head_object(path).await? else {
+            return Ok(None);
+        };
+        let metadata = metadata_from_headers(&headers, &self.metadata_prefix)?;
+
+        // Filter already expired objects but leave them to garbage collection.
+        if metadata.expiration_policy.is_timeout()
+            && metadata
+                .time_expires
+                .is_some_and(|ts| ts < SystemTime::now())
+        {
+            objectstore_log::debug!("Object found but past expiry");
+            return Ok(None);
+        }
+
+        self.bump_tti_if_needed(path, &metadata).await?;
+        Ok(Some(metadata))
+    }
+
     /// Issues a HEAD request and returns the raw response headers.
     ///
     /// `Bucket::head_object` is not sufficient because it only surfaces
@@ -461,21 +484,9 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
         objectstore_log::debug!("Reading from s3_compatible backend");
         let path = self.object_path(id);
 
-        let Some(headers) = self.head_object(&path).await? else {
+        let Some(metadata) = self.fetch_live_metadata(&path).await? else {
             return Ok(None);
         };
-        let metadata = metadata_from_headers(&headers, &self.metadata_prefix)?;
-
-        // Filter already expired objects but leave them to garbage collection.
-        let access_time = SystemTime::now();
-        if metadata.expiration_policy.is_timeout()
-            && metadata.time_expires.is_some_and(|ts| ts < access_time)
-        {
-            objectstore_log::debug!("Object found but past expiry");
-            return Ok(None);
-        }
-
-        self.bump_tti_if_needed(&path, &metadata).await?;
 
         let response = match self.bucket.get_object_stream(&path).await {
             Ok(response) => response,
@@ -495,23 +506,7 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
     async fn get_metadata(&self, id: &ObjectId) -> Result<MetadataResponse> {
         objectstore_log::debug!("Reading metadata from s3_compatible backend");
         let path = self.object_path(id);
-
-        let Some(headers) = self.head_object(&path).await? else {
-            return Ok(None);
-        };
-        let metadata = metadata_from_headers(&headers, &self.metadata_prefix)?;
-
-        // Filter already expired objects but leave them to garbage collection.
-        let access_time = SystemTime::now();
-        if metadata.expiration_policy.is_timeout()
-            && metadata.time_expires.is_some_and(|ts| ts < access_time)
-        {
-            objectstore_log::debug!("Object found but past expiry");
-            return Ok(None);
-        }
-
-        self.bump_tti_if_needed(&path, &metadata).await?;
-        Ok(Some(metadata))
+        self.fetch_live_metadata(&path).await
     }
 
     #[tracing::instrument(level = "trace", fields(?id), skip_all)]

--- a/objectstore-service/src/lib.rs
+++ b/objectstore-service/src/lib.rs
@@ -8,6 +8,7 @@ pub mod error;
 mod gcp_auth;
 pub mod id;
 pub mod multipart;
+pub mod secret;
 pub mod service;
 pub mod stream;
 pub mod streaming;

--- a/objectstore-service/src/lib.rs
+++ b/objectstore-service/src/lib.rs
@@ -7,6 +7,7 @@ mod concurrency;
 pub mod error;
 mod gcp_auth;
 pub mod id;
+pub mod multipart;
 pub mod service;
 pub mod stream;
 pub mod streaming;

--- a/objectstore-service/src/multipart.rs
+++ b/objectstore-service/src/multipart.rs
@@ -1,0 +1,66 @@
+//! Shared types for Objectstore's multipart upload protocol.
+
+use std::time::SystemTime;
+
+/// Identifier for an in-progress multipart upload.
+pub type UploadId = String;
+/// 1-indexed position of a part within its multipart upload.
+pub type PartNumber = u32;
+/// Opaque per-part identifier returned by the backend after a successful part upload.
+pub type ETag = String;
+
+/// Description of one part in the response to
+/// [`MultipartUploadBackend::list_parts`](crate::backend::common::MultipartUploadBackend::list_parts).
+#[derive(Clone, Debug)]
+pub struct PartInfo {
+    /// 1-indexed position of this part within the upload.
+    pub part_number: PartNumber,
+    /// Identifier returned when the part was uploaded.
+    pub etag: ETag,
+    /// Server-recorded time at which the part was uploaded.
+    pub last_modified: SystemTime,
+    /// Size of the part in bytes.
+    pub size: u64,
+}
+
+/// Pair of (part number, ETag) that the client provides on
+/// [`MultipartUploadBackend::complete_multipart`](crate::backend::common::MultipartUploadBackend::complete_multipart)
+/// to identify the parts in order.
+#[derive(Clone, Debug)]
+pub struct CompletedPart {
+    /// 1-indexed position of this part within the upload.
+    pub part_number: PartNumber,
+    /// Identifier returned when the part was uploaded.
+    pub etag: ETag,
+}
+
+/// Response from
+/// [`MultipartUploadBackend::list_parts`](crate::backend::common::MultipartUploadBackend::list_parts).
+#[derive(Clone, Debug)]
+pub struct ListedParts {
+    /// Parts uploaded so far, in `part_number` order.
+    pub parts: Vec<PartInfo>,
+    /// Set when the listing was truncated and more parts can be fetched
+    /// using [`Self::next_part_number_marker`] as the next
+    /// `part_number_marker`.
+    pub is_truncated: bool,
+    /// Marker to pass as the next `part_number_marker` when
+    /// [`Self::is_truncated`] is `true`.
+    pub next_part_number_marker: Option<PartNumber>,
+}
+
+/// Backend response for
+/// [`MultipartUploadBackend::initiate_multipart`](crate::backend::common::MultipartUploadBackend::initiate_multipart).
+pub type InitiateMultipartResponse = UploadId;
+/// Backend response for
+/// [`MultipartUploadBackend::upload_part`](crate::backend::common::MultipartUploadBackend::upload_part).
+pub type UploadPartResponse = ETag;
+/// Backend response for
+/// [`MultipartUploadBackend::list_parts`](crate::backend::common::MultipartUploadBackend::list_parts).
+pub type ListPartsResponse = ListedParts;
+/// Backend response for
+/// [`MultipartUploadBackend::abort_multipart`](crate::backend::common::MultipartUploadBackend::abort_multipart).
+pub type AbortMultipartResponse = ();
+/// Backend response for
+/// [`MultipartUploadBackend::complete_multipart`](crate::backend::common::MultipartUploadBackend::complete_multipart).
+pub type CompleteMultipartResponse = ();

--- a/objectstore-service/src/secret.rs
+++ b/objectstore-service/src/secret.rs
@@ -1,0 +1,46 @@
+//! Newtype for redacted, zeroized secret values used in backend configuration.
+
+use std::fmt;
+
+use secrecy::{CloneableSecret, SerializableSecret, zeroize::Zeroize};
+use serde::{Deserialize, Serialize};
+
+/// Newtype around `String` that may protect against accidental
+/// logging of secrets in our configuration struct. Use with
+/// [`secrecy::SecretBox`].
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct ConfigSecret(String);
+
+impl ConfigSecret {
+    /// Returns the secret value as a string slice.
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl From<&str> for ConfigSecret {
+    fn from(str: &str) -> Self {
+        ConfigSecret(str.to_string())
+    }
+}
+
+impl std::ops::Deref for ConfigSecret {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl fmt::Debug for ConfigSecret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "[redacted]")
+    }
+}
+
+impl CloneableSecret for ConfigSecret {}
+impl SerializableSecret for ConfigSecret {}
+impl Zeroize for ConfigSecret {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
+    }
+}


### PR DESCRIPTION
⚠️ Stacked on https://github.com/getsentry/objectstore/pull/445

We don't really need this anymore because I found out my GCS -> S3 approach won't really work.
However this will be needed for self-hosted and I already had this done, so might as well merge it.