### PR TITLE
ci: Report Test Coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch: false
+
+comment:
+  layout: "diff"
+  require_changes: true

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,5 +6,24 @@ coverage:
     patch: false
 
 comment:
-  layout: "diff"
+  layout: "condensed_header, diff, condensed_files, components, condensed_footer"
   require_changes: true
+
+component_management:
+  individual_components:
+    - component_id: rust_backend
+      name: Rust Backend
+      paths:
+        - objectstore-server/**
+        - objectstore-service/**
+        - objectstore-types/**
+
+    - component_id: rust_client
+      name: Rust Client
+      paths:
+        - clients/rust/**
+
+    - component_id: python_client
+      name: Python Client
+      paths:
+        - clients/python/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,64 @@ jobs:
       - name: Run Tests
         run: cargo test --workspace --all-features
 
+  codecov:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Start Bigtable Emulator
+        run: |
+          docker run -d \
+            --name bigtable-emulator \
+            -p 8086:8086 \
+            -e BIGTABLE_EMULATOR_HOST=localhost:8086 \
+            -v $PWD/devservices/run-bigtable.sh:/run-bigtable.sh \
+            google/cloud-sdk \
+            /run-bigtable.sh
+
+      - name: Start GCS Emulator
+        run: |
+          docker run -d \
+            --name gcs-emulator \
+            -p 8087:9000 \
+            -e GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME=test-bucket \
+            gcr.io/cloud-devrel-public-resources/storage-testbench:latest
+
+      - name: Start MinIO
+        run: |
+          docker run -d \
+            --name minio \
+            -p 8089:9000 \
+            --entrypoint /run-minio.sh \
+            -v $PWD/devservices/run-minio.sh:/run-minio.sh \
+            minio/minio
+
+      - name: Install Rust Toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup component add llvm-tools-preview
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
+        with:
+          key: ${{ github.job }}
+
+      - uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Generate coverage
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info --locked
+
+      - uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   test-python:
     name: Test Python
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,8 +119,8 @@ jobs:
       - name: Run Tests
         run: cargo test --workspace --all-features
 
-  codecov:
-    name: Code Coverage
+  coverage:
+    name: Test Coverage
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,56 +106,6 @@ jobs:
       - name: Install Rust Toolchain
         run: |
           rustup toolchain install stable --profile minimal --no-self-update
-
-      - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
-        with:
-          key: ${{ github.job }}
-
-      - name: Run Tests
-        run: cargo test --workspace --all-features
-
-  coverage:
-    name: Test Coverage
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
-      - name: Start Bigtable Emulator
-        run: |
-          docker run -d \
-            --name bigtable-emulator \
-            -p 8086:8086 \
-            -e BIGTABLE_EMULATOR_HOST=localhost:8086 \
-            -v $PWD/devservices/run-bigtable.sh:/run-bigtable.sh \
-            google/cloud-sdk \
-            /run-bigtable.sh
-
-      - name: Start GCS Emulator
-        run: |
-          docker run -d \
-            --name gcs-emulator \
-            -p 8087:9000 \
-            -e GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME=test-bucket \
-            gcr.io/cloud-devrel-public-resources/storage-testbench:latest
-
-      - name: Start MinIO
-        run: |
-          docker run -d \
-            --name minio \
-            -p 8089:9000 \
-            --entrypoint /run-minio.sh \
-            -v $PWD/devservices/run-minio.sh:/run-minio.sh \
-            minio/minio
-
-      - name: Install Rust Toolchain
-        run: |
-          rustup toolchain install stable --profile minimal --no-self-update
           rustup component add llvm-tools-preview
 
       - name: Install protoc
@@ -169,12 +119,15 @@ jobs:
 
       - uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Generate coverage
+      - name: Run tests with coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info --locked
 
-      - uses: codecov/codecov-action@v5
+      - name: Upload Rust coverage
+        uses: codecov/codecov-action@v5
+        continue-on-error: true
         with:
           files: lcov.info
+          flags: rust
           token: ${{ secrets.CODECOV_TOKEN }}
 
   test-python:
@@ -203,8 +156,16 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-packages --all-groups
 
-      - name: Run tests
-        run: uv run pytest clients/python
+      - name: Run tests with coverage
+        run: uv run pytest clients/python --cov=clients/python/src --cov-report=xml:python-coverage.xml
+
+      - name: Upload Python coverage
+        uses: codecov/codecov-action@v5
+        continue-on-error: true
+        with:
+          files: python-coverage.xml
+          flags: python
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   docs:
     name: Build and Publish Documentation

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ profile.json.gz
 /**/target
 **/__pycache__
 /dist
+
+# Coverage
+.coverage
+*.lcov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ members = [
 dev = [
     "devservices>=1.2.2",
     "pytest>=8.3.3",
+    "pytest-cov>=4.1.0",
     "mypy>=1.17.1",
     "ruff>=0.14.2",
     "pre-commit>=4.2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -93,6 +93,33 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.6.4"
+source = { registry = "https://pypi.devinfra.sentry.io/simple" }
+wheels = [
+    { url = "https://pypi.devinfra.sentry.io/wheels/coverage-7.6.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:73d2b73584446e66ee633eaad1a56aad577c077f46c35ca3283cd687b7715b0b" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/coverage-7.6.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:51b44306032045b383a7a8a2c13878de375117946d68dcb54308111f39775a25" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/coverage-7.6.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b3fb02fe73bed561fa12d279a417b432e5b50fe03e8d663d61b3d5990f29546" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/coverage-7.6.4-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b369ead6527d025a0fe7bd3864e46dbee3aa8f652d48df6174f8d0bac9e26e0e" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/coverage-7.6.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:12394842a3a8affa3ba62b0d4ab7e9e210c5e366fbac3e8b2a68636fb19892c2" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/coverage-7.6.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2b6b4c83d8e8ea79f27ab80778c19bc037759aea298da4b56621f4474ffeb117" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/coverage-7.6.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d5b8007f81b88696d06f7df0cb9af0d3b835fe0c8dbf489bad70b45f0e45613" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/coverage-7.6.4-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5915fcdec0e54ee229926868e9b08586376cae1f5faa9bbaf8faf3561b393d52" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/coverage-7.6.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:023bf8ee3ec6d35af9c1c6ccc1d18fa69afa1cb29eaac57cb064dbb262a517f9" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/coverage-7.6.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b0ac3d42cb51c4b12df9c5f0dd2f13a4f24f01943627120ec4d293c9181219ba" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/coverage-7.6.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8fe4984b431f8621ca53d9380901f62bfb54ff759a1348cd140490ada7b693c" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/coverage-7.6.4-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dacbc52de979f2823a819571f2e3a350a7e36b8cb7484cdb1e289bceaf35305f" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/coverage-7.6.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:195bb15106367d53b0568a0f5cdf6e3b90ab60a618bcc52769585d5384941021" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/coverage-7.6.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_31_aarch64.whl", hash = "sha256:4ba20745bbafc23169ddbac67751686f5c062e843482c00d12bce78229f91832" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/coverage-7.6.4-cp314-cp314-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_31_x86_64.whl", hash = "sha256:62d663523d03014e6215fcc04ccdc843bb7c4d05eda4720972128f3b83885fb9" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
 name = "cryptography"
 version = "46.0.5"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
@@ -268,6 +295,7 @@ dev = [
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "ruff" },
 ]
 docs = [
@@ -283,6 +311,7 @@ dev = [
     { name = "mypy", specifier = ">=1.17.1" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "ruff", specifier = ">=0.14.2" },
 ]
 docs = [
@@ -402,6 +431,18 @@ dependencies = [
 ]
 wheels = [
     { url = "https://pypi.devinfra.sentry.io/wheels/pytest-8.3.3-py3-none-any.whl", hash = "sha256:a6853c7375b2663155079443d2e45de913a911a11d669df02a50814944db57b2" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "4.1.0"
+source = { registry = "https://pypi.devinfra.sentry.io/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pytest" },
+]
+wheels = [
+    { url = "https://pypi.devinfra.sentry.io/wheels/pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a" },
 ]
 
 [[package]]
@@ -607,6 +648,26 @@ dependencies = [
 ]
 wheels = [
     { url = "https://pypi.devinfra.sentry.io/wheels/supervisor-4.2.5-py2.py3-none-any.whl", hash = "sha256:2ecaede32fc25af814696374b79e42644ecaba5c09494c51016ffda9602d0f08" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.2.1"
+source = { registry = "https://pypi.devinfra.sentry.io/simple" }
+wheels = [
+    { url = "https://pypi.devinfra.sentry.io/wheels/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds setup for test coverage using Codecov.
Coverage is collected using the complete test suite (including emulators), so that we can measure coverage of the backends too.
Status checks are reported as informational only, they don't block PRs from merging.