### PR TITLE
feat(service): Implement MultipartUploadBackend on GcsBackend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2577,6 +2577,7 @@ dependencies = [
  "objectstore-log",
  "objectstore-metrics",
  "objectstore-types",
+ "quick-xml",
  "regex",
  "reqwest 0.12.28",
  "sentry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,7 +1031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1633,7 +1633,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2227,7 +2227,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3077,6 +3077,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3089,7 +3099,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3127,9 +3137,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3491,7 +3501,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3550,7 +3560,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3685,7 +3695,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4179,7 +4189,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4997,7 +5007,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/objectstore-service/Cargo.toml
+++ b/objectstore-service/Cargo.toml
@@ -22,6 +22,7 @@ humantime-serde = { workspace = true }
 objectstore-log = { workspace = true }
 objectstore-metrics = { workspace = true }
 objectstore-types = { workspace = true }
+quick-xml = { version = "0.38.4", features = ["serialize"] }
 regex = { workspace = true }
 reqwest = { workspace = true, features = [
     "hickory-dns",

--- a/objectstore-service/src/backend/common.rs
+++ b/objectstore-service/src/backend/common.rs
@@ -75,12 +75,22 @@ pub trait MultipartUploadBackend: Backend + fmt::Debug + Send + Sync + 'static {
     ) -> Result<InitiateMultipartResponse>;
 
     /// Uploads a single part of the upload identified by `(id, upload_id)`.
+    ///
+    /// `content_length` is required by the protocol — neither AWS S3 nor
+    /// MinIO accept `Transfer-Encoding: chunked` on `UploadPart`, so we
+    /// always need an upfront length. `content_md5`, when supplied, is
+    /// forwarded as the `Content-MD5` header so the storage backend can
+    /// verify the part's bytes; format follows [RFC 1864] (base64-encoded
+    /// MD5).
+    ///
+    /// [RFC 1864]: https://www.rfc-editor.org/rfc/rfc1864
     async fn upload_part(
         &self,
         id: &ObjectId,
         upload_id: &UploadId,
         part_number: PartNumber,
         content_length: u64,
+        content_md5: Option<&str>,
         body: ClientStream,
     ) -> Result<UploadPartResponse>;
 

--- a/objectstore-service/src/backend/common.rs
+++ b/objectstore-service/src/backend/common.rs
@@ -75,15 +75,6 @@ pub trait MultipartUploadBackend: Backend + fmt::Debug + Send + Sync + 'static {
     ) -> Result<InitiateMultipartResponse>;
 
     /// Uploads a single part of the upload identified by `(id, upload_id)`.
-    ///
-    /// `content_length` is required by the protocol — neither AWS S3 nor
-    /// MinIO accept `Transfer-Encoding: chunked` on `UploadPart`, so we
-    /// always need an upfront length. `content_md5`, when supplied, is
-    /// forwarded as the `Content-MD5` header so the storage backend can
-    /// verify the part's bytes; format follows [RFC 1864] (base64-encoded
-    /// MD5).
-    ///
-    /// [RFC 1864]: https://www.rfc-editor.org/rfc/rfc1864
     async fn upload_part(
         &self,
         id: &ObjectId,

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -293,59 +293,6 @@ impl serde::Serialize for GcsMetaKey {
     }
 }
 
-/// Response for a GCS XML API initiate multipart request.
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-struct XmlInitiateMultipartUploadResponse {
-    upload_id: String,
-}
-
-/// Response for a GCS XML API list parts request.
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-struct XmlListPartsResponse {
-    #[serde(default)]
-    is_truncated: bool,
-    next_part_number_marker: Option<u32>,
-    #[serde(default, rename = "Part")]
-    parts: Vec<XmlPart>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-struct XmlPart {
-    part_number: u32,
-    #[serde(rename = "ETag")]
-    e_tag: String,
-    #[serde(with = "humantime_serde")]
-    last_modified: SystemTime,
-    size: u64,
-}
-
-/// Request body for a GCS XML API complete multipart upload request.
-#[derive(Debug, Serialize)]
-#[serde(rename = "CompleteMultipartUpload")]
-struct XmlCompleteMultipartUpload<'a> {
-    #[serde(rename = "Part")]
-    parts: Vec<XmlCompletePart<'a>>,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "PascalCase")]
-struct XmlCompletePart<'a> {
-    part_number: PartNumber,
-    #[serde(rename = "ETag")]
-    e_tag: &'a str,
-}
-
-/// Error response for a complete multipart request.
-#[derive(Debug, Deserialize)]
-#[serde(rename = "Error", rename_all = "PascalCase")]
-struct XmlError {
-    code: String,
-    message: String,
-}
-
 /// Builds HTTP headers that encode `metadata` for a GCS XML API request.
 fn metadata_to_gcs_headers(metadata: &Metadata) -> Result<header::HeaderMap> {
     let mut headers = header::HeaderMap::new();
@@ -764,6 +711,108 @@ impl Backend for GcsBackend {
     }
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct XmlInitiateMultipartUploadResponse {
+    upload_id: String,
+}
+
+impl From<XmlInitiateMultipartUploadResponse> for InitiateMultipartResponse {
+    fn from(r: XmlInitiateMultipartUploadResponse) -> Self {
+        r.upload_id
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct XmlListPartsResponse {
+    #[serde(default)]
+    is_truncated: bool,
+    next_part_number_marker: Option<u32>,
+    #[serde(default, rename = "Part")]
+    parts: Vec<XmlPart>,
+}
+
+impl From<XmlListPartsResponse> for ListPartsResponse {
+    fn from(xml: XmlListPartsResponse) -> Self {
+        Self {
+            parts: xml.parts.into_iter().map(Into::into).collect(),
+            is_truncated: xml.is_truncated,
+            next_part_number_marker: xml.next_part_number_marker,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct XmlPart {
+    part_number: u32,
+    #[serde(rename = "ETag")]
+    e_tag: String,
+    #[serde(with = "humantime_serde")]
+    last_modified: SystemTime,
+    size: u64,
+}
+
+impl From<XmlPart> for crate::multipart::Part {
+    fn from(p: XmlPart) -> Self {
+        Self {
+            part_number: p.part_number,
+            etag: p.e_tag,
+            last_modified: p.last_modified,
+            size: p.size,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename = "CompleteMultipartUpload")]
+struct XmlCompleteMultipartUpload {
+    #[serde(rename = "Part")]
+    parts: Vec<XmlCompletePart>,
+}
+
+impl From<Vec<CompletedPart>> for XmlCompleteMultipartUpload {
+    fn from(parts: Vec<CompletedPart>) -> Self {
+        Self {
+            parts: parts.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct XmlCompletePart {
+    part_number: PartNumber,
+    #[serde(rename = "ETag")]
+    e_tag: String,
+}
+
+impl From<CompletedPart> for XmlCompletePart {
+    fn from(p: CompletedPart) -> Self {
+        Self {
+            part_number: p.part_number,
+            e_tag: p.etag,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename = "Error", rename_all = "PascalCase")]
+struct XmlError {
+    code: String,
+    message: String,
+}
+
+impl From<XmlError> for crate::multipart::CompleteMultipartError {
+    fn from(e: XmlError) -> Self {
+        Self {
+            code: e.code,
+            message: e.message,
+        }
+    }
+}
+
 #[async_trait::async_trait]
 impl MultipartUploadBackend for GcsBackend {
     #[tracing::instrument(level = "trace", fields(?id), skip_all)]
@@ -798,13 +847,13 @@ impl MultipartUploadBackend for GcsBackend {
             .await
             .map_err(|e| Error::reqwest("GCS: read initiate multipart body", e))?;
 
-        let result: XmlInitiateMultipartUploadResponse = quick_xml::de::from_reader(body.as_ref())
+        let xml: XmlInitiateMultipartUploadResponse = quick_xml::de::from_reader(body.as_ref())
             .map_err(|e| Error::Generic {
                 context: "GCS: failed to parse initiate multipart response".to_owned(),
                 cause: Some(Box::new(e)),
             })?;
 
-        Ok(result.upload_id)
+        Ok(xml.into())
     }
 
     #[tracing::instrument(level = "trace", fields(?id, upload_id, part_number), skip_all)]
@@ -883,28 +932,13 @@ impl MultipartUploadBackend for GcsBackend {
             .await
             .map_err(|e| Error::reqwest("GCS: read list parts body", e))?;
 
-        let parsed: XmlListPartsResponse =
+        let xml: XmlListPartsResponse =
             quick_xml::de::from_reader(body.as_ref()).map_err(|e| Error::Generic {
                 context: "GCS: failed to parse list parts response".to_owned(),
                 cause: Some(Box::new(e)),
             })?;
 
-        let parts = parsed
-            .parts
-            .into_iter()
-            .map(|p| crate::multipart::Part {
-                part_number: p.part_number,
-                etag: p.e_tag,
-                last_modified: p.last_modified,
-                size: p.size,
-            })
-            .collect();
-
-        Ok(ListPartsResponse {
-            parts,
-            is_truncated: parsed.is_truncated,
-            next_part_number_marker: parsed.next_part_number_marker,
-        })
+        Ok(xml.into())
     }
 
     #[tracing::instrument(level = "trace", fields(?id, upload_id), skip_all)]
@@ -938,15 +972,7 @@ impl MultipartUploadBackend for GcsBackend {
         let mut url = self.xml_object_url(id)?;
         url.query_pairs_mut().append_pair("uploadId", upload_id);
 
-        let body = XmlCompleteMultipartUpload {
-            parts: parts
-                .iter()
-                .map(|p| XmlCompletePart {
-                    part_number: p.part_number,
-                    e_tag: &p.etag,
-                })
-                .collect(),
-        };
+        let body = XmlCompleteMultipartUpload::from(parts);
         let xml = quick_xml::se::to_string(&body).map_err(|e| Error::Generic {
             context: "GCS: failed to serialize complete multipart request".into(),
             cause: Some(Box::new(e)),
@@ -969,10 +995,7 @@ impl MultipartUploadBackend for GcsBackend {
 
         let error = quick_xml::de::from_reader::<_, XmlError>(body.as_ref())
             .ok()
-            .map(|e| crate::multipart::CompleteMultipartError {
-                code: e.code,
-                message: e.message,
-            });
+            .map(Into::into);
 
         Ok(error)
     }

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -23,7 +23,7 @@ use crate::gcp_auth::PrefetchingTokenProvider;
 use crate::id::ObjectId;
 use crate::multipart::{
     AbortMultipartResponse, CompleteMultipartResponse, CompletedPart, InitiateMultipartResponse,
-    ListPartsResponse, ListedParts, PartInfo, PartNumber, UploadId, UploadPartResponse,
+    ListPartsResponse, ListedParts, PartNumber, UploadId, UploadPartResponse,
 };
 use crate::stream::{self, ClientStream};
 
@@ -292,17 +292,17 @@ impl serde::Serialize for GcsMetaKey {
     }
 }
 
-/// Response from a GCS XML API `POST ?uploads` (initiate multipart) request.
+/// Response for a GCS XML API initiate multipart request.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
-struct InitiateMultipartUploadResult {
+struct XmlInitiateMultipartUploadResponse {
     upload_id: String,
 }
 
-/// Response from a GCS XML API `GET ?uploadId=…` (list parts) request.
+/// Response for a GCS XML API list parts request.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
-struct XmlListPartsResult {
+struct XmlListPartsResponse {
     #[serde(default)]
     is_truncated: bool,
     next_part_number_marker: Option<u32>,
@@ -316,57 +316,100 @@ struct XmlPart {
     part_number: u32,
     #[serde(rename = "ETag")]
     e_tag: String,
-    last_modified: String,
+    #[serde(with = "humantime_serde")]
+    last_modified: SystemTime,
     size: u64,
 }
 
-/// Error body that GCS/S3 can embed in a 200 response on complete-multipart.
+/// Request body for a GCS XML API complete multipart upload.
+#[derive(Debug, Serialize)]
+#[serde(rename = "CompleteMultipartUpload")]
+struct XmlCompleteMultipartUpload<'a> {
+    #[serde(rename = "Part")]
+    parts: Vec<XmlCompletePart<'a>>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct XmlCompletePart<'a> {
+    part_number: PartNumber,
+    #[serde(rename = "ETag")]
+    e_tag: &'a str,
+}
+
+/// Error response for a complete multipart request.
 #[derive(Debug, Deserialize)]
 #[serde(rename = "Error", rename_all = "PascalCase")]
-struct GcsXmlError {
+struct XmlError {
     code: String,
     message: String,
 }
 
-/// Builds HTTP headers that encode `metadata` for a GCS XML API
-/// initiate-multipart request, translating the same fields that
-/// [`GcsObject::from_metadata`] produces for the JSON API.
-fn metadata_to_xml_headers(metadata: &Metadata) -> Result<header::HeaderMap> {
-    let gcs_obj = GcsObject::from_metadata(metadata);
+/// Builds HTTP headers that encode `metadata` for a GCS XML API request.
+fn metadata_to_gcs_headers(metadata: &Metadata) -> Result<header::HeaderMap> {
     let mut headers = header::HeaderMap::new();
 
-    if let Some(custom_time) = gcs_obj.custom_time {
+    if let Some(expires_in) = metadata.expiration_policy.expires_in() {
+        let custom_time = SystemTime::now() + expires_in;
         let formatted = humantime::format_rfc3339_seconds(custom_time);
         headers.insert(
             HeaderName::from_static("x-goog-custom-time"),
-            formatted
-                .to_string()
-                .parse()
-                .map_err(|_| Error::generic("GCS: invalid custom-time header value"))?,
-        );
-    }
-
-    if let Some(encoding) = &gcs_obj.content_encoding {
-        headers.insert(
-            header::CONTENT_ENCODING,
-            encoding
-                .parse()
-                .map_err(|_| Error::generic("GCS: invalid content-encoding header value"))?,
-        );
-    }
-
-    for (key, value) in &gcs_obj.metadata {
-        let header_name = format!("x-goog-meta-{key}");
-        headers.insert(
-            HeaderName::try_from(&header_name)
-                .map_err(|_| Error::generic(format!("GCS: invalid header name: {header_name}")))?,
-            value.parse().map_err(|_| {
-                Error::generic(format!("GCS: invalid header value for {header_name}"))
+            formatted.to_string().parse().map_err(|e| Error::Generic {
+                context: "GCS: invalid custom-time header value".into(),
+                cause: Some(Box::new(e)),
             })?,
         );
     }
 
+    if let Some(compression) = metadata.compression {
+        headers.insert(
+            header::CONTENT_ENCODING,
+            compression
+                .to_string()
+                .parse()
+                .map_err(|e| Error::Generic {
+                    context: "GCS: invalid content-encoding header value".into(),
+                    cause: Some(Box::new(e)),
+                })?,
+        );
+    }
+
+    if metadata.expiration_policy != ExpirationPolicy::default() {
+        insert_gcs_meta_header(
+            &mut headers,
+            &GcsMetaKey::Expiration,
+            &metadata.expiration_policy.to_string(),
+        )?;
+    }
+
+    if let Some(origin) = &metadata.origin {
+        insert_gcs_meta_header(&mut headers, &GcsMetaKey::Origin, origin)?;
+    }
+
+    for (key, value) in &metadata.custom {
+        insert_gcs_meta_header(&mut headers, &GcsMetaKey::Custom(key.clone()), value)?;
+    }
+
     Ok(headers)
+}
+
+fn insert_gcs_meta_header(
+    headers: &mut header::HeaderMap,
+    key: &GcsMetaKey,
+    value: &str,
+) -> Result<()> {
+    let header_name = format!("x-goog-meta-{key}");
+    headers.insert(
+        HeaderName::try_from(&header_name).map_err(|e| Error::Generic {
+            context: format!("GCS: invalid header name: {header_name}"),
+            cause: Some(Box::new(e)),
+        })?,
+        value.parse().map_err(|e| Error::Generic {
+            context: format!("GCS: invalid header value for {header_name}"),
+            cause: Some(Box::new(e)),
+        })?,
+    );
+    Ok(())
 }
 
 /// Returns `true` if the error is a transient reqwest failure worth retrying.
@@ -746,7 +789,7 @@ impl MultipartUploadBackend for GcsBackend {
             .header(header::CONTENT_TYPE, metadata.content_type.as_ref())
             .header(header::CONTENT_LENGTH, "0");
 
-        let meta_headers = metadata_to_xml_headers(metadata)?;
+        let meta_headers = metadata_to_gcs_headers(metadata)?;
         for (name, value) in &meta_headers {
             builder = builder.header(name, value);
         }
@@ -762,7 +805,7 @@ impl MultipartUploadBackend for GcsBackend {
             .await
             .map_err(|e| Error::reqwest("GCS: read initiate multipart body", e))?;
 
-        let result: InitiateMultipartUploadResult = quick_xml::de::from_reader(body.as_ref())
+        let result: XmlInitiateMultipartUploadResponse = quick_xml::de::from_reader(body.as_ref())
             .map_err(|e| Error::Generic {
                 context: "GCS: failed to parse initiate multipart response".to_owned(),
                 cause: Some(Box::new(e)),
@@ -847,7 +890,7 @@ impl MultipartUploadBackend for GcsBackend {
             .await
             .map_err(|e| Error::reqwest("GCS: read list parts body", e))?;
 
-        let parsed: XmlListPartsResult =
+        let parsed: XmlListPartsResponse =
             quick_xml::de::from_reader(body.as_ref()).map_err(|e| Error::Generic {
                 context: "GCS: failed to parse list parts response".to_owned(),
                 cause: Some(Box::new(e)),
@@ -856,16 +899,11 @@ impl MultipartUploadBackend for GcsBackend {
         let parts = parsed
             .parts
             .into_iter()
-            .map(|p| {
-                let last_modified = humantime::parse_rfc3339(&p.last_modified)
-                    .or_else(|_| humantime::parse_rfc3339_weak(&p.last_modified))
-                    .unwrap_or(SystemTime::UNIX_EPOCH);
-                PartInfo {
-                    part_number: p.part_number,
-                    etag: p.e_tag,
-                    last_modified,
-                    size: p.size,
-                }
+            .map(|p| crate::multipart::Part {
+                part_number: p.part_number,
+                etag: p.e_tag,
+                last_modified: p.last_modified,
+                size: p.size,
             })
             .collect();
 
@@ -907,14 +945,19 @@ impl MultipartUploadBackend for GcsBackend {
         let mut url = self.xml_object_url(id)?;
         url.query_pairs_mut().append_pair("uploadId", upload_id);
 
-        let mut xml = String::from("<CompleteMultipartUpload>");
-        for part in &parts {
-            xml.push_str(&format!(
-                "<Part><PartNumber>{}</PartNumber><ETag>{}</ETag></Part>",
-                part.part_number, part.etag
-            ));
-        }
-        xml.push_str("</CompleteMultipartUpload>");
+        let body = XmlCompleteMultipartUpload {
+            parts: parts
+                .iter()
+                .map(|p| XmlCompletePart {
+                    part_number: p.part_number,
+                    e_tag: &p.etag,
+                })
+                .collect(),
+        };
+        let xml = quick_xml::se::to_string(&body).map_err(|e| Error::Generic {
+            context: "GCS: failed to serialize complete multipart request".into(),
+            cause: Some(Box::new(e)),
+        })?;
 
         let resp = self
             .request(Method::POST, url)
@@ -931,7 +974,7 @@ impl MultipartUploadBackend for GcsBackend {
             .await
             .map_err(|e| Error::reqwest("GCS: read complete multipart body", e))?;
 
-        if let Ok(err) = quick_xml::de::from_reader::<_, GcsXmlError>(body.as_ref()) {
+        if let Ok(err) = quick_xml::de::from_reader::<_, XmlError>(body.as_ref()) {
             return Err(Error::generic(format!(
                 "GCS: complete multipart upload failed: {} ({})",
                 err.message, err.code
@@ -1267,5 +1310,4 @@ mod tests {
 
         Ok(())
     }
-
 }

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -321,7 +321,7 @@ struct XmlPart {
     size: u64,
 }
 
-/// Request body for a GCS XML API complete multipart upload.
+/// Request body for a GCS XML API complete multipart upload request.
 #[derive(Debug, Serialize)]
 #[serde(rename = "CompleteMultipartUpload")]
 struct XmlCompleteMultipartUpload<'a> {
@@ -974,14 +974,14 @@ impl MultipartUploadBackend for GcsBackend {
             .await
             .map_err(|e| Error::reqwest("GCS: read complete multipart body", e))?;
 
-        if let Ok(err) = quick_xml::de::from_reader::<_, XmlError>(body.as_ref()) {
-            return Err(Error::generic(format!(
-                "GCS: complete multipart upload failed: {} ({})",
-                err.message, err.code
-            )));
-        }
+        let error = quick_xml::de::from_reader::<_, XmlError>(body.as_ref())
+            .ok()
+            .map(|e| crate::multipart::CompleteMultipartError {
+                code: e.code,
+                message: e.message,
+            });
 
-        Ok(())
+        Ok(CompleteMultipartResponse { error })
     }
 }
 

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::future::Future;
+use std::net::ToSocketAddrs;
 use std::time::{Duration, SystemTime};
 use std::{fmt, io};
 
@@ -507,24 +508,16 @@ impl GcsBackend {
     ///
     /// Unlike [`object_url`](Self::object_url) (JSON API at
     /// `/storage/v1/b/{bucket}/o/{name}`), this produces
-    /// `/{bucket}/{path_segments}` for the S3-compatible XML API used by
+    /// `/{bucket}/{name}` for the S3-compatible XML API used by
     /// multipart uploads.
     fn xml_object_url(&self, id: &ObjectId) -> Result<Url> {
-        let mut url = self.endpoint.clone();
-        {
-            let mut segments = url.path_segments_mut().map_err(|()| Error::Generic {
-                context: format!(
-                    "GCS: invalid endpoint URL, {} cannot be a base",
-                    self.endpoint
-                ),
-                cause: None,
-            })?;
-            segments.push(&self.bucket);
-            for part in id.as_storage_path().to_string().split('/') {
-                segments.push(part);
-            }
-        }
-        Ok(url)
+        Url::parse(&format!(
+            "{}/{}/{}",
+            self.endpoint.as_str(),
+            &self.bucket,
+            id.as_storage_path(),
+        ))
+        .map_err(|_| Error::generic("GCS: failed to build XML object URL"))
     }
 
     /// Creates a request builder with the appropriate authentication.

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -3,7 +3,6 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::future::Future;
-use std::net::ToSocketAddrs;
 use std::time::{Duration, SystemTime};
 use std::{fmt, io};
 
@@ -455,16 +454,24 @@ impl GcsBackend {
     ///
     /// Unlike [`object_url`](Self::object_url) (JSON API at
     /// `/storage/v1/b/{bucket}/o/{name}`), this produces
-    /// `/{bucket}/{name}` for the S3-compatible XML API used by
+    /// `/{bucket}/{path_segments}` for the S3-compatible XML API used by
     /// multipart uploads.
     fn xml_object_url(&self, id: &ObjectId) -> Result<Url> {
-        Url::parse(&format!(
-            "{}/{}/{}",
-            self.endpoint.as_str(),
-            &self.bucket,
-            id.as_storage_path(),
-        ))
-        .map_err(|_| Error::generic("GCS: failed to build XML object URL"))
+        let mut url = self.endpoint.clone();
+        {
+            let mut segments = url.path_segments_mut().map_err(|()| Error::Generic {
+                context: format!(
+                    "GCS: invalid endpoint URL, {} cannot be a base",
+                    self.endpoint
+                ),
+                cause: None,
+            })?;
+            segments.push(&self.bucket);
+            for part in id.as_storage_path().to_string().split('/') {
+                segments.push(part);
+            }
+        }
+        Ok(url)
     }
 
     /// Creates a request builder with the appropriate authentication.

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -23,7 +23,7 @@ use crate::gcp_auth::PrefetchingTokenProvider;
 use crate::id::ObjectId;
 use crate::multipart::{
     AbortMultipartResponse, CompleteMultipartResponse, CompletedPart, InitiateMultipartResponse,
-    ListPartsResponse, ListedParts, PartNumber, UploadId, UploadPartResponse,
+    ListPartsResponse, PartNumber, UploadId, UploadPartResponse,
 };
 use crate::stream::{self, ClientStream};
 
@@ -907,7 +907,7 @@ impl MultipartUploadBackend for GcsBackend {
             })
             .collect();
 
-        Ok(ListedParts {
+        Ok(ListPartsResponse {
             parts,
             is_truncated: parsed.is_truncated,
             next_part_number_marker: parsed.next_part_number_marker,
@@ -981,7 +981,7 @@ impl MultipartUploadBackend for GcsBackend {
                 message: e.message,
             });
 
-        Ok(CompleteMultipartResponse { error })
+        Ok(error)
     }
 }
 

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -10,15 +10,21 @@ use anyhow::Context;
 use futures_util::{StreamExt, TryStreamExt};
 use gcp_auth::TokenProvider;
 use objectstore_types::metadata::{ExpirationPolicy, Metadata};
+use reqwest::header::HeaderName;
 use reqwest::{Body, IntoUrl, Method, RequestBuilder, StatusCode, Url, header, multipart};
 use serde::{Deserialize, Serialize};
 
 use crate::backend::common::{
-    self, Backend, DeleteResponse, GetResponse, MetadataResponse, PutResponse,
+    self, Backend, DeleteResponse, GetResponse, MetadataResponse, MultipartUploadBackend,
+    PutResponse,
 };
 use crate::error::{Error, Result};
 use crate::gcp_auth::PrefetchingTokenProvider;
 use crate::id::ObjectId;
+use crate::multipart::{
+    AbortMultipartResponse, CompleteMultipartResponse, CompletedPart, InitiateMultipartResponse,
+    ListPartsResponse, ListedParts, PartInfo, PartNumber, UploadId, UploadPartResponse,
+};
 use crate::stream::{self, ClientStream};
 
 /// Configuration for [`GcsBackend`].
@@ -286,6 +292,83 @@ impl serde::Serialize for GcsMetaKey {
     }
 }
 
+/// Response from a GCS XML API `POST ?uploads` (initiate multipart) request.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct InitiateMultipartUploadResult {
+    upload_id: String,
+}
+
+/// Response from a GCS XML API `GET ?uploadId=…` (list parts) request.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct XmlListPartsResult {
+    #[serde(default)]
+    is_truncated: bool,
+    next_part_number_marker: Option<u32>,
+    #[serde(default, rename = "Part")]
+    parts: Vec<XmlPart>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct XmlPart {
+    part_number: u32,
+    #[serde(rename = "ETag")]
+    e_tag: String,
+    last_modified: String,
+    size: u64,
+}
+
+/// Error body that GCS/S3 can embed in a 200 response on complete-multipart.
+#[derive(Debug, Deserialize)]
+#[serde(rename = "Error", rename_all = "PascalCase")]
+struct GcsXmlError {
+    code: String,
+    message: String,
+}
+
+/// Builds HTTP headers that encode `metadata` for a GCS XML API
+/// initiate-multipart request, translating the same fields that
+/// [`GcsObject::from_metadata`] produces for the JSON API.
+fn metadata_to_xml_headers(metadata: &Metadata) -> Result<header::HeaderMap> {
+    let gcs_obj = GcsObject::from_metadata(metadata);
+    let mut headers = header::HeaderMap::new();
+
+    if let Some(custom_time) = gcs_obj.custom_time {
+        let formatted = humantime::format_rfc3339_seconds(custom_time);
+        headers.insert(
+            HeaderName::from_static("x-goog-custom-time"),
+            formatted
+                .to_string()
+                .parse()
+                .map_err(|_| Error::generic("GCS: invalid custom-time header value"))?,
+        );
+    }
+
+    if let Some(encoding) = &gcs_obj.content_encoding {
+        headers.insert(
+            header::CONTENT_ENCODING,
+            encoding
+                .parse()
+                .map_err(|_| Error::generic("GCS: invalid content-encoding header value"))?,
+        );
+    }
+
+    for (key, value) in &gcs_obj.metadata {
+        let header_name = format!("x-goog-meta-{key}");
+        headers.insert(
+            HeaderName::try_from(&header_name)
+                .map_err(|_| Error::generic(format!("GCS: invalid header name: {header_name}")))?,
+            value.parse().map_err(|_| {
+                Error::generic(format!("GCS: invalid header value for {header_name}"))
+            })?,
+        );
+    }
+
+    Ok(headers)
+}
+
 /// Returns `true` if the error is a transient reqwest failure worth retrying.
 fn is_retryable(error: &Error) -> bool {
     let Error::Reqwest { cause, .. } = error else {
@@ -374,6 +457,30 @@ impl GcsBackend {
             .append_pair("uploadType", upload_type)
             .append_pair("name", &id.as_storage_path().to_string());
 
+        Ok(url)
+    }
+
+    /// Formats a GCS XML API URL for the given object.
+    ///
+    /// Unlike [`object_url`](Self::object_url) (JSON API at
+    /// `/storage/v1/b/{bucket}/o/{name}`), this produces
+    /// `/{bucket}/{path_segments}` for the S3-compatible XML API used by
+    /// multipart uploads.
+    fn xml_object_url(&self, id: &ObjectId) -> Result<Url> {
+        let mut url = self.endpoint.clone();
+        {
+            let mut segments = url.path_segments_mut().map_err(|()| Error::Generic {
+                context: format!(
+                    "GCS: invalid endpoint URL, {} cannot be a base",
+                    self.endpoint
+                ),
+                cause: None,
+            })?;
+            segments.push(&self.bucket);
+            for part in id.as_storage_path().to_string().split('/') {
+                segments.push(part);
+            }
+        }
         Ok(url)
     }
 
@@ -618,6 +725,220 @@ impl Backend for GcsBackend {
             Ok(())
         })
         .await
+    }
+}
+
+#[async_trait::async_trait]
+impl MultipartUploadBackend for GcsBackend {
+    #[tracing::instrument(level = "trace", fields(?id), skip_all)]
+    async fn initiate_multipart(
+        &self,
+        id: &ObjectId,
+        metadata: &Metadata,
+    ) -> Result<InitiateMultipartResponse> {
+        objectstore_log::debug!("Initiating multipart upload on GCS backend");
+        let mut url = self.xml_object_url(id)?;
+        url.set_query(Some("uploads"));
+
+        let mut builder = self
+            .request(Method::POST, url)
+            .await?
+            .header(header::CONTENT_TYPE, metadata.content_type.as_ref())
+            .header(header::CONTENT_LENGTH, "0");
+
+        let meta_headers = metadata_to_xml_headers(metadata)?;
+        for (name, value) in &meta_headers {
+            builder = builder.header(name, value);
+        }
+
+        let resp = builder
+            .send()
+            .await
+            .and_then(|r| r.error_for_status())
+            .map_err(|e| Error::reqwest("GCS: initiate multipart upload", e))?;
+
+        let body = resp
+            .bytes()
+            .await
+            .map_err(|e| Error::reqwest("GCS: read initiate multipart body", e))?;
+
+        let result: InitiateMultipartUploadResult = quick_xml::de::from_reader(body.as_ref())
+            .map_err(|e| Error::Generic {
+                context: "GCS: failed to parse initiate multipart response".to_owned(),
+                cause: Some(Box::new(e)),
+            })?;
+
+        Ok(result.upload_id)
+    }
+
+    #[tracing::instrument(level = "trace", fields(?id, upload_id, part_number), skip_all)]
+    async fn upload_part(
+        &self,
+        id: &ObjectId,
+        upload_id: &UploadId,
+        part_number: PartNumber,
+        content_length: u64,
+        content_md5: Option<&str>,
+        body: ClientStream,
+    ) -> Result<UploadPartResponse> {
+        objectstore_log::debug!("Uploading part to GCS backend");
+        let mut url = self.xml_object_url(id)?;
+        url.query_pairs_mut()
+            .append_pair("partNumber", &part_number.to_string())
+            .append_pair("uploadId", upload_id);
+
+        let mut builder = self
+            .request(Method::PUT, url)
+            .await?
+            .header(header::CONTENT_LENGTH, content_length)
+            .body(Body::wrap_stream(body));
+
+        if let Some(md5) = content_md5 {
+            builder = builder.header("content-md5", md5);
+        }
+
+        let resp = builder
+            .send()
+            .await
+            .and_then(|r| r.error_for_status())
+            .map_err(|e| Error::reqwest("GCS: upload part", e))?;
+
+        let etag = resp
+            .headers()
+            .get(header::ETAG)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_owned())
+            .ok_or_else(|| Error::generic("GCS: upload part response missing ETag header"))?;
+
+        Ok(etag)
+    }
+
+    #[tracing::instrument(level = "trace", fields(?id, upload_id), skip_all)]
+    async fn list_parts(
+        &self,
+        id: &ObjectId,
+        upload_id: &UploadId,
+        max_parts: Option<u32>,
+        part_number_marker: Option<PartNumber>,
+    ) -> Result<ListPartsResponse> {
+        objectstore_log::debug!("Listing parts on GCS backend");
+        let mut url = self.xml_object_url(id)?;
+        {
+            let mut pairs = url.query_pairs_mut();
+            pairs.append_pair("uploadId", upload_id);
+            if let Some(max) = max_parts {
+                pairs.append_pair("max-parts", &max.to_string());
+            }
+            if let Some(marker) = part_number_marker {
+                pairs.append_pair("part-number-marker", &marker.to_string());
+            }
+        }
+
+        let resp = self
+            .request(Method::GET, url)
+            .await?
+            .send()
+            .await
+            .and_then(|r| r.error_for_status())
+            .map_err(|e| Error::reqwest("GCS: list parts", e))?;
+
+        let body = resp
+            .bytes()
+            .await
+            .map_err(|e| Error::reqwest("GCS: read list parts body", e))?;
+
+        let parsed: XmlListPartsResult =
+            quick_xml::de::from_reader(body.as_ref()).map_err(|e| Error::Generic {
+                context: "GCS: failed to parse list parts response".to_owned(),
+                cause: Some(Box::new(e)),
+            })?;
+
+        let parts = parsed
+            .parts
+            .into_iter()
+            .map(|p| {
+                let last_modified = humantime::parse_rfc3339(&p.last_modified)
+                    .or_else(|_| humantime::parse_rfc3339_weak(&p.last_modified))
+                    .unwrap_or(SystemTime::UNIX_EPOCH);
+                PartInfo {
+                    part_number: p.part_number,
+                    etag: p.e_tag,
+                    last_modified,
+                    size: p.size,
+                }
+            })
+            .collect();
+
+        Ok(ListedParts {
+            parts,
+            is_truncated: parsed.is_truncated,
+            next_part_number_marker: parsed.next_part_number_marker,
+        })
+    }
+
+    #[tracing::instrument(level = "trace", fields(?id, upload_id), skip_all)]
+    async fn abort_multipart(
+        &self,
+        id: &ObjectId,
+        upload_id: &UploadId,
+    ) -> Result<AbortMultipartResponse> {
+        objectstore_log::debug!("Aborting multipart upload on GCS backend");
+        let mut url = self.xml_object_url(id)?;
+        url.query_pairs_mut().append_pair("uploadId", upload_id);
+
+        self.request(Method::DELETE, url)
+            .await?
+            .send()
+            .await
+            .and_then(|r| r.error_for_status())
+            .map_err(|e| Error::reqwest("GCS: abort multipart upload", e))?;
+
+        Ok(())
+    }
+
+    #[tracing::instrument(level = "trace", fields(?id, upload_id), skip_all)]
+    async fn complete_multipart(
+        &self,
+        id: &ObjectId,
+        upload_id: &UploadId,
+        parts: Vec<CompletedPart>,
+    ) -> Result<CompleteMultipartResponse> {
+        objectstore_log::debug!("Completing multipart upload on GCS backend");
+        let mut url = self.xml_object_url(id)?;
+        url.query_pairs_mut().append_pair("uploadId", upload_id);
+
+        let mut xml = String::from("<CompleteMultipartUpload>");
+        for part in &parts {
+            xml.push_str(&format!(
+                "<Part><PartNumber>{}</PartNumber><ETag>{}</ETag></Part>",
+                part.part_number, part.etag
+            ));
+        }
+        xml.push_str("</CompleteMultipartUpload>");
+
+        let resp = self
+            .request(Method::POST, url)
+            .await?
+            .header(header::CONTENT_TYPE, "application/xml")
+            .body(xml)
+            .send()
+            .await
+            .and_then(|r| r.error_for_status())
+            .map_err(|e| Error::reqwest("GCS: complete multipart upload", e))?;
+
+        let body = resp
+            .bytes()
+            .await
+            .map_err(|e| Error::reqwest("GCS: read complete multipart body", e))?;
+
+        if let Ok(err) = quick_xml::de::from_reader::<_, GcsXmlError>(body.as_ref()) {
+            return Err(Error::generic(format!(
+                "GCS: complete multipart upload failed: {} ({})",
+                err.message, err.code
+            )));
+        }
+
+        Ok(())
     }
 }
 
@@ -946,4 +1267,5 @@ mod tests {
 
         Ok(())
     }
+
 }

--- a/objectstore-service/src/multipart.rs
+++ b/objectstore-service/src/multipart.rs
@@ -63,4 +63,21 @@ pub type ListPartsResponse = ListedParts;
 pub type AbortMultipartResponse = ();
 /// Backend response for
 /// [`MultipartUploadBackend::complete_multipart`](crate::backend::common::MultipartUploadBackend::complete_multipart).
-pub type CompleteMultipartResponse = ();
+///
+/// S3-compatible APIs can return HTTP 200 with an error body on complete-multipart.
+/// This struct mirrors that behavior so callers can inspect the error without the
+/// backend having to treat it as a hard failure.
+#[derive(Clone, Debug)]
+pub struct CompleteMultipartResponse {
+    /// An error embedded in the 200 response body, if present.
+    pub error: Option<CompleteMultipartError>,
+}
+
+/// An error embedded in a 200 response from a complete-multipart request.
+#[derive(Clone, Debug)]
+pub struct CompleteMultipartError {
+    /// S3/GCS error code (e.g. `InternalError`).
+    pub code: String,
+    /// Human-readable error description.
+    pub message: String,
+}

--- a/objectstore-service/src/multipart.rs
+++ b/objectstore-service/src/multipart.rs
@@ -34,10 +34,28 @@ pub struct CompletedPart {
     pub etag: ETag,
 }
 
-/// Response from
+/// Error optionally returned by
+/// [`MultipartUploadBackend::complete_multipart`](crate::backend::common::MultipartUploadBackend::complete_multipart).
+#[derive(Clone, Debug)]
+pub struct CompleteMultipartError {
+    /// Error code or identifier.
+    pub code: String,
+    /// Human-readable error description.
+    pub message: String,
+}
+
+/// Response for
+/// [`MultipartUploadBackend::initiate_multipart`](crate::backend::common::MultipartUploadBackend::initiate_multipart).
+pub type InitiateMultipartResponse = UploadId;
+
+/// Response for
+/// [`MultipartUploadBackend::upload_part`](crate::backend::common::MultipartUploadBackend::upload_part).
+pub type UploadPartResponse = ETag;
+
+/// Response for
 /// [`MultipartUploadBackend::list_parts`](crate::backend::common::MultipartUploadBackend::list_parts).
 #[derive(Clone, Debug)]
-pub struct ListedParts {
+pub struct ListPartsResponse {
     /// Parts uploaded so far, in `part_number` order.
     pub parts: Vec<Part>,
     /// Set when the listing was truncated and more parts can be fetched
@@ -49,35 +67,10 @@ pub struct ListedParts {
     pub next_part_number_marker: Option<PartNumber>,
 }
 
-/// Backend response for
-/// [`MultipartUploadBackend::initiate_multipart`](crate::backend::common::MultipartUploadBackend::initiate_multipart).
-pub type InitiateMultipartResponse = UploadId;
-/// Backend response for
-/// [`MultipartUploadBackend::upload_part`](crate::backend::common::MultipartUploadBackend::upload_part).
-pub type UploadPartResponse = ETag;
-/// Backend response for
-/// [`MultipartUploadBackend::list_parts`](crate::backend::common::MultipartUploadBackend::list_parts).
-pub type ListPartsResponse = ListedParts;
-/// Backend response for
+/// Response for
 /// [`MultipartUploadBackend::abort_multipart`](crate::backend::common::MultipartUploadBackend::abort_multipart).
 pub type AbortMultipartResponse = ();
-/// Backend response for
-/// [`MultipartUploadBackend::complete_multipart`](crate::backend::common::MultipartUploadBackend::complete_multipart).
-///
-/// S3-compatible APIs can return HTTP 200 with an error body on complete-multipart.
-/// This struct mirrors that behavior so callers can inspect the error without the
-/// backend having to treat it as a hard failure.
-#[derive(Clone, Debug)]
-pub struct CompleteMultipartResponse {
-    /// An error embedded in the 200 response body, if present.
-    pub error: Option<CompleteMultipartError>,
-}
 
-/// An error embedded in a 200 response from a complete-multipart request.
-#[derive(Clone, Debug)]
-pub struct CompleteMultipartError {
-    /// S3/GCS error code (e.g. `InternalError`).
-    pub code: String,
-    /// Human-readable error description.
-    pub message: String,
-}
+/// Response for
+/// [`MultipartUploadBackend::complete_multipart`](crate::backend::common::MultipartUploadBackend::complete_multipart).
+pub type CompleteMultipartResponse = Option<CompleteMultipartError>;

--- a/objectstore-service/src/multipart.rs
+++ b/objectstore-service/src/multipart.rs
@@ -12,7 +12,7 @@ pub type ETag = String;
 /// Description of one part in the response to
 /// [`MultipartUploadBackend::list_parts`](crate::backend::common::MultipartUploadBackend::list_parts).
 #[derive(Clone, Debug)]
-pub struct PartInfo {
+pub struct Part {
     /// 1-indexed position of this part within the upload.
     pub part_number: PartNumber,
     /// Identifier returned when the part was uploaded.
@@ -39,7 +39,7 @@ pub struct CompletedPart {
 #[derive(Clone, Debug)]
 pub struct ListedParts {
     /// Parts uploaded so far, in `part_number` order.
-    pub parts: Vec<PartInfo>,
+    pub parts: Vec<Part>,
     /// Set when the listing was truncated and more parts can be fetched
     /// using [`Self::next_part_number_marker`] as the next
     /// `part_number_marker`.


### PR DESCRIPTION
Implements multipart uploads on the GcsBackend, using the S3-compatible XML API.
Ideally this implementation could go in `s3_compatible.rs` and be shared, which I've attempted, but this wasn't that easy due to auth differences between the two.

Also reduces some indirection in the service types.

A follow-up PR will add tests against a fork of our emulator (Google's `storage-testbench`) where I implemented this API.

Closes FS-338