### PR TITLE
fix(server): Use actual elapsed time for bandwidth estimation

### DIFF
--- a/objectstore-server/src/rate_limits.rs
+++ b/objectstore-server/src/rate_limits.rs
@@ -380,6 +380,9 @@ impl BandwidthRateLimiter {
         const TICK: Duration = Duration::from_millis(50); // Recompute EWMA on every TICK
 
         let mut interval = tokio::time::interval(TICK);
+        // The first tick of a tokio interval fires immediately. Consume it so the
+        // first real iteration has a full ~50ms of elapsed time.
+        interval.tick().await;
         let mut last = Instant::now();
         let mut global_ewma: f64 = 0.0;
         // Shadow EWMAs for per-usecase/per-scope entries, keyed the same way as the maps.

--- a/objectstore-server/src/rate_limits.rs
+++ b/objectstore-server/src/rate_limits.rs
@@ -380,7 +380,7 @@ impl BandwidthRateLimiter {
         const TICK: Duration = Duration::from_millis(50); // Recompute EWMA on every TICK
 
         let mut interval = tokio::time::interval(TICK);
-        let to_bps = 1.0 / TICK.as_secs_f64(); // Conversion factor from bytes to bps
+        let mut last = Instant::now();
         let mut global_ewma: f64 = 0.0;
         // Shadow EWMAs for per-usecase/per-scope entries, keyed the same way as the maps.
         let mut usecase_ewmas: std::collections::HashMap<String, f64> =
@@ -390,6 +390,10 @@ impl BandwidthRateLimiter {
 
         loop {
             interval.tick().await;
+
+            let now = Instant::now();
+            let to_bps = 1.0 / now.duration_since(last).as_secs_f64();
+            last = now;
 
             // Global
             global.update_ewma(&mut global_ewma, to_bps);

--- a/objectstore-server/src/rate_limits.rs
+++ b/objectstore-server/src/rate_limits.rs
@@ -380,6 +380,7 @@ impl BandwidthRateLimiter {
         const TICK: Duration = Duration::from_millis(50); // Recompute EWMA on every TICK
 
         let mut interval = tokio::time::interval(TICK);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         // The first tick of a tokio interval fires immediately. Consume it so the
         // first real iteration has a full ~50ms of elapsed time.
         interval.tick().await;
@@ -558,6 +559,7 @@ impl ThroughputRateLimiter {
         tokio::task::spawn(async move {
             const TICK: Duration = Duration::from_millis(50);
             let mut interval = tokio::time::interval(TICK);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             interval.tick().await;
             let mut last = Instant::now();
             let mut global_ewma: f64 = 0.0;

--- a/objectstore-server/src/rate_limits.rs
+++ b/objectstore-server/src/rate_limits.rs
@@ -558,10 +558,14 @@ impl ThroughputRateLimiter {
         tokio::task::spawn(async move {
             const TICK: Duration = Duration::from_millis(50);
             let mut interval = tokio::time::interval(TICK);
-            let to_rps = 1.0 / TICK.as_secs_f64();
+            interval.tick().await;
+            let mut last = Instant::now();
             let mut global_ewma: f64 = 0.0;
             loop {
                 interval.tick().await;
+                let now = Instant::now();
+                let to_rps = 1.0 / now.duration_since(last).as_secs_f64();
+                last = now;
                 global_estimator.update_ewma(&mut global_ewma, to_rps);
                 objectstore_metrics::gauge!("server.throughput.ewma" = global_ewma.floor() as u64);
                 if let Some(limit) = global_limit {


### PR DESCRIPTION
The bandwidth EWMA conversion factor was computed from the nominal 50ms tick duration.
If the system is under load, it's possible that the accumulator accumulates bytes for more than 50ms but then still divides as if only 50ms has passed, inflating the estimate.
This changes it so that we use the elapsed time for the computation.
Hopefully this improves the precision of the estimate.