### PR TITLE
fix(server): Enforce per-field size limit during streaming read

### DIFF
--- a/objectstore-server/src/extractors/batch.rs
+++ b/objectstore-server/src/extractors/batch.rs
@@ -9,6 +9,7 @@ use axum::extract::{
     FromRequest, Multipart, Request,
     multipart::{Field, MultipartError, MultipartRejection},
 };
+use bytes::BytesMut;
 use futures::{StreamExt, stream::BoxStream};
 use objectstore_service::streaming::{Delete, Get, Insert, Operation};
 use objectstore_types::metadata::Metadata;
@@ -50,7 +51,7 @@ pub enum BatchError {
     },
 }
 
-async fn try_operation_from_field(field: Field<'_>) -> Result<Operation, BatchError> {
+async fn try_operation_from_field(mut field: Field<'_>) -> Result<Operation, BatchError> {
     let kind = field
         .headers()
         .get(HEADER_BATCH_OPERATION_KIND)
@@ -103,16 +104,19 @@ async fn try_operation_from_field(field: Field<'_>) -> Result<Operation, BatchEr
         }),
         "insert" => {
             let metadata = Metadata::from_headers(field.headers(), "")?;
-            let payload = field.bytes().await?;
-            if payload.len() > MAX_FIELD_SIZE {
-                return Err(BatchError::LimitExceeded(format!(
-                    "individual request in batch exceeds body size limit of {MAX_FIELD_SIZE} bytes"
-                )));
+            let mut payload = BytesMut::new();
+            while let Some(chunk) = field.chunk().await? {
+                if payload.len() + chunk.len() > MAX_FIELD_SIZE {
+                    return Err(BatchError::LimitExceeded(format!(
+                        "individual request in batch exceeds body size limit of {MAX_FIELD_SIZE} bytes"
+                    )));
+                }
+                payload.extend_from_slice(&chunk);
             }
             Operation::Insert(Insert {
                 key,
                 metadata,
-                payload,
+                payload: payload.freeze(),
             })
         }
         _ => {


### PR DESCRIPTION
In batch insert operations, `field.bytes().await` buffered the entire multipart field into memory before checking the 1 MB `MAX_FIELD_SIZE` limit. Since axum/multer only enforce a 1 GB total-body limit (via `DefaultBodyLimit`), a single insert field could allocate up to 1 GB before being rejected — the per-field cap was only checked after the full read.

**Streaming size check**

Replaces `field.bytes()` with a `field.chunk()` loop that checks accumulated size on each chunk and bails early. Memory per field is now bounded to ~1 MB + one chunk instead of ~1 GB.

Note: multer's built-in `SizeLimit::per_field()` can't be used here because it also enforces the limit during the drain phase when `next_field()` skips unconsumed field data — this would break error isolation for subsequent batch operations.