### PR TITLE
fix(ci): use oidc for codecov coverage uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ env:
   CARGO_TERM_COLOR: always
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
@@ -128,7 +129,7 @@ jobs:
         with:
           files: lcov.info
           flags: rust
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
 
   test-python:
     name: Test Python
@@ -165,7 +166,7 @@ jobs:
         with:
           files: python-coverage.xml
           flags: python
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
 
   docs:
     name: Build and Publish Documentation


### PR DESCRIPTION
don't know why the token we had wasn't working but oidc is a simple alternative