### PR TITLE
fix(py-client): Unpin `uv_build`

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.11.3,<0.12"]
+requires = ["uv_build"]
 build-backend = "uv_build"
 
 [dependency-groups]


### PR DESCRIPTION
Reverts https://github.com/getsentry/objectstore/pull/420 until we find a better approach.
Putting an upper bound on `uv_build` causes publishing to our internal PyPI to fail (https://github.com/getsentry/pypi/pull/2117) because it only has `uv` versions `0.9.26` and `0.9.28` available in that index.