### PR TITLE
feat(py-client): Pin `uv_build==0.9.26`

### DIFF
--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 ]
 
 [build-system]
-requires = ["uv_build"]
+requires = ["uv_build==0.9.26"]
 build-backend = "uv_build"
 
 [dependency-groups]


### PR DESCRIPTION
This should work because it's available in our internal PyPI, and it's better than not pinning.