### PR TITLE
chore: Use `uv sync` with `--locked` everywhere

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,7 +5,7 @@ if ! command -v uv >/dev/null 2>&1; then
     return 1
 fi
 
-uv sync --all-packages --all-groups
+uv sync --all-packages --all-groups --locked
 source .venv/bin/activate
 
 source_env_if_exists .envrc.private

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: astral-sh/setup-uv@5a7eac68fb9809dea845d802897dc5c723910fa3 # v7.1.3
 
       - name: Install dependencies
-        run: uv sync --all-packages --all-groups
+        run: uv sync --all-packages --all-groups --locked
 
       - name: Format
         run: uv run ruff format
@@ -155,7 +155,7 @@ jobs:
       - uses: astral-sh/setup-uv@5a7eac68fb9809dea845d802897dc5c723910fa3 # v7.1.3
 
       - name: Install dependencies
-        run: uv sync --all-packages --all-groups
+        run: uv sync --all-packages --all-groups --locked
 
       - name: Run tests with coverage
         run: uv run pytest clients/python --cov=clients/python/src --cov-report=xml:python-coverage.xml
@@ -201,7 +201,7 @@ jobs:
       - uses: astral-sh/setup-uv@5a7eac68fb9809dea845d802897dc5c723910fa3 # v7.1.3
 
       - name: Install Python dependencies
-        run: uv sync --all-packages --all-groups
+        run: uv sync --all-packages --all-groups --locked
 
       - name: Build Python Docs
         run: |


### PR DESCRIPTION
Like the `cargo` flag, this will make CI fail if `uv.lock` is out of sync with `pyproject.toml`.