### PR TITLE
fix(bigtable): Fix `time_expires` derivation

### DIFF
--- a/objectstore-service/src/backend/bigtable.rs
+++ b/objectstore-service/src/backend/bigtable.rs
@@ -527,7 +527,12 @@ impl RowData {
 
         for cell in cells {
             // NB: All cells are written with the same timestamp; last write is safe.
-            expire_at = micros_to_time(cell.timestamp_micros);
+
+            // Only derive expiration from GC-family cells — manual-family cells
+            // use server-assigned timestamps that don't represent expiration.
+            if cell.family_name == FAMILY_GC {
+                expire_at = micros_to_time(cell.timestamp_micros);
+            }
 
             match cell.qualifier.as_slice() {
                 COLUMN_REDIRECT => {


### PR DESCRIPTION
This fixes a bug where, if an object is written with `ExpirationPolicy::Manual`, and it goes to Bigtable, then you will get a bogus timestamp ([here](https://docs.cloud.google.com/bigtable/docs/reference/data/rpc/google.bigtable.v2#google.bigtable.v2.Mutation.SetCell:~:text=the%20empty%20string.-,timestamp_micros,-int64) documented to be the time when the server created the row, obtained because we [pass -1 as the timestamp](https://github.com/getsentry/objectstore/blob/1615f71d97624af34f73a749555193d4884936eb/objectstore-service/src/backend/bigtable.rs#L406)) in the `x-sn-time-expires` header (i.e. `Metadata::time_expires`) when fetching the object back with a GET request.

Such objects should instead carry no `Metadata::expiration`, indicating that they don't expire.

On another note, we most likely don't want such objects, but they can theoretically exist (I encountered this while testing some stuff manually), so might as well fix this.

