### PR TITLE
Revert "chore: Use `uv sync` with `--locked` everywhere"

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,7 +5,7 @@ if ! command -v uv >/dev/null 2>&1; then
     return 1
 fi
 
-uv sync --all-packages --all-groups --locked
+uv sync --all-packages --all-groups
 source .venv/bin/activate
 
 source_env_if_exists .envrc.private

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: astral-sh/setup-uv@5a7eac68fb9809dea845d802897dc5c723910fa3 # v7.1.3
 
       - name: Install dependencies
-        run: uv sync --all-packages --all-groups --locked
+        run: uv sync --all-packages --all-groups
 
       - name: Format
         run: uv run ruff format
@@ -155,7 +155,7 @@ jobs:
       - uses: astral-sh/setup-uv@5a7eac68fb9809dea845d802897dc5c723910fa3 # v7.1.3
 
       - name: Install dependencies
-        run: uv sync --all-packages --all-groups --locked
+        run: uv sync --all-packages --all-groups
 
       - name: Run tests with coverage
         run: uv run pytest clients/python --cov=clients/python/src --cov-report=xml:python-coverage.xml
@@ -201,7 +201,7 @@ jobs:
       - uses: astral-sh/setup-uv@5a7eac68fb9809dea845d802897dc5c723910fa3 # v7.1.3
 
       - name: Install Python dependencies
-        run: uv sync --all-packages --all-groups --locked
+        run: uv sync --all-packages --all-groups
 
       - name: Build Python Docs
         run: |


### PR DESCRIPTION
Reverts getsentry/objectstore#472

I think this was a mistake. Since the Python part here is a library, we should have a lax version requirement, and let users bring their own version.