### PR TITLE
chore(gocd): bump gocd-jsonnet lib to v3.0.4

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v3.0.3"
+      "version": "v3.0.4"
     }
   ],
   "legacyImports": true


### PR DESCRIPTION
## Summary

- Bumps `gocd-jsonnet` lib from `v3.0.3` to `v3.0.4` in `gocd/templates/jsonnetfile.json`

## Test plan

- [ ] GoCD pipeline picks up the updated jsonnet lib version