### PR TITLE
fix(server): Apply Sentry middleware first

### DIFF
--- a/objectstore-server/src/web/app.rs
+++ b/objectstore-server/src/web/app.rs
@@ -32,9 +32,9 @@ impl App {
         //  - Requests go from top to bottom
         //  - Responses go from bottom to top
         let middleware = ServiceBuilder::new()
+            .layer(axum::middleware::from_fn(m::emit_request_metrics))
             .layer(NewSentryLayer::new_from_top())
             .layer(SentryHttpLayer::new().enable_transaction())
-            .layer(axum::middleware::from_fn(m::emit_request_metrics))
             .layer(axum::middleware::from_fn_with_state(
                 state.request_counter.clone(),
                 m::limit_web_concurrency,

--- a/objectstore-server/src/web/app.rs
+++ b/objectstore-server/src/web/app.rs
@@ -32,6 +32,8 @@ impl App {
         //  - Requests go from top to bottom
         //  - Responses go from bottom to top
         let middleware = ServiceBuilder::new()
+            .layer(NewSentryLayer::new_from_top())
+            .layer(SentryHttpLayer::new().enable_transaction())
             .layer(axum::middleware::from_fn(m::emit_request_metrics))
             .layer(axum::middleware::from_fn_with_state(
                 state.request_counter.clone(),
@@ -40,8 +42,6 @@ impl App {
             .layer(state.request_counter.layer())
             .layer(CatchPanicLayer::custom(m::handle_panic))
             .layer(m::set_server_header())
-            .layer(NewSentryLayer::new_from_top())
-            .layer(SentryHttpLayer::new().enable_transaction())
             .layer(
                 TraceLayer::new_for_http()
                     .make_span_with(m::make_http_span)


### PR DESCRIPTION
I noticed that some of our errors in Sentry have wrong trace correlation, and e.g. logs for multiple requests show up in the logs tab for a single error (this is just a symptom of wrong trace correlation i.e. using the wrong Hub).

I haven't found the root cause, so this probably doesn't really fix anything, but it's the correct order in principle.

However, if we logged anything in the other middleware (which I think we do in `limit_web_concurrency`), without this fix those logs would not show up under the trace for the request we're making (because there wouldn't be one yet), so this fixes at least those potential cases.