### PR TITLE
feat!(types): Use MediaTypeBuf for Metadata.content_type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,6 +2139,9 @@ name = "mediatype"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "120fa187be19d9962f0926633453784691731018a2bf936ddb4e29101b79c4a7"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "memchr"
@@ -2571,6 +2574,7 @@ dependencies = [
  "futures-util",
  "infer",
  "jsonwebtoken",
+ "mediatype",
  "multer",
  "objectstore-test",
  "objectstore-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ http = "1.3.1"
 humantime = "2.2.0"
 humantime-serde = "1.1.1"
 jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
+mediatype = { version = "0.21.0", features = ["serde"] }
 rand = "0.9.3"
 regex = "1.12.3"
 # Same as default features on 0.12.x (0.13.x uses rustls by default)

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -18,6 +18,7 @@ bytes = { workspace = true }
 futures-util = { workspace = true }
 infer = { version = "0.19.0", default-features = false }
 jsonwebtoken = { workspace = true }
+mediatype = { workspace = true }
 multer = "3.1.0"
 objectstore-types = { workspace = true }
 reqwest = { version = "0.13.1", default-features = false, features = ["charset", "http2", "system-proxy", "json", "stream", "multipart"] }

--- a/clients/rust/src/multipart.rs
+++ b/clients/rust/src/multipart.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::collections::BTreeMap;
 
 use base64::Engine as _;
@@ -119,8 +118,8 @@ impl InitiateMultipartBuilder {
     ///
     /// You can use the utility function [`crate::utils::guess_mime_type`] to attempt to guess a
     /// `content_type` based on magic bytes.
-    pub fn content_type(mut self, content_type: impl Into<Cow<'static, str>>) -> Self {
-        self.metadata.content_type = content_type.into();
+    pub fn content_type(mut self, content_type: mediatype::MediaTypeBuf) -> Self {
+        self.metadata.content_type = content_type;
         self
     }
 

--- a/clients/rust/src/put.rs
+++ b/clients/rust/src/put.rs
@@ -1,7 +1,7 @@
+use std::collections::BTreeMap;
 use std::fmt;
 use std::io::{self, Cursor};
 use std::path::PathBuf;
-use std::{borrow::Cow, collections::BTreeMap};
 
 use async_compression::tokio::bufread::ZstdEncoder;
 use bytes::Bytes;
@@ -141,8 +141,8 @@ impl PutBuilder {
     ///
     /// You can use the utility function [`crate::utils::guess_mime_type`] to attempt to guess a
     /// `content_type` based on magic bytes.
-    pub fn content_type(mut self, content_type: impl Into<Cow<'static, str>>) -> Self {
-        self.metadata.content_type = content_type.into();
+    pub fn content_type(mut self, content_type: mediatype::MediaTypeBuf) -> Self {
+        self.metadata.content_type = content_type;
         self
     }
 

--- a/clients/rust/src/utils.rs
+++ b/clients/rust/src/utils.rs
@@ -1,6 +1,8 @@
 //! Utility functions that might be useful when working with Objectstore.
 
+use mediatype::MediaTypeBuf;
+
 /// Attempts to guess the MIME type from the given contents.
-pub fn guess_mime_type<T: AsRef<[u8]>>(contents: T) -> Option<&'static str> {
-    infer::get(contents.as_ref()).map(|kind| kind.mime_type())
+pub fn guess_mime_type<T: AsRef<[u8]>>(contents: T) -> Option<MediaTypeBuf> {
+    infer::get(contents.as_ref()).and_then(|kind| kind.mime_type().parse().ok())
 }

--- a/clients/rust/tests/multipart.rs
+++ b/clients/rust/tests/multipart.rs
@@ -212,7 +212,7 @@ async fn test_metadata_preserved() {
         .initiate_multipart_upload()
         .key("metadata-key")
         .compression(None)
-        .content_type("text/plain")
+        .content_type("text/plain".parse().unwrap())
         .origin("203.0.113.42")
         .append_metadata("my-key".to_string(), "my-value".to_string())
         .send()
@@ -224,7 +224,7 @@ async fn test_metadata_preserved() {
     let key = upload.complete([part]).await.unwrap();
 
     let response = session.get(&key).send().await.unwrap().unwrap();
-    assert_eq!(response.metadata.content_type, "text/plain");
+    assert_eq!(response.metadata.content_type.as_str(), "text/plain");
     assert_eq!(response.metadata.origin.as_deref(), Some("203.0.113.42"));
     assert_eq!(
         response.metadata.custom.get("my-key").map(String::as_str),

--- a/objectstore-server/src/extractors/batch.rs
+++ b/objectstore-server/src/extractors/batch.rs
@@ -255,7 +255,10 @@ mod tests {
             panic!("expected insert operation");
         };
         assert_eq!(insert_op1.key.as_deref(), Some("test1"));
-        assert_eq!(insert_op1.metadata.content_type, "application/octet-stream");
+        assert_eq!(
+            insert_op1.metadata.content_type.as_str(),
+            "application/octet-stream"
+        );
         assert_eq!(insert_op1.metadata.origin, None);
         assert_eq!(insert_op1.payload.as_ref(), insert1_data);
 
@@ -263,7 +266,7 @@ mod tests {
             panic!("expected insert operation");
         };
         assert_eq!(insert_op2.key.as_deref(), Some("test2"));
-        assert_eq!(insert_op2.metadata.content_type, "text/plain");
+        assert_eq!(insert_op2.metadata.content_type.as_str(), "text/plain");
         assert_eq!(insert_op2.metadata.expiration_policy, expiration);
         assert_eq!(insert_op2.metadata.origin.as_deref(), Some("203.0.113.42"));
         assert_eq!(insert_op2.payload.as_ref(), insert2_data);

--- a/objectstore-service/src/backend/bigtable.rs
+++ b/objectstore-service/src/backend/bigtable.rs
@@ -1341,7 +1341,7 @@ mod tests {
 
         let id = make_id();
         let metadata = Metadata {
-            content_type: "text/plain".into(),
+            content_type: "text/plain".parse().unwrap(),
             time_created: Some(SystemTime::now()),
             custom: BTreeMap::from_iter([("hello".into(), "world".into())]),
             ..Default::default()
@@ -1567,7 +1567,7 @@ mod tests {
         // object
         let id = make_id();
         let put_meta = Metadata {
-            content_type: "text/plain".into(),
+            content_type: "text/plain".parse().unwrap(),
             custom: BTreeMap::from_iter([("k".into(), "v".into())]),
             ..Default::default()
         };

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -134,7 +134,7 @@ impl GcsObject {
     /// Converts our Metadata type to GCS JSON object metadata.
     pub fn from_metadata(metadata: &Metadata) -> Self {
         let mut gcs_object = GcsObject {
-            content_type: metadata.content_type.clone(),
+            content_type: metadata.content_type.to_string().into(),
             size: metadata.size.map(|size| size.to_string()),
             content_encoding: None,
             custom_time: None,
@@ -189,7 +189,11 @@ impl GcsObject {
 
         let origin = self.metadata.remove(&GcsMetaKey::Origin);
 
-        let content_type = self.content_type;
+        let content_type: objectstore_types::metadata::MediaTypeBuf =
+            self.content_type.parse().map_err(|e| Error::Generic {
+                context: "GCS: invalid content type in object metadata".to_string(),
+                cause: Some(Box::new(e)),
+            })?;
         let compression = self.content_encoding.map(|s| s.parse()).transpose()?;
         let size = self
             .size
@@ -631,9 +635,9 @@ impl Backend for GcsBackend {
             .part(
                 "media",
                 multipart::Part::stream(Body::wrap_stream(stream))
-                    .mime_str(&metadata.content_type)
+                    .mime_str(metadata.content_type.as_str())
                     .map_err(|e| Error::Generic {
-                        context: format!("invalid mime type: {}", &metadata.content_type),
+                        context: format!("invalid mime type: {}", metadata.content_type),
                         cause: Some(Box::new(e)),
                     })?,
             );
@@ -845,7 +849,7 @@ impl MultipartUploadBackend for GcsBackend {
         let mut builder = self
             .request(Method::POST, url)
             .await?
-            .header(header::CONTENT_TYPE, metadata.content_type.as_ref())
+            .header(header::CONTENT_TYPE, metadata.content_type.as_str())
             .header(header::CONTENT_LENGTH, "0");
 
         let meta_headers = metadata_to_gcs_headers(metadata)?;
@@ -1057,7 +1061,7 @@ mod tests {
 
         let id = make_id();
         let metadata = Metadata {
-            content_type: "text/plain".into(),
+            content_type: "text/plain".parse().unwrap(),
             expiration_policy: ExpirationPolicy::Manual,
             compression: None,
             origin: Some("203.0.113.42".into()),
@@ -1209,7 +1213,7 @@ mod tests {
 
         let id = make_id();
         let metadata = Metadata {
-            content_type: "text/plain".into(),
+            content_type: "text/plain".parse().unwrap(),
             origin: Some("203.0.113.42".into()),
             custom: BTreeMap::from_iter([("hello".into(), "world".into())]),
             ..Default::default()
@@ -1246,7 +1250,7 @@ mod tests {
         // TTI must exceed TTI_DEBOUNCE (1 day) for the bump condition to be reachable.
         let tti = Duration::from_secs(2 * 24 * 3600); // 2 days
         let metadata = Metadata {
-            content_type: "text/plain".into(),
+            content_type: "text/plain".parse().unwrap(),
             expiration_policy: ExpirationPolicy::TimeToIdle(tti),
             ..Default::default()
         };
@@ -1289,7 +1293,7 @@ mod tests {
         // TTI must exceed TTI_DEBOUNCE (1 day) for the bump condition to be reachable.
         let tti = Duration::from_secs(2 * 24 * 3600); // 2 days
         let metadata = Metadata {
-            content_type: "text/plain".into(),
+            content_type: "text/plain".parse().unwrap(),
             expiration_policy: ExpirationPolicy::TimeToIdle(tti),
             ..Default::default()
         };
@@ -1325,7 +1329,7 @@ mod tests {
 
         let id = make_id();
         let metadata = Metadata {
-            content_type: "text/plain".into(),
+            content_type: "text/plain".parse().unwrap(),
             compression: Some(Compression::Zstd),
             ..Default::default()
         };
@@ -1351,7 +1355,7 @@ mod tests {
         let backend = create_test_backend().await?;
         let id = make_id();
         let metadata = Metadata {
-            content_type: "text/plain".into(),
+            content_type: "text/plain".parse().unwrap(),
             expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_mins(33)),
             origin: Some("203.0.113.42".into()),
             custom: BTreeMap::from_iter([("hello".into(), "world".into())]),
@@ -1387,7 +1391,7 @@ mod tests {
         let (meta, stream) = backend.get_object(&id).await?.unwrap();
         let payload = stream::read_to_vec(stream).await?;
         assert_eq!(payload, data);
-        assert_eq!(meta.content_type, "text/plain".to_string());
+        assert_eq!(meta.content_type.as_str(), "text/plain");
         assert_eq!(
             meta.expiration_policy,
             ExpirationPolicy::TimeToLive(Duration::from_mins(33))
@@ -1727,7 +1731,7 @@ mod tests {
 
         let id = make_id();
         let metadata = Metadata {
-            content_type: "text/plain".into(),
+            content_type: "text/plain".parse().unwrap(),
             compression: Some(Compression::Zstd),
             ..Default::default()
         };

--- a/objectstore-service/src/backend/in_memory.rs
+++ b/objectstore-service/src/backend/in_memory.rs
@@ -482,7 +482,7 @@ mod tests {
         let backend = InMemoryBackend::new("test");
         let id = make_id();
         let metadata = Metadata {
-            content_type: "text/plain".into(),
+            content_type: "text/plain".parse().unwrap(),
             expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_secs(3600)),
             origin: Some("203.0.113.42".into()),
             custom: [("foo".into(), "bar".into())].into(),
@@ -520,7 +520,7 @@ mod tests {
         let (meta, body) = backend.get_object(&id).await.unwrap().unwrap();
         let payload = stream::read_to_vec(body).await.unwrap();
         assert_eq!(payload, data);
-        assert_eq!(meta.content_type, "text/plain".to_string());
+        assert_eq!(meta.content_type.as_str(), "text/plain");
         assert_eq!(
             meta.expiration_policy,
             ExpirationPolicy::TimeToIdle(Duration::from_secs(3600))

--- a/objectstore-service/src/backend/local_fs.rs
+++ b/objectstore-service/src/backend/local_fs.rs
@@ -452,7 +452,7 @@ mod tests {
         });
 
         let metadata = Metadata {
-            content_type: "text/plain".into(),
+            content_type: "text/plain".parse().unwrap(),
             expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_secs(3600)),
             time_created: Some(SystemTime::now()),
             time_expires: None,
@@ -492,7 +492,7 @@ mod tests {
         });
 
         let metadata = Metadata {
-            content_type: "text/plain".into(),
+            content_type: "text/plain".parse().unwrap(),
             compression: Some(Compression::Zstd),
             origin: Some("203.0.113.42".into()),
             custom: [("foo".into(), "bar".into())].into(),
@@ -549,7 +549,7 @@ mod tests {
         let (_tempdir, backend) = make_backend();
         let id = make_id();
         let metadata = Metadata {
-            content_type: "text/plain".into(),
+            content_type: "text/plain".parse().unwrap(),
             expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_secs(3600)),
             origin: Some("203.0.113.42".into()),
             custom: [("foo".into(), "bar".into())].into(),
@@ -587,7 +587,7 @@ mod tests {
         let (meta, body) = backend.get_object(&id).await.unwrap().unwrap();
         let payload: BytesMut = body.try_collect().await.unwrap();
         assert_eq!(payload.as_ref(), data);
-        assert_eq!(meta.content_type, "text/plain".to_string());
+        assert_eq!(meta.content_type.as_str(), "text/plain");
         assert_eq!(
             meta.expiration_policy,
             ExpirationPolicy::TimeToIdle(Duration::from_secs(3600))

--- a/objectstore-service/src/backend/tiered.rs
+++ b/objectstore-service/src/backend/tiered.rs
@@ -922,7 +922,7 @@ mod tests {
         let id = make_id("large");
         let payload = vec![0xCDu8; 2 * 1024 * 1024]; // 2 MiB, over threshold
         let metadata_in = Metadata {
-            content_type: "image/png".into(),
+            content_type: "image/png".parse().unwrap(),
             expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_secs(3600)),
             origin: Some("10.0.0.1".into()),
             ..Default::default()
@@ -945,7 +945,7 @@ mod tests {
 
         // LT object at revision key with correct metadata.
         let (lt_meta, _) = lt.get(&lt_id).expect_object();
-        assert_eq!(lt_meta.content_type, "image/png");
+        assert_eq!(lt_meta.content_type.as_str(), "image/png");
         assert_eq!(lt_meta.expiration_policy, metadata_in.expiration_policy);
 
         // get_object follows the tombstone and returns the correct payload.
@@ -955,7 +955,7 @@ mod tests {
 
         // get_metadata follows the tombstone and returns the correct content_type.
         let metadata = storage.get_metadata(&id).await.unwrap().unwrap();
-        assert_eq!(metadata.content_type, "image/png");
+        assert_eq!(metadata.content_type.as_str(), "image/png");
     }
 
     // --- Put overwrites ---
@@ -1563,7 +1563,7 @@ mod tests {
         let (storage, hv, lt, _) = make_tiered_storage();
         let id = make_id("mp-single");
         let metadata = Metadata {
-            content_type: "application/octet-stream".into(),
+            content_type: "application/octet-stream".parse().unwrap(),
             expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_secs(3600)),
             ..Default::default()
         };
@@ -1603,7 +1603,7 @@ mod tests {
         let (got_meta, s) = storage.get_object(&id).await.unwrap().unwrap();
         let body = stream::read_to_vec(s).await.unwrap();
         assert_eq!(body, payload);
-        assert_eq!(got_meta.content_type, "application/octet-stream");
+        assert_eq!(got_meta.content_type.as_str(), "application/octet-stream");
 
         // HV should have a tombstone, LT should have the object at the physical key.
         let tombstone = hv.get(&id).expect_tombstone();

--- a/objectstore-types/Cargo.toml
+++ b/objectstore-types/Cargo.toml
@@ -13,7 +13,7 @@ publish = true
 http = { workspace = true }
 humantime = { workspace = true }
 humantime-serde = { workspace = true }
-mediatype = "0.21.0"
+mediatype = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 

--- a/objectstore-types/src/metadata.rs
+++ b/objectstore-types/src/metadata.rs
@@ -27,14 +27,15 @@
 //! The [`Metadata::from_headers`] and [`Metadata::to_headers`] methods accept
 //! a `prefix` parameter for this purpose.
 
-use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::str::FromStr;
+use std::sync::LazyLock;
 use std::time::{Duration, SystemTime};
 
 use http::header::{self, HeaderMap, HeaderName};
 use humantime::{format_duration, format_rfc3339_micros, parse_duration, parse_rfc3339};
+pub use mediatype::MediaTypeBuf;
 use serde::{Deserialize, Serialize};
 
 /// The custom HTTP header that contains the serialized [`ExpirationPolicy`].
@@ -49,7 +50,8 @@ pub const HEADER_ORIGIN: &str = "x-sn-origin";
 pub const HEADER_META_PREFIX: &str = "x-snme-";
 
 /// The default content type for objects without a known content type.
-pub const DEFAULT_CONTENT_TYPE: &str = "application/octet-stream";
+pub static DEFAULT_CONTENT_TYPE: LazyLock<MediaTypeBuf> =
+    LazyLock::new(|| MediaTypeBuf::from(mediatype::media_type!(APPLICATION / OCTET_STREAM)));
 
 /// Errors that can happen dealing with metadata
 #[derive(Debug, thiserror::Error)]
@@ -245,7 +247,7 @@ pub struct Metadata {
     /// IANA media type of the object (header: `Content-Type`).
     ///
     /// Defaults to [`DEFAULT_CONTENT_TYPE`] (`application/octet-stream`).
-    pub content_type: Cow<'static, str>,
+    pub content_type: MediaTypeBuf,
 
     /// The compression algorithm used for this object (header: `Content-Encoding`).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -284,9 +286,7 @@ impl Metadata {
             match *name {
                 // standard HTTP headers
                 header::CONTENT_TYPE => {
-                    let content_type = value.to_str()?;
-                    validate_content_type(content_type)?;
-                    metadata.content_type = content_type.to_owned().into();
+                    metadata.content_type = value.to_str()?.parse()?;
                 }
                 header::CONTENT_ENCODING => {
                     let compression = value.to_str()?;
@@ -351,7 +351,7 @@ impl Metadata {
         let mut headers = HeaderMap::new();
 
         // standard headers
-        headers.append(header::CONTENT_TYPE, content_type.parse()?);
+        headers.append(header::CONTENT_TYPE, content_type.as_str().parse()?);
         if let Some(compression) = compression {
             headers.append(header::CONTENT_ENCODING, compression.as_str().parse()?);
         }
@@ -386,20 +386,13 @@ impl Metadata {
     }
 }
 
-/// Validates that `content_type` is a valid [IANA Media
-/// Type](https://www.iana.org/assignments/media-types/media-types.xhtml).
-fn validate_content_type(content_type: &str) -> Result<(), Error> {
-    mediatype::MediaType::parse(content_type)?;
-    Ok(())
-}
-
 impl Default for Metadata {
     fn default() -> Self {
         Self {
             expiration_policy: ExpirationPolicy::Manual,
             time_created: None,
             time_expires: None,
-            content_type: DEFAULT_CONTENT_TYPE.into(),
+            content_type: DEFAULT_CONTENT_TYPE.clone(),
             compression: None,
             origin: None,
             size: None,
@@ -420,7 +413,7 @@ mod tests {
 
         let metadata = Metadata::from_headers(&headers, "").unwrap();
         assert_eq!(metadata.origin.as_deref(), Some("203.0.113.42"));
-        assert_eq!(metadata.content_type, "text/plain");
+        assert_eq!(metadata.content_type.as_str(), "text/plain");
     }
 
     #[test]
@@ -469,7 +462,7 @@ mod tests {
         headers.insert("content-encoding", "zstd".parse().unwrap());
 
         let metadata = Metadata::from_headers(&headers, "").unwrap();
-        assert_eq!(metadata.content_type, "application/json");
+        assert_eq!(metadata.content_type.as_str(), "application/json");
         assert_eq!(metadata.compression, Some(Compression::Zstd));
     }
 
@@ -565,7 +558,7 @@ mod tests {
             expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_secs(60)),
             time_created: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000)),
             time_expires: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_060)),
-            content_type: "text/html".into(),
+            content_type: "text/html".parse().unwrap(),
             compression: Some(Compression::Zstd),
             origin: Some("10.0.0.1".into()),
             size: None,
@@ -598,7 +591,7 @@ mod tests {
             expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_secs(7200)),
             time_created: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000)),
             time_expires: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_007_200)),
-            content_type: "image/png".into(),
+            content_type: "image/png".parse().unwrap(),
             compression: Some(Compression::Zstd),
             origin: Some("192.168.1.1".into()),
             size: None,
@@ -654,7 +647,7 @@ mod tests {
             expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_secs(3600)),
             time_created: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000)),
             time_expires: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_003_600)),
-            content_type: "application/json".into(),
+            content_type: "application/json".parse().unwrap(),
             compression: Some(Compression::Zstd),
             origin: Some("10.0.0.1".into()),
             size: Some(1024),
@@ -681,7 +674,7 @@ mod tests {
     #[test]
     fn default_metadata() {
         let metadata = Metadata::default();
-        assert_eq!(metadata.content_type, DEFAULT_CONTENT_TYPE);
+        assert_eq!(metadata.content_type, *DEFAULT_CONTENT_TYPE);
         assert_eq!(metadata.expiration_policy, ExpirationPolicy::Manual);
         assert!(metadata.compression.is_none());
         assert!(metadata.origin.is_none());


### PR DESCRIPTION
I noticed that we were using `Cow<'static, str>` and then using a util `vaildate_content_type` when deserializing, which I think is kinda weird, so this changes the type to use `mediatype::MediaTypeBuf` directly.

Most paths still remain fallible due to the need to de/serialize this field.

This is a breaking change for the rust client, as users will now have to pass a `MediaTypeBuf`.