### PR TITLE
feat(py-client): Add HEAD API

### DIFF
--- a/clients/python/src/objectstore_client/client.py
+++ b/clients/python/src/objectstore_client/client.py
@@ -441,6 +441,29 @@ class Session:
         """
         return self._make_url(key, full=True)
 
+    def head(self, key: str) -> Metadata | None:
+        """
+        Checks whether an object exists and retrieves its metadata.
+
+        Returns the object's ``Metadata`` if it exists, ``None`` otherwise.
+
+        If the object has a TTI expiration policy, this is considered an access,
+        and therefore bumps its expiration.
+        """
+        headers = self._make_headers()
+        with measure_storage_operation(
+            self._metrics_backend, "head", self._usecase.name
+        ):
+            response = self._pool.request(
+                "HEAD",
+                self._make_url(key),
+                headers=headers,
+            )
+            if response.status == 404:
+                return None
+            raise_for_status(response)
+            return Metadata.from_headers(response.headers)
+
     def delete(self, key: str) -> None:
         """
         Deletes the blob with the given `key`.

--- a/clients/python/tests/test_e2e.py
+++ b/clients/python/tests/test_e2e.py
@@ -169,6 +169,30 @@ def test_full_cycle(server_url: str) -> None:
     assert exc_info.value.status == 404
 
 
+def test_head(server_url: str) -> None:
+    client = Client(
+        server_url,
+        token=TestTokenGenerator.get(),
+    )
+    test_usecase = Usecase(
+        "test-usecase",
+        expiration_policy=TimeToLive(timedelta(days=1)),
+    )
+
+    session = client.session(test_usecase, org=42, project=1337)
+
+    object_key = session.put(b"test data", origin="203.0.113.42")
+
+    metadata = session.head(object_key)
+    assert metadata is not None
+    assert metadata.time_created is not None
+    assert metadata.origin == "203.0.113.42"
+
+    session.delete(object_key)
+
+    assert session.head(object_key) is None
+
+
 def test_full_cycle_with_origin(server_url: str) -> None:
     client = Client(
         server_url,


### PR DESCRIPTION
This API is already present in the Rust client and will be needed to bump TTI on individual debug files when we need to do so from the monolith.