### PR TITLE
feat(server): Add more info to rate limiting logs and metrics

### DIFF
--- a/objectstore-server/src/endpoints/batch.rs
+++ b/objectstore-server/src/endpoints/batch.rs
@@ -79,7 +79,7 @@ async fn batch(
         let state = Arc::clone(&state);
         let context = context.clone();
         move |_op| {
-            if state.rate_limiter.check(&context) {
+            if state.rate_limiter.check(&context, None) {
                 Ok(())
             } else {
                 Err(ApiError::from(BatchError::RateLimited))

--- a/objectstore-server/src/extractors/id.rs
+++ b/objectstore-server/src/extractors/id.rs
@@ -68,7 +68,7 @@ impl FromRequestParts<ServiceState> for Xt<ObjectId> {
             return Err(ObjectRejection::Killswitched);
         }
 
-        if !state.rate_limiter.check(id.context()) {
+        if !state.rate_limiter.check(id.context(), Some(id.key())) {
             return Err(ObjectRejection::RateLimited);
         }
 
@@ -141,7 +141,7 @@ impl FromRequestParts<ServiceState> for Xt<ObjectContext> {
             return Err(ObjectRejection::Killswitched);
         }
 
-        if !state.rate_limiter.check(&context) {
+        if !state.rate_limiter.check(&context, None) {
             return Err(ObjectRejection::RateLimited);
         }
 

--- a/objectstore-server/src/rate_limits.rs
+++ b/objectstore-server/src/rate_limits.rs
@@ -230,9 +230,14 @@ impl RateLimiter {
             return true;
         };
 
-        objectstore_metrics::count!("server.request.rate_limited", reason = rejection.as_str());
+        objectstore_metrics::count!(
+            "server.request.rate_limited",
+            reason = rejection.as_str(),
+            usecase = context.usecase.clone()
+        );
         objectstore_log::warn!(
             reason = rejection.as_str(),
+            usecase = &context.usecase,
             "Request rejected: rate limit exceeded"
         );
         false

--- a/objectstore-server/src/rate_limits.rs
+++ b/objectstore-server/src/rate_limits.rs
@@ -217,7 +217,7 @@ impl RateLimiter {
     /// Returns `true` if the request is admitted, `false` if it was rejected. On rejection, emits a
     /// `server.request.rate_limited` metric counter and a `warn!` log. Bandwidth is checked before
     /// throughput so that rejected requests are never counted toward admitted traffic.
-    pub fn check(&self, context: &ObjectContext) -> bool {
+    pub fn check(&self, context: &ObjectContext, key: Option<&str>) -> bool {
         // Bandwidth is checked first because it is a pure read (no token consumption).
         // Throughput increments the EWMA accumulator only on success, so checking it
         // second ensures rejected requests are never counted toward admitted traffic.
@@ -238,6 +238,8 @@ impl RateLimiter {
         objectstore_log::warn!(
             reason = rejection.as_str(),
             usecase = &context.usecase,
+            scopes = %context.scopes.as_api_path(),
+            key,
             "Request rejected: rate limit exceeded"
         );
         false
@@ -898,7 +900,7 @@ mod tests {
             .store(1, std::sync::atomic::Ordering::Relaxed);
 
         let context = make_context();
-        assert!(!limiter.check(&context));
+        assert!(!limiter.check(&context, None));
 
         // The throughput accumulator must still be 0.
         assert_eq!(


### PR DESCRIPTION
Threads down the `key` to `RateLimiter::check`, including the `usecase` in both rate limit logs and metrics, as well as the `scopes` and `key` in logs, to give us more information on which requests are rate limited.