### PR TITLE
fix(ci): make gocd asset upload retry-safe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,5 +194,5 @@ jobs:
           docker load --input /tmp/objectstore-amd64.tar
           docker run --rm amd64 version > /tmp/release-name
 
-          gsutil -m cp /tmp/release-name \
+          gcloud storage cp --no-clobber /tmp/release-name \
             "gs://dicd-team-devinfra-cd--objectstore/deployment-assets/$GITHUB_SHA/"


### PR DESCRIPTION
Same fix as getsentry/relay#6105, for objectstore's GoCD asset upload.

When the upload fails partway, re-running it fails: the `gha-gcr-push` SA can only create objects, not replace them, and re-uploading an object that already exists counts as replacing it (which needs delete). We switch to `gcloud storage cp --no-clobber`, which skips objects that already exist instead of replacing them, so a re-run is safe and needs no delete permission.

The read grant the SA needs for this is in getsentry/devinfra-deployment-service#880. No composite-upload change here, since this step only uploads the small `release-name` file. 
