### PR TITLE
ref: Use Duration helper methods for hours and minutes

### DIFF
--- a/bigtable-bench/src/main.rs
+++ b/bigtable-bench/src/main.rs
@@ -188,7 +188,7 @@ async fn main() -> anyhow::Result<()> {
             ]),
         };
         let metadata = Metadata {
-            expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_secs(3600)),
+            expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_hours(1)),
             ..Metadata::default()
         };
 

--- a/objectstore-server/src/usecases.rs
+++ b/objectstore-server/src/usecases.rs
@@ -214,14 +214,14 @@ mod tests {
     #[test]
     fn unconfigured_usecase_allows_ttl() {
         let usecases = UseCases::default();
-        let metadata = make_metadata(ExpirationPolicy::TimeToLive(Duration::from_secs(3600)));
+        let metadata = make_metadata(ExpirationPolicy::TimeToLive(Duration::from_hours(1)));
         usecases.validate("anything", &metadata).unwrap();
     }
 
     #[test]
     fn unconfigured_usecase_allows_tti() {
         let usecases = UseCases::default();
-        let metadata = make_metadata(ExpirationPolicy::TimeToIdle(Duration::from_secs(3600)));
+        let metadata = make_metadata(ExpirationPolicy::TimeToIdle(Duration::from_hours(1)));
         usecases.validate("anything", &metadata).unwrap();
     }
 
@@ -268,7 +268,7 @@ mod tests {
             },
         });
 
-        let metadata = make_metadata(ExpirationPolicy::TimeToLive(Duration::from_secs(3600)));
+        let metadata = make_metadata(ExpirationPolicy::TimeToLive(Duration::from_hours(1)));
         let err = usecases.validate("test", &metadata).unwrap_err();
         assert!(matches!(err, UseCaseError::PolicyNotAllowed { .. }));
     }
@@ -279,13 +279,13 @@ mod tests {
             expiration: ExpirationConfig {
                 ttl: DurationPolicyConfig {
                     allowed: true,
-                    max: Some(Duration::from_secs(7200)),
+                    max: Some(Duration::from_hours(2)),
                 },
                 ..ExpirationConfig::default()
             },
         });
 
-        let metadata = make_metadata(ExpirationPolicy::TimeToLive(Duration::from_secs(3600)));
+        let metadata = make_metadata(ExpirationPolicy::TimeToLive(Duration::from_hours(1)));
         usecases.validate("test", &metadata).unwrap();
     }
 
@@ -295,13 +295,13 @@ mod tests {
             expiration: ExpirationConfig {
                 ttl: DurationPolicyConfig {
                     allowed: true,
-                    max: Some(Duration::from_secs(3600)),
+                    max: Some(Duration::from_hours(1)),
                 },
                 ..ExpirationConfig::default()
             },
         });
 
-        let metadata = make_metadata(ExpirationPolicy::TimeToLive(Duration::from_secs(3600)));
+        let metadata = make_metadata(ExpirationPolicy::TimeToLive(Duration::from_hours(1)));
         usecases.validate("test", &metadata).unwrap();
     }
 
@@ -311,13 +311,13 @@ mod tests {
             expiration: ExpirationConfig {
                 ttl: DurationPolicyConfig {
                     allowed: true,
-                    max: Some(Duration::from_secs(3600)),
+                    max: Some(Duration::from_hours(1)),
                 },
                 ..ExpirationConfig::default()
             },
         });
 
-        let metadata = make_metadata(ExpirationPolicy::TimeToLive(Duration::from_secs(7200)));
+        let metadata = make_metadata(ExpirationPolicy::TimeToLive(Duration::from_hours(2)));
         let err = usecases.validate("test", &metadata).unwrap_err();
         assert!(matches!(err, UseCaseError::DurationExceeded { .. }));
     }
@@ -336,7 +336,7 @@ mod tests {
             },
         });
 
-        let metadata = make_metadata(ExpirationPolicy::TimeToIdle(Duration::from_secs(3600)));
+        let metadata = make_metadata(ExpirationPolicy::TimeToIdle(Duration::from_hours(1)));
         let err = usecases.validate("test", &metadata).unwrap_err();
         assert!(matches!(err, UseCaseError::PolicyNotAllowed { .. }));
     }
@@ -347,13 +347,13 @@ mod tests {
             expiration: ExpirationConfig {
                 tti: DurationPolicyConfig {
                     allowed: true,
-                    max: Some(Duration::from_secs(7200)),
+                    max: Some(Duration::from_hours(2)),
                 },
                 ..ExpirationConfig::default()
             },
         });
 
-        let metadata = make_metadata(ExpirationPolicy::TimeToIdle(Duration::from_secs(3600)));
+        let metadata = make_metadata(ExpirationPolicy::TimeToIdle(Duration::from_hours(1)));
         usecases.validate("test", &metadata).unwrap();
     }
 
@@ -363,13 +363,13 @@ mod tests {
             expiration: ExpirationConfig {
                 tti: DurationPolicyConfig {
                     allowed: true,
-                    max: Some(Duration::from_secs(3600)),
+                    max: Some(Duration::from_hours(1)),
                 },
                 ..ExpirationConfig::default()
             },
         });
 
-        let metadata = make_metadata(ExpirationPolicy::TimeToIdle(Duration::from_secs(7200)));
+        let metadata = make_metadata(ExpirationPolicy::TimeToIdle(Duration::from_hours(2)));
         let err = usecases.validate("test", &metadata).unwrap_err();
         assert!(matches!(err, UseCaseError::DurationExceeded { .. }));
     }
@@ -391,7 +391,7 @@ mod tests {
         let metadata = make_metadata(ExpirationPolicy::Manual);
         usecases.validate("test", &metadata).unwrap();
 
-        let metadata = make_metadata(ExpirationPolicy::TimeToLive(Duration::from_secs(3600)));
+        let metadata = make_metadata(ExpirationPolicy::TimeToLive(Duration::from_hours(1)));
         usecases.validate("test", &metadata).unwrap();
     }
 }

--- a/objectstore-server/tests/limits.rs
+++ b/objectstore-server/tests/limits.rs
@@ -589,7 +589,7 @@ async fn test_usecase_expiration_policy() -> Result<()> {
                         manual: ManualPolicyConfig { allowed: false },
                         ttl: DurationPolicyConfig {
                             allowed: true,
-                            max: Some(Duration::from_secs(90 * 24 * 3600)),
+                            max: Some(Duration::from_hours(90 * 24)),
                         },
                         tti: DurationPolicyConfig {
                             allowed: false,
@@ -609,7 +609,7 @@ async fn test_usecase_expiration_policy() -> Result<()> {
                         },
                         tti: DurationPolicyConfig {
                             allowed: true,
-                            max: Some(Duration::from_secs(90 * 24 * 3600)),
+                            max: Some(Duration::from_hours(90 * 24)),
                         },
                     },
                 },

--- a/objectstore-service/src/backend/bigtable.rs
+++ b/objectstore-service/src/backend/bigtable.rs
@@ -136,7 +136,7 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// reconnection, resulting in increased latency for those requests.
 const MAX_CHANNEL_AGE: Option<Duration> = Some(Duration::from_mins(50));
 /// Time to debounce bumping an object with configured TTI.
-const TTI_DEBOUNCE: Duration = Duration::from_secs(24 * 3600); // 1 day
+const TTI_DEBOUNCE: Duration = Duration::from_hours(24);
 /// Permission scopes required for accessing the BigTable data API.
 const TOKEN_SCOPES: &[&str] = &["https://www.googleapis.com/auth/bigtable.data"];
 
@@ -1441,7 +1441,7 @@ mod tests {
     async fn test_tti_bump() -> Result<()> {
         let backend = create_test_backend().await?;
         // TTI must exceed TTI_DEBOUNCE (1 day) for the bump condition to be reachable.
-        let tti = Duration::from_secs(2 * 24 * 3600); // 2 days
+        let tti = Duration::from_hours(2 * 24);
         let metadata = Metadata {
             expiration_policy: ExpirationPolicy::TimeToIdle(tti),
             ..Default::default()
@@ -1449,7 +1449,7 @@ mod tests {
 
         // Pass a backdated `now` so the written expiry is inside the bump window:
         // expire_at = past_now + tti = now - TTI_DEBOUNCE - 60s (stale but not yet expired).
-        let past_now = SystemTime::now() - TTI_DEBOUNCE - Duration::from_secs(60);
+        let past_now = SystemTime::now() - TTI_DEBOUNCE - Duration::from_mins(1);
 
         // Sub-sequence 1: get_object triggers bump (loaded=true path).
         let id1 = make_id();
@@ -1494,7 +1494,7 @@ mod tests {
 
         let id = make_id();
         // TTI must exceed TTI_DEBOUNCE (1 day) for the bump condition to be reachable.
-        let tti = Duration::from_secs(2 * 24 * 3600); // 2 days
+        let tti = Duration::from_hours(2 * 24);
         let metadata = Metadata {
             expiration_policy: ExpirationPolicy::TimeToIdle(tti),
             ..Default::default()
@@ -1734,7 +1734,7 @@ mod tests {
 
         let hv_id = make_id();
         let lt_id = ObjectId::random(hv_id.context().clone());
-        let expiration_policy = ExpirationPolicy::TimeToLive(Duration::from_secs(3600));
+        let expiration_policy = ExpirationPolicy::TimeToLive(Duration::from_hours(1));
         let tombstone = Tombstone {
             target: lt_id.clone(),
             expiration_policy,
@@ -1971,7 +1971,7 @@ mod tests {
         // A future cell timestamp (now + TTL) is required so `expires_before` does not
         // immediately filter the row.
         let id = make_id();
-        let ttl = Duration::from_secs(2 * 24 * 3600);
+        let ttl = Duration::from_hours(2 * 24);
         write_legacy_tombstone(&backend, &id, ExpirationPolicy::TimeToLive(ttl), None).await?;
 
         let TieredMetadata::Tombstone(t) = backend.get_tiered_metadata(&id).await? else {
@@ -1992,11 +1992,11 @@ mod tests {
         let id = make_id();
         let path = id.as_storage_path().to_string().into_bytes();
 
-        let tti = Duration::from_secs(2 * 24 * 3600); // must exceed TTI_DEBOUNCE (1 day)
+        let tti = Duration::from_hours(2 * 24); // must exceed TTI_DEBOUNCE (1 day)
 
         // Place time_expires just inside the bump window: past `now + tti - TTI_DEBOUNCE`
         // but still in the future so `expires_before(now)` does not filter the row.
-        let old_deadline = SystemTime::now() + tti - TTI_DEBOUNCE - Duration::from_secs(60);
+        let old_deadline = SystemTime::now() + tti - TTI_DEBOUNCE - Duration::from_mins(1);
         write_legacy_tombstone(
             &backend,
             &id,
@@ -2113,7 +2113,7 @@ mod tests {
         let new_lt_id = ObjectId::random(id.context().clone());
         let new_tombstone = Tombstone {
             target: new_lt_id.clone(),
-            expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_secs(3600)),
+            expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_hours(1)),
         };
         let committed = backend
             .compare_and_write(&id, None, TieredWrite::Tombstone(new_tombstone))

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -78,7 +78,7 @@ const DEFAULT_ENDPOINT: &str = "https://storage.googleapis.com";
 /// Permission scopes required for accessing GCS.
 const TOKEN_SCOPES: &[&str] = &["https://www.googleapis.com/auth/devstorage.read_write"];
 /// Time to debounce bumping an object with configured TTI.
-const TTI_DEBOUNCE: Duration = Duration::from_secs(24 * 3600); // 1 day
+const TTI_DEBOUNCE: Duration = Duration::from_hours(24);
 /// How many times to retry failed operations.
 const REQUEST_RETRY_COUNT: usize = 2;
 
@@ -1285,7 +1285,7 @@ mod tests {
 
         let id = make_id();
         // TTI must exceed TTI_DEBOUNCE (1 day) for the bump condition to be reachable.
-        let tti = Duration::from_secs(2 * 24 * 3600); // 2 days
+        let tti = Duration::from_hours(2 * 24);
         let metadata = Metadata {
             content_type: "text/plain".into(),
             expiration_policy: ExpirationPolicy::TimeToIdle(tti),
@@ -1299,7 +1299,7 @@ mod tests {
         // Manually set custom_time to just inside the bump window.
         // The bump condition is: expire_at < now + tti - TTI_DEBOUNCE.
         let object_url = backend.object_url(&id)?;
-        let old_deadline = SystemTime::now() + tti - TTI_DEBOUNCE - Duration::from_secs(60);
+        let old_deadline = SystemTime::now() + tti - TTI_DEBOUNCE - Duration::from_mins(1);
         backend.update_custom_time(object_url, old_deadline).await?;
 
         // First get_metadata sees the old timestamp and triggers a TTI bump.
@@ -1328,7 +1328,7 @@ mod tests {
 
         let id = make_id();
         // TTI must exceed TTI_DEBOUNCE (1 day) for the bump condition to be reachable.
-        let tti = Duration::from_secs(2 * 24 * 3600); // 2 days
+        let tti = Duration::from_hours(2 * 24);
         let metadata = Metadata {
             content_type: "text/plain".into(),
             expiration_policy: ExpirationPolicy::TimeToIdle(tti),

--- a/objectstore-service/src/backend/in_memory.rs
+++ b/objectstore-service/src/backend/in_memory.rs
@@ -516,7 +516,7 @@ mod tests {
         let id = make_id();
         let metadata = Metadata {
             content_type: "text/plain".into(),
-            expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_secs(3600)),
+            expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_hours(1)),
             origin: Some("203.0.113.42".into()),
             custom: [("foo".into(), "bar".into())].into(),
             ..Default::default()
@@ -556,7 +556,7 @@ mod tests {
         assert_eq!(meta.content_type, "text/plain".to_string());
         assert_eq!(
             meta.expiration_policy,
-            ExpirationPolicy::TimeToIdle(Duration::from_secs(3600))
+            ExpirationPolicy::TimeToIdle(Duration::from_hours(1))
         );
         assert_eq!(meta.origin, Some("203.0.113.42".into()));
         assert_eq!(meta.custom, [("foo".into(), "bar".into())].into());

--- a/objectstore-service/src/backend/local_fs.rs
+++ b/objectstore-service/src/backend/local_fs.rs
@@ -468,7 +468,7 @@ mod tests {
 
         let metadata = Metadata {
             content_type: "text/plain".into(),
-            expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_secs(3600)),
+            expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_hours(1)),
             time_created: Some(SystemTime::now()),
             time_expires: None,
             compression: Some(Compression::Zstd),
@@ -565,7 +565,7 @@ mod tests {
         let id = make_id();
         let metadata = Metadata {
             content_type: "text/plain".into(),
-            expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_secs(3600)),
+            expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_hours(1)),
             origin: Some("203.0.113.42".into()),
             custom: [("foo".into(), "bar".into())].into(),
             ..Default::default()
@@ -605,7 +605,7 @@ mod tests {
         assert_eq!(meta.content_type, "text/plain".to_string());
         assert_eq!(
             meta.expiration_policy,
-            ExpirationPolicy::TimeToIdle(Duration::from_secs(3600))
+            ExpirationPolicy::TimeToIdle(Duration::from_hours(1))
         );
         assert_eq!(meta.origin, Some("203.0.113.42".into()));
         assert_eq!(meta.custom, [("foo".into(), "bar".into())].into());

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -63,7 +63,7 @@ const GCS_CUSTOM_PREFIX: &str = "x-goog-meta-";
 /// See: <https://cloud.google.com/storage/docs/xml-api/reference-headers#xgoogcustomtime>
 const GCS_CUSTOM_TIME: &str = "x-goog-custom-time";
 /// Time to debounce bumping an object with configured TTI.
-const TTI_DEBOUNCE: Duration = Duration::from_secs(24 * 3600); // 1 day
+const TTI_DEBOUNCE: Duration = Duration::from_hours(24);
 
 /// An authentication token that can be passed as a bearer credential.
 pub trait Token: Send + Sync {

--- a/objectstore-service/src/backend/tiered.rs
+++ b/objectstore-service/src/backend/tiered.rs
@@ -983,7 +983,7 @@ mod tests {
         let payload = vec![0xCDu8; 2 * 1024 * 1024]; // 2 MiB, over threshold
         let metadata_in = Metadata {
             content_type: "image/png".into(),
-            expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_secs(3600)),
+            expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_hours(1)),
             origin: Some("10.0.0.1".into()),
             ..Default::default()
         };
@@ -1624,7 +1624,7 @@ mod tests {
         let id = make_id("mp-single");
         let metadata = Metadata {
             content_type: "application/octet-stream".into(),
-            expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_secs(3600)),
+            expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_hours(1)),
             ..Default::default()
         };
         let payload = vec![0xABu8; 2 * 1024 * 1024]; // 2 MiB

--- a/objectstore-service/src/gcp_auth.rs
+++ b/objectstore-service/src/gcp_auth.rs
@@ -268,7 +268,7 @@ mod tests {
 
     #[tokio::test]
     async fn constructor_fetches_initial_token() {
-        let token = make_token(Duration::from_secs(3600));
+        let token = make_token(Duration::from_hours(1));
         let mock = MockTokenProvider::new(vec![Ok(token)]);
 
         let provider = PrefetchingTokenProvider::new(
@@ -295,7 +295,7 @@ mod tests {
 
     #[tokio::test]
     async fn returns_cached_token() {
-        let token = make_token(Duration::from_secs(3600));
+        let token = make_token(Duration::from_hours(1));
         let mock = MockTokenProvider::new(vec![Ok(token.clone())]);
 
         let provider = PrefetchingTokenProvider::new(mock, &["scope-a"])
@@ -317,7 +317,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn background_refresh_before_expiry() {
         let initial = make_token(Duration::from_secs(25));
-        let refreshed = make_token(Duration::from_secs(3600));
+        let refreshed = make_token(Duration::from_hours(1));
 
         let mock = MockTokenProvider::new(vec![Ok(initial), Ok(refreshed)]);
 
@@ -340,7 +340,7 @@ mod tests {
     async fn waits_when_near_expiry() {
         // Token that expires in 8 seconds (below WAIT_THRESHOLD of 10s).
         let initial = make_token(Duration::from_secs(8));
-        let refreshed = make_token(Duration::from_secs(3600));
+        let refreshed = make_token(Duration::from_hours(1));
 
         let mock = MockTokenProvider::new(vec![Ok(initial), Ok(refreshed)]);
 
@@ -362,8 +362,8 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn retries_silently_while_token_valid() {
         // Token with 60s expiry: after 40s (sleep = 60 - 20 = 40), refresh is attempted.
-        let initial = make_token(Duration::from_secs(60));
-        let after_retry = make_token(Duration::from_secs(3600));
+        let initial = make_token(Duration::from_mins(1));
+        let after_retry = make_token(Duration::from_hours(1));
 
         let mock = MockTokenProvider::new(vec![
             Ok(initial),
@@ -430,8 +430,8 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn recovers_after_error() {
-        let initial = make_token(Duration::from_secs(60));
-        let recovered = make_token(Duration::from_secs(3600));
+        let initial = make_token(Duration::from_mins(1));
+        let recovered = make_token(Duration::from_hours(1));
 
         let mock = MockTokenProvider::new(vec![
             Ok(initial),
@@ -459,7 +459,7 @@ mod tests {
 
     #[tokio::test]
     async fn drop_cancels_task() {
-        let token = make_token(Duration::from_secs(3600));
+        let token = make_token(Duration::from_hours(1));
         let mock = MockTokenProvider::new(vec![Ok(token)]);
 
         let provider = PrefetchingTokenProvider::new(mock, &["scope"])
@@ -476,7 +476,7 @@ mod tests {
 
     #[tokio::test]
     async fn project_id_delegates() {
-        let token = make_token(Duration::from_secs(3600));
+        let token = make_token(Duration::from_hours(1));
         let mock = MockTokenProvider::new(vec![Ok(token)]);
 
         let provider = PrefetchingTokenProvider::new(mock, &["scope"])
@@ -492,8 +492,8 @@ mod tests {
 
     #[tokio::test]
     async fn mismatched_scopes_fall_through() {
-        let cached_token = make_token(Duration::from_secs(3600));
-        let fallthrough_token = make_token(Duration::from_secs(60));
+        let cached_token = make_token(Duration::from_hours(1));
+        let fallthrough_token = make_token(Duration::from_mins(1));
 
         let mock = MockTokenProvider::new(vec![Ok(cached_token), Ok(fallthrough_token)]);
 

--- a/objectstore-types/src/metadata.rs
+++ b/objectstore-types/src/metadata.rs
@@ -518,7 +518,7 @@ mod tests {
         let metadata = Metadata::from_headers(&headers, prefix).unwrap();
         assert_eq!(
             metadata.expiration_policy,
-            ExpirationPolicy::TimeToIdle(Duration::from_secs(3600))
+            ExpirationPolicy::TimeToIdle(Duration::from_hours(1))
         );
         assert_eq!(metadata.custom.get("my-key").unwrap(), "my-value");
     }
@@ -562,7 +562,7 @@ mod tests {
     #[test]
     fn to_headers_all_fields() {
         let metadata = Metadata {
-            expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_secs(60)),
+            expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_mins(1)),
             time_created: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000)),
             time_expires: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_060)),
             content_type: "text/html".into(),
@@ -595,7 +595,7 @@ mod tests {
     fn full_roundtrip_all_fields() {
         let prefix = "x-test-";
         let metadata = Metadata {
-            expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_secs(7200)),
+            expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_hours(2)),
             time_created: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000)),
             time_expires: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_007_200)),
             content_type: "image/png".into(),
@@ -651,7 +651,7 @@ mod tests {
     #[test]
     fn serde_roundtrip_all_fields() {
         let metadata = Metadata {
-            expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_secs(3600)),
+            expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_hours(1)),
             time_created: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000)),
             time_expires: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_003_600)),
             content_type: "application/json".into(),
@@ -696,7 +696,7 @@ mod tests {
         let cases = [
             ExpirationPolicy::Manual,
             ExpirationPolicy::TimeToLive(Duration::from_secs(30)),
-            ExpirationPolicy::TimeToIdle(Duration::from_secs(3600)),
+            ExpirationPolicy::TimeToIdle(Duration::from_hours(1)),
         ];
 
         for policy in cases {
@@ -719,8 +719,8 @@ mod tests {
         assert!(ExpirationPolicy::Manual.is_manual());
         assert!(!ExpirationPolicy::Manual.is_timeout());
 
-        let ttl = ExpirationPolicy::TimeToLive(Duration::from_secs(60));
-        assert_eq!(ttl.expires_in(), Some(Duration::from_secs(60)));
+        let ttl = ExpirationPolicy::TimeToLive(Duration::from_mins(1));
+        assert_eq!(ttl.expires_in(), Some(Duration::from_mins(1)));
         assert!(ttl.is_timeout());
         assert!(!ttl.is_manual());
 

--- a/stresstest/src/stresstest.rs
+++ b/stresstest/src/stresstest.rs
@@ -33,7 +33,7 @@ pub struct Stresstest {
 
 impl Stresstest {
     /// Default runtime for the stresstest.
-    pub const DEFAULT_DURATION: Duration = Duration::from_secs(60);
+    pub const DEFAULT_DURATION: Duration = Duration::from_mins(1);
 
     /// Default TTL for all objects created during the stresstest.
     pub const DEFAULT_TTL: Duration = Duration::from_hours(1);


### PR DESCRIPTION
Replace `Duration::from_secs` arithmetic with `Duration::from_hours` and `Duration::from_mins` where the intent is hours or minutes. Expressions like `from_secs(2 * 24 * 3600)` become `from_hours(2 * 24)`, and `from_secs(3600)` becomes `from_hours(1)`.

`Duration::from_days` would be preferable in some cases (e.g., `from_hours(90 * 24)`) but it's still nightly-only (`duration_constructors_lite`, [#141881](https://github.com/rust-lang/rust/issues/141881)).