### PR TITLE
ref: Use Duration::from_mins for missed 120s constant

### DIFF
--- a/objectstore-types/src/metadata.rs
+++ b/objectstore-types/src/metadata.rs
@@ -724,8 +724,8 @@ mod tests {
         assert!(ttl.is_timeout());
         assert!(!ttl.is_manual());
 
-        let tti = ExpirationPolicy::TimeToIdle(Duration::from_secs(120));
-        assert_eq!(tti.expires_in(), Some(Duration::from_secs(120)));
+        let tti = ExpirationPolicy::TimeToIdle(Duration::from_mins(2));
+        assert_eq!(tti.expires_in(), Some(Duration::from_mins(2)));
         assert!(tti.is_timeout());
         assert!(!tti.is_manual());
     }


### PR DESCRIPTION
Follow-up to #503 — one missed `Duration::from_secs(120)` → `Duration::from_mins(2)` in the metadata test. Clears the last `clippy::duration_suboptimal_units` warning.