### PR TITLE
docs: Fix multipart endpoint paths and client examples

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -118,7 +118,7 @@ chunks = [b"part1", b"part2", b"part3", b"part4"]
 
 def upload_part(part_number: int, data: bytes):
     compressed = compressor.compress(data)
-    return upload.upload_part(
+    return upload.put_part(
         compressed, part_number=part_number, content_length=len(compressed)
     )
 

--- a/clients/rust/README.md
+++ b/clients/rust/README.md
@@ -130,6 +130,13 @@ session.put("payload")
 
 ### Multipart Upload API
 
+> **Feature flag required:** Enable the `multipart` Cargo feature to use this API.
+> It is not included in the default feature set.
+>
+> ```toml
+> objectstore-client = { version = "...", features = ["multipart"] }
+> ```
+
 For large objects, use multipart uploads to upload parts concurrently with bounded
 parallelism.
 

--- a/objectstore-server/docs/architecture.md
+++ b/objectstore-server/docs/architecture.md
@@ -22,12 +22,14 @@ All object operations live under the `/v1/` prefix:
 
 | Method    | Path                                                         | Description                          |
 |-----------|--------------------------------------------------------------|--------------------------------------|
-| `POST`    | `/v1/objects:multipart:initiate/{usecase}/{scopes}/`         | Initiate upload (server-generated key) |
-| `PUT`     | `/v1/objects:multipart:initiate/{usecase}/{scopes}/{key}`    | Initiate upload (user-provided key)  |
+| `POST`    | `/v1/objects:multipart/{usecase}/{scopes}/`                  | Initiate upload (server-generated key) |
+| `PUT`     | `/v1/objects:multipart/{usecase}/{scopes}/{*key}`            | Initiate upload (user-provided key)  |
 | `PUT`     | `/v1/objects:multipart:parts/{usecase}/{scopes}/{key}`       | Upload a part (`uploadId`, `partNumber` query params) |
 | `GET`     | `/v1/objects:multipart:parts/{usecase}/{scopes}/{key}`       | List uploaded parts (`uploadId` query param) |
 | `POST`    | `/v1/objects:multipart:complete/{usecase}/{scopes}/{key}`    | Complete upload (`uploadId` query param) |
 | `DELETE`  | `/v1/objects:multipart/{usecase}/{scopes}/{key}`             | Abort upload (`uploadId` query param) |
+
+The initiate POST endpoint accepts both trailing-slash and non-trailing-slash forms.
 
 The complete endpoint returns `200 OK` immediately, with a streaming body that
 will contain the error (if any) as JSON. Whitespace is sent in the streaming body

--- a/objectstore-types/src/lib.rs
+++ b/objectstore-types/src/lib.rs
@@ -22,6 +22,12 @@
 //! into hierarchical namespaces and double as the authorization boundary checked
 //! against JWT claims.
 //!
+//! ## Multipart
+//!
+//! The [`multipart`] module defines the request and response types for the
+//! multipart upload protocol, which splits large objects into independently
+//! uploaded parts that are assembled server-side on completion.
+//!
 //! ## Auth
 //!
 //! The [`auth`] module defines [`Permission`](auth::Permission), the set of

--- a/objectstore-types/src/multipart.rs
+++ b/objectstore-types/src/multipart.rs
@@ -1,4 +1,15 @@
 //! Types for the multipart upload protocol.
+//!
+//! Multipart uploads split large objects into independently uploaded parts that
+//! are assembled server-side on completion. This module defines the request and
+//! response types exchanged between clients and the server during each phase of
+//! the protocol: initiation, part upload, part listing, and completion.
+//!
+//! Key types:
+//! - [`UploadId`] — opaque, path-safe identifier for an in-progress upload.
+//! - [`InitiateResponse`] — returned when a new upload is created.
+//! - [`CompletePart`] / [`CompleteRequest`] — part manifest sent to finalize.
+//! - [`PartInfo`] / [`ListPartsResponse`] — used to resume interrupted uploads.
 
 use std::fmt;
 use std::num::NonZeroU32;


### PR DESCRIPTION
- Fix Python README calling `upload_part()` instead of the actual method name `put_part()`
- Remove stale `:initiate` segment from multipart endpoint paths in server architecture doc
- Add missing `multipart` Cargo feature flag note to Rust client README
- Document trailing-slash acceptance on multipart initiate POST
- Expand multipart module and crate-level doc comments in objectstore-types