### PR TITLE
build: Consolidate workspace dependencies and pin explicit versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.6.2",
+ "socket2 0.6.4",
  "time",
  "tracing",
  "url",
@@ -164,18 +164,6 @@ name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
 
 [[package]]
 name = "aho-corasick"
@@ -203,9 +191,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "argh"
-version = "0.1.14"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f384d96bfd3c0b3c41f24dae69ee9602c091d64fc432225cf5295b5abbe0036"
+checksum = "211818e820cda9ca6f167a64a5c808837366a6dfd807157c64c1304c486cd033"
 dependencies = [
  "argh_derive",
  "argh_shared",
@@ -213,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "argh_derive"
-version = "0.1.14"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938e5f66269c1f168035e29ed3fb437b084e476465e9314a0328f4005d7be599"
+checksum = "c442a9d18cef5dde467405d27d461d080d68972d6d0dfd0408265b6749ec427d"
 dependencies = [
  "argh_shared",
  "proc-macro2",
@@ -225,18 +213,18 @@ dependencies = [
 
 [[package]]
 name = "argh_shared"
-version = "0.1.14"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5127f8a5bc1cfb0faf1f6248491452b8a5b6901068d8da2d47cbb285986ae683"
+checksum = "e5ade012bac4db278517a0132c8c10c6427025868dca16c801087c28d5a411f1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "async-compression"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -322,15 +310,15 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "hyper",
@@ -362,7 +350,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "mime",
@@ -434,7 +422,7 @@ source = "git+https://github.com/getsentry/bigtable_rs.git?rev=4cb75bc5e5f872043
 dependencies = [
  "futures-util",
  "gcp_auth",
- "http 1.4.0",
+ "http 1.4.2",
  "hyper-util",
  "log",
  "prost",
@@ -501,15 +489,15 @@ checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "bytesize"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+checksum = "49e78e506b9d7633710dab98996f22f95f3d0f488e8f1aa162830556ed9fc14d"
 dependencies = [
  "serde_core",
 ]
@@ -566,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -599,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "compression-core",
  "zstd",
@@ -610,31 +598,18 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "console"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
  "unicode-width",
  "windows-sys 0.61.2",
 ]
@@ -1250,7 +1225,7 @@ dependencies = [
  "base64",
  "bytes",
  "chrono",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -1359,7 +1334,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.4.2",
  "indexmap 2.13.0",
  "slab",
  "tokio",
@@ -1521,9 +1496,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1536,7 +1511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -1547,7 +1522,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "pin-project-lite",
 ]
@@ -1591,7 +1566,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "httparse",
  "httpdate",
@@ -1609,7 +1584,7 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.2",
  "hyper",
  "hyper-util",
  "rustls",
@@ -1659,14 +1634,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1847,7 +1822,7 @@ version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
- "console 0.16.2",
+ "console",
  "portable-atomic",
  "unicode-width",
  "unit-prefix",
@@ -1868,11 +1843,11 @@ checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "insta"
-version = "1.46.3"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
- "console 0.15.11",
+ "console",
  "once_cell",
  "similar",
  "tempfile",
@@ -2026,9 +2001,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.3.0"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -2045,6 +2020,7 @@ dependencies = [
  "sha2",
  "signature",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -2070,9 +2046,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -2148,19 +2124,19 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metrics"
-version = "0.24.3"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
- "ahash",
  "portable-atomic",
+ "rapidhash",
 ]
 
 [[package]]
 name = "metrics-exporter-dogstatsd"
-version = "0.9.6"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961f3712d8a7cfe14caaf74c3af503fe701cee6439ff49a7a3ebd04bf49c0502"
+checksum = "b4f39e912d07239992146dc617951ef78a909daec25f0b31c629767cf59f34bb"
 dependencies = [
  "bytes",
  "itoa",
@@ -2218,9 +2194,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -2254,7 +2230,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "httparse",
  "memchr",
  "mime",
@@ -2305,6 +2281,18 @@ name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2575,7 +2563,7 @@ dependencies = [
  "objectstore-test",
  "objectstore-types",
  "percent-encoding",
- "reqwest 0.13.4",
+ "reqwest",
  "sentry-core",
  "serde",
  "tempfile",
@@ -2592,7 +2580,7 @@ name = "objectstore-log"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "console 0.16.2",
+ "console",
  "sentry",
  "serde",
  "tracing",
@@ -2624,11 +2612,11 @@ dependencies = [
  "futures",
  "futures-util",
  "globset",
- "http 1.4.0",
+ "http 1.4.2",
  "humantime",
  "humantime-serde",
  "jsonwebtoken",
- "nix",
+ "nix 0.31.3",
  "num_cpus",
  "objectstore-log",
  "objectstore-metrics",
@@ -2638,7 +2626,7 @@ dependencies = [
  "papaya",
  "percent-encoding",
  "rand 0.9.4",
- "reqwest 0.13.4",
+ "reqwest",
  "rustls",
  "secrecy",
  "sentry",
@@ -2651,7 +2639,7 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.7.0",
 ]
 
 [[package]]
@@ -2674,7 +2662,7 @@ dependencies = [
  "objectstore-types",
  "quick-xml",
  "regex",
- "reqwest 0.13.4",
+ "reqwest",
  "sentry",
  "serde",
  "serde_json",
@@ -2703,7 +2691,7 @@ dependencies = [
 name = "objectstore-types"
 version = "0.1.12"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.2",
  "humantime",
  "humantime-serde",
  "insta",
@@ -2783,7 +2771,7 @@ checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
 dependencies = [
  "android_system_properties",
  "log",
- "nix",
+ "nix 0.30.1",
  "objc2",
  "objc2-foundation",
  "objc2-ui-kit",
@@ -2817,9 +2805,9 @@ dependencies = [
 
 [[package]]
 name = "papaya"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92dd0b07c53a0a0c764db2ace8c541dc47320dad97c2200c2a637ab9dd2328f"
+checksum = "997ee03cd38c01469a7046643714f0ad28880bcb9e6679ff0666e24817ca19b7"
 dependencies = [
  "equivalent",
  "seize",
@@ -3190,9 +3178,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
  "serde",
@@ -3211,7 +3199,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.2",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3249,7 +3237,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3381,6 +3369,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3420,9 +3417,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3449,47 +3446,9 @@ checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
-
-[[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http 1.4.0",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-tls",
- "hyper-util",
- "js-sys",
- "log",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-native-tls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -3500,11 +3459,12 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
  "hickory-resolver",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "hyper",
@@ -3531,7 +3491,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3626,9 +3586,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3826,13 +3786,14 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "sentry"
-version = "0.45.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48b85e25e8a1fc13928885e8bf13abe8a09e15c46993aed05d6405f7755d6e20"
+checksum = "931a20b0da02350676e3d6d3c9028d58eaa448cf42a866712eec5845a505421e"
 dependencies = [
+ "cfg_aliases",
  "httpdate",
  "native-tls",
- "reqwest 0.12.28",
+ "reqwest",
  "sentry-actix",
  "sentry-backtrace",
  "sentry-contexts",
@@ -3848,9 +3809,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-actix"
-version = "0.45.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc694e6ffc8d5d7fdb2a33923b0358f6ad41c0b428ced034b349b9e2b08260bc"
+checksum = "5ffb8fd78b8f4527146013ab52293e03242770a31dcd97eee4b82b7f770ffab3"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -3861,9 +3822,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.45.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3253a495ab536f6de1746a58d5d7824b77d75e08e1a4b8ca6fb356839077ae0"
+checksum = "911ee36abf5b7fa335fccd5f54361ba9c16baea5f0c3bb361a687b6c195c21cf"
 dependencies = [
  "backtrace",
  "regex",
@@ -3872,9 +3833,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.45.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027f81a728836e66b88c07666a10f5ed5a35e2695b04eb7aa0fcbed93f814900"
+checksum = "9b9d7d469e9e22741c17ca23fb8b42d79861590eb7cf330f3da34fc1e4bc1bc6"
 dependencies = [
  "hostname",
  "libc",
@@ -3886,9 +3847,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.45.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b6729c8e71ac968edbe9bf2dd4109c162e552b52bacd2b07e24ede1aba84a5"
+checksum = "545dc562b6758d646ac19e1407f4ebc26d452111386743e03323464bc48bb2e0"
 dependencies = [
  "rand 0.9.4",
  "sentry-types",
@@ -3899,9 +3860,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.45.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc85b59c1dfb19912bfba1af73a592e2e5548cae241a79ecb805afab3333d04c"
+checksum = "660e9def38a573a869a182f7e90f58aaaa460f38b92b31fd1755ec537193bb48"
 dependencies = [
  "findshlibs",
  "sentry-core",
@@ -3909,9 +3870,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-log"
-version = "0.45.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "912fea629a3fc7bfcb97f7bde31a5c815df8526ba19088dcef3ae32ea1e25418"
+checksum = "2c13b9313bdd6a9db19e65ac0e4754e64dea6f18cdd15444656abb050db4538d"
 dependencies = [
  "bitflags",
  "log",
@@ -3920,9 +3881,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.45.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac0471f04f8f97af0c17eeca2c516e23faa1c0271a55bc64371d9ce488c2d40"
+checksum = "772d9de150c8ca910c835353c85f434457348fdd21208f9b3da3574202b1dc5d"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -3930,12 +3891,12 @@ dependencies = [
 
 [[package]]
 name = "sentry-tower"
-version = "0.45.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "417bd48071863a65ca5f33d15af9aabd49a5cee7f97415d3f08ce8c90ed2c531"
+checksum = "2abea154597936d5df2d39fbe8aac16d584de6b3572c70c39558764d9d2efe15"
 dependencies = [
  "axum",
- "http 1.4.0",
+ "http 1.4.2",
  "pin-project",
  "sentry-core",
  "tower-layer",
@@ -3945,9 +3906,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.45.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428f780866a613142dcc81b7f8551ae4d1c056f4df22b6d7ddd9154a9974eb03"
+checksum = "c51ec9620a4d398dcdf7ee90effbf8d8691cfa24e91978bfa8565cac039d4980"
 dependencies = [
  "bitflags",
  "sentry-backtrace",
@@ -3958,9 +3919,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.45.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c19d1d1967b55659c358886d0f1aa3076488d445f84c7d727d384c675adaec1"
+checksum = "041359745a44dd2e14fe21b7510fe7ca8b5beffce6636a0b52e5bc7d5f736887"
 dependencies = [
  "debugid",
  "hex",
@@ -4005,9 +3966,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -4193,12 +4154,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4318,9 +4279,9 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
@@ -4467,9 +4428,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -4477,16 +4438,16 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4540,16 +4501,16 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
  "base64",
  "bytes",
  "h2",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "hyper",
@@ -4557,7 +4518,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.2",
+ "socket2 0.6.4",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -4635,13 +4596,30 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
- "http-body-util",
  "iri-string",
  "pin-project-lite",
- "tokio",
  "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http 1.4.2",
+ "http-body",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4725,9 +4703,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -4876,7 +4854,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
 dependencies = [
  "base64",
- "http 1.4.0",
+ "http 1.4.2",
  "httparse",
  "log",
 ]
@@ -4908,9 +4886,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5244,15 +5222,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -5697,6 +5666,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
  "bytesize",
  "objectstore-service",
  "objectstore-types",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rand_distr",
  "rustls",
  "sketches-ddsketch",
@@ -2624,7 +2624,7 @@ dependencies = [
  "objectstore-types",
  "papaya",
  "percent-encoding",
- "rand 0.9.4",
+ "rand 0.10.1",
  "reqwest",
  "rustls",
  "secrecy",
@@ -3350,12 +3350,12 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.9.4",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -4195,7 +4195,7 @@ dependencies = [
  "humantime-serde",
  "indicatif",
  "objectstore-client",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rand_distr",
  "serde",
  "serde_yaml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,7 +402,6 @@ dependencies = [
  "argh",
  "bytes",
  "bytesize",
- "futures-util",
  "objectstore-service",
  "objectstore-types",
  "rand 0.9.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,8 +64,8 @@ num_cpus = "1.17.0"
 papaya = "0.2.4"
 percent-encoding = "2.3.2"
 quick-xml = "0.40.1"
-rand = "0.9.4"
-rand_distr = "0.5.1"
+rand = "0.10.1"
+rand_distr = "0.6.0"
 regex = "1.12.4"
 reqwest = { version = "0.13.4", default-features = false }
 rustls = { version = "0.23.40", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,18 +32,18 @@ stresstest = { path = "stresstest" }
 
 anyhow = "1.0.102"
 argh = "0.1.19"
-async-compression = { version = "0.4.42", features = ["tokio", "zstd"] }
+async-compression = "0.4.42"
 async-stream = "0.3.6"
 async-trait = "0.1.89"
-axum = { version = "0.8.9", features = ["multipart"] }
+axum = "0.8.9"
 base64 = "0.22.1"
 bigtable_rs = { git = "https://github.com/getsentry/bigtable_rs.git", rev = "4cb75bc5e5f87204363973f6302107768e64972e" }
 bytes = "1.12.0"
-bytesize = { version = "2.4.0", features = ["serde"] }
+bytesize = "2.4.0"
 chrono = "0.4.45"
 console = "0.16.3"
-elegant-departure = { version = "0.3.2", features = ["tokio"] }
-figment = { version = "0.10.19", features = ["env", "test", "yaml"] }
+elegant-departure = "0.3.2"
+figment = "0.10.19"
 futures = "0.3.32"
 futures-util = "0.3.32"
 gcp_auth = "0.12.6"
@@ -59,34 +59,34 @@ mediatype = "0.21.0"
 metrics = "0.24.6"
 metrics-exporter-dogstatsd = "0.9.8"
 multer = "3.1.0"
-nix = { version = "0.31.3", features = ["signal"] }
+nix = "0.31.3"
 num_cpus = "1.17.0"
 papaya = "0.2.4"
 percent-encoding = "2.3.2"
-quick-xml = { version = "0.40.1", features = ["serialize"] }
+quick-xml = "0.40.1"
 rand = "0.9.4"
 rand_distr = "0.5.1"
 regex = "1.12.4"
-reqwest = { version = "0.13.4", default-features = false, features = ["charset", "http2", "system-proxy", "native-tls-no-alpn"] }
+reqwest = { version = "0.13.4", default-features = false }
 rustls = { version = "0.23.40", default-features = false }
-secrecy = { version = "0.10.3", features = ["serde"] }
+secrecy = "0.10.3"
 sentry = { version = "0.48.2" }
-sentry-core = { version = "0.48.2", features = ["client"] }
+sentry-core = "0.48.2"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 serde_yaml = "0.9.34-deprecated"
 sketches-ddsketch = "0.3.1"
 tempfile = "3.27.0"
 thiserror = "2.0.18"
-tikv-jemalloc-ctl = { version = "0.7.0", features = ["stats"] }
+tikv-jemalloc-ctl = "0.7.0"
 tikv-jemallocator = { version = "0.7.0", features = ["background_threads", "override_allocator_on_supported_platforms"] }
 tokio = "1.52.3"
-tokio-util = { version = "0.7.18", features = ["rt"] }
+tokio-util = "0.7.18"
 tonic = { version = "0.14.6", default-features = false }
 tower = "0.5.3"
-tower-http = { version = "0.7.0", default-features = false, features = ["catch-panic", "metrics", "set-header", "trace"] }
+tower-http = { version = "0.7.0", default-features = false }
 tracing = "0.1.44"
-tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
+tracing-subscriber = "0.3.23"
 url = "2.5.8"
 uuid = { version = "1.23.3", features = ["v4"] }
 yansi = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,32 +28,67 @@ objectstore-server = { path = "objectstore-server" }
 objectstore-service = { path = "objectstore-service" }
 objectstore-test = { path = "objectstore-test" }
 objectstore-types = { path = "objectstore-types", version = "0.1.12" }
-percent-encoding = "2.3"
 stresstest = { path = "stresstest" }
 
-anyhow = "1.0.69"
-async-trait = "0.1.88"
-bytes = "1.11.1"
-futures = "0.3.31"
-futures-util = "0.3.31"
-http = "1.3.1"
-humantime = "2.2.0"
+anyhow = "1.0.102"
+argh = "0.1.19"
+async-compression = { version = "0.4.42", features = ["tokio", "zstd"] }
+async-stream = "0.3.6"
+async-trait = "0.1.89"
+axum = { version = "0.8.9", features = ["multipart"] }
+base64 = "0.22.1"
+bigtable_rs = { git = "https://github.com/getsentry/bigtable_rs.git", rev = "4cb75bc5e5f87204363973f6302107768e64972e" }
+bytes = "1.12.0"
+bytesize = { version = "2.4.0", features = ["serde"] }
+chrono = "0.4.45"
+console = "0.16.3"
+elegant-departure = { version = "0.3.2", features = ["tokio"] }
+figment = { version = "0.10.19", features = ["env", "test", "yaml"] }
+futures = "0.3.32"
+futures-util = "0.3.32"
+gcp_auth = "0.12.6"
+globset = "0.4.18"
+http = "1.4.2"
+humantime = "2.3.0"
 humantime-serde = "1.1.1"
-jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
-rand = "0.9.3"
-regex = "1.12.3"
-# Same as default features on 0.12.x (0.13.x uses rustls by default)
+indicatif = "0.18.4"
+infer = { version = "0.19.0", default-features = false }
+insta = "1.48.0"
+jsonwebtoken = { version = "10.4.0", features = ["rust_crypto"] }
+mediatype = "0.21.0"
+metrics = "0.24.6"
+metrics-exporter-dogstatsd = "0.9.8"
+multer = "3.1.0"
+nix = { version = "0.31.3", features = ["signal"] }
+num_cpus = "1.17.0"
+papaya = "0.2.4"
+percent-encoding = "2.3.2"
+quick-xml = { version = "0.40.1", features = ["serialize"] }
+rand = "0.9.4"
+rand_distr = "0.5.1"
+regex = "1.12.4"
 reqwest = { version = "0.13.4", default-features = false, features = ["charset", "http2", "system-proxy", "native-tls-no-alpn"] }
-sentry = { version = "0.45.0" }
-serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.140"
-tempfile = "3.20.0"
-thiserror = "2.0.17"
-tikv-jemallocator = { version = "0.7.0", features = ["background_threads", "override_allocator_on_supported_platforms"] }
+rustls = { version = "0.23.40", default-features = false }
+secrecy = { version = "0.10.3", features = ["serde"] }
+sentry = { version = "0.48.2" }
+sentry-core = { version = "0.48.2", features = ["client"] }
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.150"
+serde_yaml = "0.9.34-deprecated"
+sketches-ddsketch = "0.3.1"
+tempfile = "3.27.0"
+thiserror = "2.0.18"
 tikv-jemalloc-ctl = { version = "0.7.0", features = ["stats"] }
-tokio = "1.47.0"
-tokio-util = { version = "0.7.15", features = ["rt"] }
-tracing = "0.1.41"
-tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }
-uuid = { version = "1.17.0", features = ["v4"] }
-sentry-options = "1.0.1"
+tikv-jemallocator = { version = "0.7.0", features = ["background_threads", "override_allocator_on_supported_platforms"] }
+tokio = "1.52.3"
+tokio-util = { version = "0.7.18", features = ["rt"] }
+tonic = { version = "0.14.6", default-features = false }
+tower = "0.5.3"
+tower-http = { version = "0.7.0", default-features = false, features = ["catch-panic", "metrics", "set-header", "trace"] }
+tracing = "0.1.44"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
+url = "2.5.8"
+uuid = { version = "1.23.3", features = ["v4"] }
+yansi = "1.0.1"
+zstd = "0.13.3"
+zstd-safe = "7.2.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,8 +78,8 @@ serde_yaml = "0.9.34-deprecated"
 sketches-ddsketch = "0.3.1"
 tempfile = "3.27.0"
 thiserror = "2.0.18"
-tikv-jemalloc-ctl = "0.7.0"
 tikv-jemallocator = { version = "0.7.0", features = ["background_threads", "override_allocator_on_supported_platforms"] }
+tikv-jemalloc-ctl = { version = "0.7.0", features = ["stats"] }
 tokio = "1.52.3"
 tokio-util = "0.7.18"
 tonic = { version = "0.14.6", default-features = false }

--- a/bigtable-bench/Cargo.toml
+++ b/bigtable-bench/Cargo.toml
@@ -11,17 +11,17 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-argh = "0.1.13"
+argh = { workspace = true }
 bytes = { workspace = true }
-bytesize = "2.0.1"
+bytesize = { workspace = true }
 futures-util = { workspace = true }
 objectstore-service = { workspace = true }
 objectstore-types = { workspace = true }
 rand = { workspace = true, features = ["small_rng"] }
-rand_distr = "0.5.1"
-rustls = { version = "0.23", default-features = false }
-sketches-ddsketch = "0.3.0"
+rand_distr = { workspace = true }
+rustls = { workspace = true }
+sketches-ddsketch = { workspace = true }
 tikv-jemallocator = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync", "macros", "signal"] }
 tokio-util = { workspace = true }
-yansi = "1.0.1"
+yansi = { workspace = true }

--- a/bigtable-bench/Cargo.toml
+++ b/bigtable-bench/Cargo.toml
@@ -14,7 +14,6 @@ anyhow = { workspace = true }
 argh = { workspace = true }
 bytes = { workspace = true }
 bytesize = { workspace = true }
-futures-util = { workspace = true }
 objectstore-service = { workspace = true }
 objectstore-types = { workspace = true }
 rand = { workspace = true, features = ["small_rng"] }

--- a/bigtable-bench/Cargo.toml
+++ b/bigtable-bench/Cargo.toml
@@ -16,7 +16,7 @@ bytes = { workspace = true }
 bytesize = { workspace = true }
 objectstore-service = { workspace = true }
 objectstore-types = { workspace = true }
-rand = { workspace = true, features = ["small_rng"] }
+rand = { workspace = true }
 rand_distr = { workspace = true }
 rustls = { workspace = true }
 sketches-ddsketch = { workspace = true }

--- a/bigtable-bench/src/main.rs
+++ b/bigtable-bench/src/main.rs
@@ -11,8 +11,8 @@ use std::time::{Duration, Instant};
 use anyhow::Context;
 use argh::FromArgs;
 use bytesize::ByteSize;
+use rand::RngExt;
 use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
 use rand_distr::{Distribution, LogNormal};
 use sketches_ddsketch::DDSketch;
 use tokio::sync::Semaphore;
@@ -212,7 +212,7 @@ async fn main() -> anyhow::Result<()> {
             tokio::spawn(async move {
                 let _permit = permit;
 
-                let mut rng = SmallRng::from_os_rng();
+                let mut rng: SmallRng = rand::make_rng();
                 let object_size = (size_dist.sample(&mut rng) as u64).min(MAX_OBJECT_SIZE) as usize;
                 let mut buf = vec![0u8; object_size];
                 rng.fill(&mut buf[..]);

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.89"
 publish = true
 
 [dependencies]
-async-compression = { workspace = true }
+async-compression = { workspace = true, features = ["tokio", "zstd"] }
 base64 = { workspace = true, optional = true }
 bytes = { workspace = true }
 futures-util = { workspace = true }
@@ -22,7 +22,7 @@ objectstore-types = { workspace = true }
 percent-encoding = { workspace = true }
 # Pinned below workspace version for MSRV compatibility
 reqwest = { version = "0.13.1", default-features = false, features = ["charset", "http2", "system-proxy", "json", "stream", "multipart"] }
-sentry-core = { workspace = true }
+sentry-core = { workspace = true, features = ["client"] }
 serde = { workspace = true }
 thiserror = { workspace = true }
 # See https://github.com/getsentry/relay/blob/9c491a185a289e09ee9d3f56d89bd9d1fa71d815/Cargo.toml#L211

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -11,24 +11,25 @@ rust-version = "1.89"
 publish = true
 
 [dependencies]
-async-compression = { version = "0.4.27", features = ["tokio", "zstd"] }
-base64 = { version = "0.22.1", optional = true }
-percent-encoding = { workspace = true }
+async-compression = { workspace = true }
+base64 = { workspace = true, optional = true }
 bytes = { workspace = true }
 futures-util = { workspace = true }
-infer = { version = "0.19.0", default-features = false }
+infer = { workspace = true }
 jsonwebtoken = { workspace = true }
-multer = "3.1.0"
+multer = { workspace = true }
 objectstore-types = { workspace = true }
+percent-encoding = { workspace = true }
+# Pinned below workspace version for MSRV compatibility
 reqwest = { version = "0.13.1", default-features = false, features = ["charset", "http2", "system-proxy", "json", "stream", "multipart"] }
-sentry-core = { version = ">=0.41", features = ["client"] }
+sentry-core = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 # See https://github.com/getsentry/relay/blob/9c491a185a289e09ee9d3f56d89bd9d1fa71d815/Cargo.toml#L211
 tokio = { version = "1.45.0", default-features = false, features = ["fs"] }
 tokio-util = { workspace = true, features = ["io"] }
-url = "2.5.7"
-zstd-safe = "7.2.4"
+url = { workspace = true }
+zstd-safe = { workspace = true }
 
 [dev-dependencies]
 futures-util = { workspace = true }
@@ -37,7 +38,7 @@ objectstore-test = { workspace = true }
 serde = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }
-zstd = "0.13.3"
+zstd = { workspace = true }
 
 [features]
 default = ["native-tls", "hickory-dns"]

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -22,7 +22,7 @@ objectstore-types = { workspace = true }
 percent-encoding = { workspace = true }
 # Pinned below workspace version for MSRV compatibility
 reqwest = { version = "0.13.1", default-features = false, features = ["charset", "http2", "system-proxy", "json", "stream", "multipart"] }
-sentry-core = { workspace = true, features = ["client"] }
+sentry-core = { version = ">=0.41", default-features = false, features = ["client"] }
 serde = { workspace = true }
 thiserror = { workspace = true }
 # See https://github.com/getsentry/relay/blob/9c491a185a289e09ee9d3f56d89bd9d1fa71d815/Cargo.toml#L211

--- a/objectstore-log/Cargo.toml
+++ b/objectstore-log/Cargo.toml
@@ -17,7 +17,7 @@ sentry = ["init", "dep:sentry"]
 
 [dependencies]
 anyhow = { workspace = true }
-console = { version = "0.16.1", optional = true }
+console = { workspace = true, optional = true }
 sentry = { workspace = true, features = ["tracing"], optional = true }
 serde = { workspace = true }
 tracing = { workspace = true }

--- a/objectstore-log/Cargo.toml
+++ b/objectstore-log/Cargo.toml
@@ -21,4 +21,4 @@ console = { workspace = true, optional = true }
 sentry = { workspace = true, features = ["tracing"], optional = true }
 serde = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "json"], optional = true }

--- a/objectstore-metrics/Cargo.toml
+++ b/objectstore-metrics/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2024"
 publish = false
 
 [dependencies]
-metrics = "0.24.3"
-metrics-exporter-dogstatsd = "0.9.6"
+metrics = { workspace = true }
+metrics-exporter-dogstatsd = { workspace = true }
 objectstore-log = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/objectstore-server/Cargo.toml
+++ b/objectstore-server/Cargo.toml
@@ -12,51 +12,54 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-argh = "0.1.13"
-async-stream = "0.3.6"
-axum = { version = "0.8.4", features = ["multipart"] }
-percent-encoding = { workspace = true }
+argh = { workspace = true }
+async-stream = { workspace = true }
+axum = { workspace = true }
 bytes = { workspace = true }
-elegant-departure = { version = "0.3.2", features = ["tokio"] }
-figment = { version = "0.10.19", features = ["env", "test", "yaml"] }
+elegant-departure = { workspace = true }
+figment = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
-globset = "0.4.15"
+globset = { workspace = true }
 http = { workspace = true }
 humantime = { workspace = true }
 humantime-serde = { workspace = true }
 jsonwebtoken = { workspace = true }
-num_cpus = "1.17.0"
+num_cpus = { workspace = true }
 objectstore-log = { workspace = true, features = ["init", "sentry"] }
 objectstore-metrics = { workspace = true }
 objectstore-service = { workspace = true }
 objectstore-types = { workspace = true }
+papaya = { workspace = true }
+percent-encoding = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true }
-rustls = { version = "0.23.31", default-features = false }
+rustls = { workspace = true }
+secrecy = { workspace = true }
 sentry = { workspace = true, features = [
     "tower-axum-matched-path",
     "tracing",
     "logs",
 ] }
-secrecy = { version = "0.10.3", features = ["serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tikv-jemallocator = { workspace = true }
 tikv-jemalloc-ctl = { workspace = true }
-tokio = { workspace = true, features = ["full"] }
-tower = { version = "0.5.2" }
-tower-http = { version = "0.6.6", default-features = false, features = [
-    "catch-panic",
-    "metrics",
-    "set-header",
-    "trace",
+tokio = { workspace = true, features = [
+    "fs",
+    "macros",
+    "net",
+    "rt-multi-thread",
+    "signal",
+    "sync",
+    "time",
 ] }
-papaya = "0.2.3"
+tower = { workspace = true }
+tower-http = { workspace = true }
 
 [dev-dependencies]
-nix = { version = "0.30.1", features = ["signal"] }
+nix = { workspace = true }
 objectstore-test = { workspace = true }
 stresstest = { workspace = true }
 tempfile = { workspace = true }

--- a/objectstore-server/Cargo.toml
+++ b/objectstore-server/Cargo.toml
@@ -36,32 +36,15 @@ rand = { workspace = true }
 reqwest = { workspace = true, features = ["charset", "http2", "system-proxy", "native-tls-no-alpn"] }
 rustls = { workspace = true }
 secrecy = { workspace = true, features = ["serde"] }
-sentry = { workspace = true, features = [
-    "tower-axum-matched-path",
-    "tracing",
-    "logs",
-] }
+sentry = { workspace = true, features = ["tower-axum-matched-path", "tracing", "logs"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tikv-jemallocator = { workspace = true }
-tikv-jemalloc-ctl = { workspace = true, features = ["stats"] }
-tokio = { workspace = true, features = [
-    "fs",
-    "macros",
-    "net",
-    "rt-multi-thread",
-    "signal",
-    "sync",
-    "time",
-] }
+tikv-jemalloc-ctl = { workspace = true }
+tokio = { workspace = true, features = ["fs", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tower = { workspace = true }
-tower-http = { workspace = true, features = [
-    "catch-panic",
-    "metrics",
-    "set-header",
-    "trace",
-] }
+tower-http = { workspace = true, features = ["catch-panic", "metrics", "set-header", "trace"] }
 
 [dev-dependencies]
 nix = { workspace = true, features = ["signal"] }

--- a/objectstore-server/Cargo.toml
+++ b/objectstore-server/Cargo.toml
@@ -14,10 +14,10 @@ publish = false
 anyhow = { workspace = true }
 argh = { workspace = true }
 async-stream = { workspace = true }
-axum = { workspace = true }
+axum = { workspace = true, features = ["multipart"] }
 bytes = { workspace = true }
-elegant-departure = { workspace = true }
-figment = { workspace = true }
+elegant-departure = { workspace = true, features = ["tokio"] }
+figment = { workspace = true, features = ["env", "test", "yaml"] }
 futures = { workspace = true }
 futures-util = { workspace = true }
 globset = { workspace = true }
@@ -33,9 +33,9 @@ objectstore-types = { workspace = true }
 papaya = { workspace = true }
 percent-encoding = { workspace = true }
 rand = { workspace = true }
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["charset", "http2", "system-proxy", "native-tls-no-alpn"] }
 rustls = { workspace = true }
-secrecy = { workspace = true }
+secrecy = { workspace = true, features = ["serde"] }
 sentry = { workspace = true, features = [
     "tower-axum-matched-path",
     "tracing",
@@ -45,7 +45,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tikv-jemallocator = { workspace = true }
-tikv-jemalloc-ctl = { workspace = true }
+tikv-jemalloc-ctl = { workspace = true, features = ["stats"] }
 tokio = { workspace = true, features = [
     "fs",
     "macros",
@@ -56,10 +56,15 @@ tokio = { workspace = true, features = [
     "time",
 ] }
 tower = { workspace = true }
-tower-http = { workspace = true }
+tower-http = { workspace = true, features = [
+    "catch-panic",
+    "metrics",
+    "set-header",
+    "trace",
+] }
 
 [dev-dependencies]
-nix = { workspace = true }
+nix = { workspace = true, features = ["signal"] }
 objectstore-test = { workspace = true }
 stresstest = { workspace = true }
 tempfile = { workspace = true }

--- a/objectstore-service/Cargo.toml
+++ b/objectstore-service/Cargo.toml
@@ -12,18 +12,18 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-base64 = "0.22"
-bigtable_rs = { git = "https://github.com/getsentry/bigtable_rs.git", rev = "4cb75bc5e5f87204363973f6302107768e64972e" }
-chrono = "0.4"
+base64 = { workspace = true }
+bigtable_rs = { workspace = true }
 bytes = { workspace = true }
+chrono = { workspace = true }
 futures-util = { workspace = true }
-gcp_auth = "0.12.3"
+gcp_auth = { workspace = true }
 humantime = { workspace = true }
 humantime-serde = { workspace = true }
 objectstore-log = { workspace = true }
 objectstore-metrics = { workspace = true }
 objectstore-types = { workspace = true }
-quick-xml = { version = "0.38.4", features = ["serialize"] }
+quick-xml = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = [
     "hickory-dns",
@@ -37,7 +37,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
-tonic = { version = "0.14.5", default-features = false }
+tonic = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true, features = ["v7"] }
 
@@ -45,4 +45,4 @@ uuid = { workspace = true, features = ["v7"] }
 futures = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
-zstd = "0.13"
+zstd = { workspace = true }

--- a/objectstore-service/Cargo.toml
+++ b/objectstore-service/Cargo.toml
@@ -25,16 +25,7 @@ objectstore-metrics = { workspace = true }
 objectstore-types = { workspace = true }
 quick-xml = { workspace = true, features = ["serialize"] }
 regex = { workspace = true }
-reqwest = { workspace = true, features = [
-    "charset",
-    "http2",
-    "hickory-dns",
-    "json",
-    "multipart",
-    "native-tls-no-alpn",
-    "stream",
-    "system-proxy",
-] }
+reqwest = { workspace = true, features = ["charset", "http2", "hickory-dns", "json", "multipart", "native-tls-no-alpn", "stream", "system-proxy"] }
 sentry = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/objectstore-service/Cargo.toml
+++ b/objectstore-service/Cargo.toml
@@ -23,20 +23,24 @@ humantime-serde = { workspace = true }
 objectstore-log = { workspace = true }
 objectstore-metrics = { workspace = true }
 objectstore-types = { workspace = true }
-quick-xml = { workspace = true }
+quick-xml = { workspace = true, features = ["serialize"] }
 regex = { workspace = true }
 reqwest = { workspace = true, features = [
+    "charset",
+    "http2",
     "hickory-dns",
-    "stream",
-    "multipart",
     "json",
+    "multipart",
+    "native-tls-no-alpn",
+    "stream",
+    "system-proxy",
 ] }
 sentry = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-tokio-util = { workspace = true }
+tokio-util = { workspace = true, features = ["io", "rt"] }
 tonic = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true, features = ["v7"] }

--- a/objectstore-test/Cargo.toml
+++ b/objectstore-test/Cargo.toml
@@ -14,4 +14,4 @@ objectstore-server = { workspace = true }
 objectstore-types = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }

--- a/objectstore-types/Cargo.toml
+++ b/objectstore-types/Cargo.toml
@@ -13,10 +13,10 @@ publish = true
 http = { workspace = true }
 humantime = { workspace = true }
 humantime-serde = { workspace = true }
-mediatype = "0.21.0"
+mediatype = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-insta = "1"
-serde_json = "1"
+insta = { workspace = true }
+serde_json = { workspace = true }

--- a/stresstest/Cargo.toml
+++ b/stresstest/Cargo.toml
@@ -11,19 +11,19 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-argh = "0.1.13"
-bytesize = { version = "2.0.1", features = ["serde"] }
+argh = { workspace = true }
+bytes = { workspace = true }
+bytesize = { workspace = true }
 futures = { workspace = true }
 humantime-serde = { workspace = true }
-indicatif = "0.18.0"
-bytes = { workspace = true }
+indicatif = { workspace = true }
 objectstore-client = { workspace = true, features = ["multipart"] }
 rand = { workspace = true, features = ["small_rng"] }
-rand_distr = "0.5.1"
+rand_distr = { workspace = true }
 serde = { workspace = true }
-serde_yaml = "0.9.34-deprecated"
-sketches-ddsketch = "0.3.0"
+serde_yaml = { workspace = true }
+sketches-ddsketch = { workspace = true }
 tikv-jemallocator = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync", "macros"] }
 tokio-util = { workspace = true }
-yansi = "1.0.1"
+yansi = { workspace = true }

--- a/stresstest/Cargo.toml
+++ b/stresstest/Cargo.toml
@@ -18,7 +18,7 @@ futures = { workspace = true }
 humantime-serde = { workspace = true }
 indicatif = { workspace = true }
 objectstore-client = { workspace = true, features = ["multipart"] }
-rand = { workspace = true, features = ["small_rng"] }
+rand = { workspace = true }
 rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }

--- a/stresstest/Cargo.toml
+++ b/stresstest/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 anyhow = { workspace = true }
 argh = { workspace = true }
 bytes = { workspace = true }
-bytesize = { workspace = true }
+bytesize = { workspace = true, features = ["serde"] }
 futures = { workspace = true }
 humantime-serde = { workspace = true }
 indicatif = { workspace = true }
@@ -25,5 +25,5 @@ serde_yaml = { workspace = true }
 sketches-ddsketch = { workspace = true }
 tikv-jemallocator = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync", "macros"] }
-tokio-util = { workspace = true }
+tokio-util = { workspace = true, features = ["io"] }
 yansi = { workspace = true }

--- a/stresstest/src/workload.rs
+++ b/stresstest/src/workload.rs
@@ -7,7 +7,7 @@ use std::{fmt, io, task};
 
 use objectstore_client::Usecase;
 use rand::rngs::SmallRng;
-use rand::{Rng, RngCore, SeedableRng};
+use rand::{Rng, RngExt, SeedableRng};
 use rand_distr::weighted::WeightedIndex;
 use rand_distr::{Distribution, LogNormal, Zipf};
 use serde::Deserialize;


### PR DESCRIPTION
- Replace `tokio` `features = ["full"]` with the 7 features objectstore-server actually uses (`fs`, `macros`, `net`, `rt-multi-thread`, `signal`, `sync`, `time`)
- Consolidate 28+ direct member-crate dependencies into `[workspace.dependencies]` as a single alphabetically-sorted block
- Pin all abbreviated version specifiers (`x.y` → `x.y.z`) and align with Cargo.lock resolved versions
- Remove unused `sentry-options` workspace dependency