### PR TITLE
ref(cogs): Use usecase directly as app_feature

### DIFF
--- a/objectstore-service/src/backend/counting.rs
+++ b/objectstore-service/src/backend/counting.rs
@@ -266,11 +266,11 @@ mod tests {
     }
 
     #[test]
-    fn unmapped_usecase_falls_back_to_shared() {
+    fn new_usecase_is_app_feature() {
         let captured = capture(async {
             let backend = CountingBackend::new(Box::new(InMemoryBackend::new("in-memory")));
             backend
-                .get_object(&object_id("unmapped"), None)
+                .get_object(&object_id("new_usecase"), None)
                 .await
                 .unwrap();
         });
@@ -278,7 +278,7 @@ mod tests {
         assert!(
             captured
                 .iter()
-                .any(|m| m == "cogs.usage:+1|c|#app_feature:shared"),
+                .any(|m| m == "cogs.usage:+1|c|#app_feature:new_usecase"),
             "captured: {captured:?}"
         );
     }

--- a/objectstore-service/src/backend/counting.rs
+++ b/objectstore-service/src/backend/counting.rs
@@ -30,28 +30,12 @@ use crate::multipart::{
 };
 use crate::stream::ClientStream;
 
-/// Converts an objectstore `usecase` into the `app_feature` value used by our COGS pipelines.
-fn usecase_to_appfeature(usecase: &str) -> &'static str {
-    // TODO: Flesh out this mapping
-    match usecase {
-        "attachments" => "attachments",
-        "preprod" => "preprod",
-        _ => {
-            objectstore_log::warn!(?usecase, "COGS: Can't convert usecase to app_feature");
-            "shared"
-        }
-    }
-}
-
 /// Increments `cogs.usage` by one operation for the given `usecase`.
 ///
-/// Under the hood, `usecase` is converted to the appropriate `app_feature` value expected in our
-/// COGS pipeline.
+/// Under the hood, the `usecase` is used as the `app_feature`. This allows to identify distinct
+/// products and map them in the for the COGs pipeline.
 fn count(usecase: &str) {
-    objectstore_metrics::count!(
-        "cogs.usage" += 1,
-        app_feature = usecase_to_appfeature(usecase),
-    );
+    objectstore_metrics::count!("cogs.usage" += 1, app_feature = usecase.to_owned());
 }
 
 /// A [`Backend`] decorator that counts each operation performed for COGS. Also implements


### PR DESCRIPTION
Usecases are created on-the-fly by clients, and by design we want to avoid code changes to support new ones, keeping config overhead and misconfiguration risk low. The hard-coded usecase-to-app_feature mapping contradicts this: every new usecase silently falls back to `"shared"`, losing COGS attribution until someone updates the match arm. Technically, `"shared"` is incorrect here, as this is not actually shared cost.

Since there is no cross-service consistency of `app_feature` values anyway, the usecase name is already the right granularity. Use it directly.