### PR TITLE
fix(test): Use async sleep in stresstest

### DIFF
--- a/objectstore-server/tests/stresstest.rs
+++ b/objectstore-server/tests/stresstest.rs
@@ -44,7 +44,7 @@ async fn test_basic() {
         .expect("Failed to spawn subprocess");
 
     // Give the server time to start, or else stresstest might fail to connect.
-    std::thread::sleep(Duration::from_secs(1));
+    tokio::time::sleep(Duration::from_secs(1)).await;
 
     let remote = HttpRemote::new(&format!("http://{addr}"));
     let workload = Workload::builder("test")


### PR DESCRIPTION
`std::thread::sleep` blocks the tokio runtime thread. Use `tokio::time::sleep` to yield back to the executor while waiting for the server to start. 

Since this is in tests, this is mostly a cosmetic change. I'm changing this for best practices.