### PR TITLE
ref: Replace test key LazyLock statics with compile-time constants

### DIFF
--- a/clients/rust/tests/common/mod.rs
+++ b/clients/rust/tests/common/mod.rs
@@ -1,12 +1,7 @@
 #![allow(dead_code)]
 
-use std::sync::LazyLock;
-
 use objectstore_client::{Client, SecretKey, Session, TokenGenerator, Usecase};
-use objectstore_test::server::{TEST_EDDSA_KID, TEST_EDDSA_PRIVKEY_PATH, TestServer, config};
-
-pub static TEST_EDDSA_PRIVKEY: LazyLock<String> =
-    LazyLock::new(|| std::fs::read_to_string(&*TEST_EDDSA_PRIVKEY_PATH).unwrap());
+use objectstore_test::server::{TEST_EDDSA_KID, TEST_EDDSA_PRIVKEY, TestServer, config};
 
 pub async fn test_server() -> TestServer {
     TestServer::with_config(config::Config {
@@ -22,7 +17,7 @@ pub async fn test_server() -> TestServer {
 pub fn test_token_generator() -> TokenGenerator {
     TokenGenerator::new(SecretKey {
         kid: TEST_EDDSA_KID.into(),
-        secret_key: TEST_EDDSA_PRIVKEY.clone(),
+        secret_key: TEST_EDDSA_PRIVKEY.to_owned(),
     })
     .unwrap()
 }

--- a/clients/rust/tests/e2e.rs
+++ b/clients/rust/tests/e2e.rs
@@ -3,14 +3,15 @@ mod common;
 use std::collections::{BTreeMap, HashSet};
 use std::io::Write as _;
 
-use common::{TEST_EDDSA_PRIVKEY, test_server, test_token_generator};
 use futures_util::StreamExt as _;
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode, get_current_timestamp};
 use objectstore_client::{Client, Error, OperationResult, Permission, Usecase};
-use objectstore_test::server::TEST_EDDSA_KID;
+use objectstore_test::server::{TEST_EDDSA_KID, TEST_EDDSA_PRIVKEY};
 use objectstore_types::metadata::Compression;
 use reqwest::StatusCode;
 use serde::Serialize;
+
+use common::{test_server, test_token_generator};
 
 #[derive(Serialize)]
 struct JwtClaims {

--- a/objectstore-server/src/auth/context.rs
+++ b/objectstore-server/src/auth/context.rs
@@ -243,7 +243,7 @@ mod tests {
     fn test_from_encoded_jwt_basic() -> Result<(), AuthError> {
         // Create a token with max permissions
         let claims = sample_claims("123", "456", "attachments", max_permission());
-        let encoded_token = sign_token(&claims, &TEST_EDDSA_PRIVKEY, None);
+        let encoded_token = sign_token(&claims, TEST_EDDSA_PRIVKEY, None);
 
         // Create test config with max permissions
         let test_config = test_key_config(max_permission());
@@ -261,7 +261,7 @@ mod tests {
     fn test_from_encoded_jwt_max_permissions_limit() -> Result<(), AuthError> {
         // Create a token with max permissions
         let claims = sample_claims("123", "456", "attachments", max_permission());
-        let encoded_token = sign_token(&claims, &TEST_EDDSA_PRIVKEY, None);
+        let encoded_token = sign_token(&claims, TEST_EDDSA_PRIVKEY, None);
 
         // Assign read-only permissions to the signing key in config
         let ro_permission = HashSet::from([Permission::ObjectRead]);
@@ -316,7 +316,7 @@ MC4CAQAwBQYDK2VwBCIEIKwVoE4TmTfWoqH3HgLVsEcHs9PHNe+ar/Hp6e4To8pK
         let claims = sample_claims("123", "456", "attachments", max_permission());
         let encoded_token = sign_token(
             &claims,
-            &TEST_EDDSA_PRIVKEY,
+            TEST_EDDSA_PRIVKEY,
             Some(jsonwebtoken::get_current_timestamp() - 100),
         );
 

--- a/objectstore-test/src/server.rs
+++ b/objectstore-test/src/server.rs
@@ -13,8 +13,6 @@
 
 use std::collections::BTreeMap;
 use std::net::{SocketAddr, TcpListener};
-use std::path::PathBuf;
-use std::sync::LazyLock;
 
 use objectstore_server::config::{
     AuthZVerificationKey, Config, MultipartUploadStorageConfig, StorageConfig,
@@ -31,26 +29,18 @@ pub use objectstore_server::config;
 pub const TEST_EDDSA_KID: &str = "test_kid";
 
 /// Filesystem path to the test Ed25519 private key PEM file.
-pub static TEST_EDDSA_PRIVKEY_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
-    [env!("CARGO_MANIFEST_DIR"), "config", "ed25519.private.pem"]
-        .iter()
-        .collect::<PathBuf>()
-});
+pub const TEST_EDDSA_PRIVKEY_PATH: &str =
+    concat!(env!("CARGO_MANIFEST_DIR"), "/config/ed25519.private.pem");
 
 /// PEM-encoded Ed25519 private key used to sign JWTs in tests.
-pub static TEST_EDDSA_PRIVKEY: LazyLock<String> =
-    LazyLock::new(|| std::fs::read_to_string(&*TEST_EDDSA_PRIVKEY_PATH).unwrap());
+pub const TEST_EDDSA_PRIVKEY: &str = include_str!("../config/ed25519.private.pem");
 
 /// Filesystem path to the test Ed25519 public key PEM file.
-pub static TEST_EDDSA_PUBKEY_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
-    [env!("CARGO_MANIFEST_DIR"), "config", "ed25519.public.pem"]
-        .iter()
-        .collect::<PathBuf>()
-});
+pub const TEST_EDDSA_PUBKEY_PATH: &str =
+    concat!(env!("CARGO_MANIFEST_DIR"), "/config/ed25519.public.pem");
 
 /// PEM-encoded Ed25519 public key registered with the test server for JWT verification.
-pub static TEST_EDDSA_PUBKEY: LazyLock<String> =
-    LazyLock::new(|| std::fs::read_to_string(&*TEST_EDDSA_PUBKEY_PATH).unwrap());
+pub const TEST_EDDSA_PUBKEY: &str = include_str!("../config/ed25519.public.pem");
 
 /// An in-process test server for use in integration tests.
 ///
@@ -84,7 +74,7 @@ impl TestServer {
             TEST_EDDSA_KID.into(),
             AuthZVerificationKey {
                 max_permissions: Permission::rwd(),
-                key_files: vec![TEST_EDDSA_PUBKEY_PATH.clone()],
+                key_files: vec![TEST_EDDSA_PUBKEY_PATH.into()],
             },
         )]);
 


### PR DESCRIPTION
Compile-time `include_str!` / `concat!(env!())` instead of runtime `LazyLock<fs::read_to_string>` — cheaper, no blocking I/O from async test bodies, and removes a duplicate definition in the Rust client tests.