### PR TITLE
ref(server): Replace TryFrom with async constructors for key directory

### DIFF
--- a/objectstore-server/src/auth/key_directory.rs
+++ b/objectstore-server/src/auth/key_directory.rs
@@ -7,8 +7,9 @@ use objectstore_types::auth::Permission;
 
 use crate::config::{AuthZ, AuthZVerificationKey};
 
-fn read_key_from_file(filename: &Path) -> anyhow::Result<DecodingKey> {
-    let key_content = std::fs::read_to_string(filename)
+async fn read_key_from_file(filename: &Path) -> anyhow::Result<DecodingKey> {
+    let key_content = tokio::fs::read_to_string(filename)
+        .await
         .with_context(|| format!("reading key from {:?}", filename))?;
     DecodingKey::from_ed_pem(key_content.as_bytes())
         .with_context(|| format!("parsing key from {:?}", filename))
@@ -34,19 +35,20 @@ pub struct PublicKeyConfig {
     pub max_permissions: HashSet<Permission>,
 }
 
-impl TryFrom<&AuthZVerificationKey> for PublicKeyConfig {
-    type Error = anyhow::Error;
+impl PublicKeyConfig {
+    /// Loads key material and permissions from an [`AuthZVerificationKey`] configuration.
+    pub async fn from_config(key_config: &AuthZVerificationKey) -> anyhow::Result<Self> {
+        let mut key_versions = Vec::with_capacity(key_config.key_files.len());
+        for filename in &key_config.key_files {
+            let key = read_key_from_file(filename)
+                .await
+                .inspect_err(|e| objectstore_log::error!("{:?}", e))?;
+            key_versions.push(key);
+        }
 
-    fn try_from(key_config: &AuthZVerificationKey) -> Result<Self, anyhow::Error> {
         Ok(Self {
             max_permissions: key_config.max_permissions.clone(),
-            key_versions: key_config
-                .key_files
-                .iter()
-                .map(|filename| {
-                    read_key_from_file(filename).inspect_err(|e| objectstore_log::error!("{:?}", e))
-                })
-                .collect::<anyhow::Result<Vec<DecodingKey>>>()?,
+            key_versions,
         })
     }
 }
@@ -63,16 +65,15 @@ pub struct PublicKeyDirectory {
     pub keys: BTreeMap<String, PublicKeyConfig>,
 }
 
-impl TryFrom<&AuthZ> for PublicKeyDirectory {
-    type Error = anyhow::Error;
+impl PublicKeyDirectory {
+    /// Loads the full key directory from an [`AuthZ`] configuration.
+    pub async fn from_config(auth_config: &AuthZ) -> anyhow::Result<Self> {
+        let mut keys = BTreeMap::new();
+        for (kid, key_config) in &auth_config.keys {
+            let config = PublicKeyConfig::from_config(key_config).await?;
+            keys.insert(kid.clone(), config);
+        }
 
-    fn try_from(auth_config: &AuthZ) -> Result<Self, Self::Error> {
-        Ok(Self {
-            keys: auth_config
-                .keys
-                .iter()
-                .map(|(kid, key)| Ok((kid.clone(), key.try_into()?)))
-                .collect::<Result<BTreeMap<String, PublicKeyConfig>, anyhow::Error>>()?,
-        })
+        Ok(Self { keys })
     }
 }

--- a/objectstore-server/src/extractors/id.rs
+++ b/objectstore-server/src/extractors/id.rs
@@ -240,7 +240,7 @@ mod tests {
 
     async fn test_state(config: Config) -> ServiceState {
         let service = StorageService::new(Box::new(InMemoryBackend::new("in-memory")));
-        let key_directory = PublicKeyDirectory::try_from(&config.auth).unwrap();
+        let key_directory = PublicKeyDirectory::from_config(&config.auth).await.unwrap();
         let rate_limiter = RateLimiter::new(config.rate_limits.clone());
 
         Arc::new(Services {

--- a/objectstore-server/src/state.rs
+++ b/objectstore-server/src/state.rs
@@ -64,7 +64,7 @@ impl Services {
             StorageService::new(backend).with_concurrency_limit(config.service.max_concurrency);
         service.start();
 
-        let key_directory = PublicKeyDirectory::try_from(&config.auth)?;
+        let key_directory = PublicKeyDirectory::from_config(&config.auth).await?;
         if config.auth.enforce && key_directory.keys.is_empty() {
             anyhow::bail!(
                 "Auth enforcement is enabled but no keys are configured. Either disable auth enforcement (dev/test environments) or configure a public key."


### PR DESCRIPTION
`PublicKeyDirectory::try_from` and `PublicKeyConfig::try_from` perform filesystem I/O
to read EdDSA key files, but `TryFrom` conventionally represents a cheap, in-memory
conversion between representations. A caller seeing `try_from` has no reason to expect
it will read files from disk.

This replaces both `TryFrom` impls with named `async fn from_config` constructors that
use `tokio::fs::read_to_string` instead of the blocking `std::fs::read_to_string`.
The async signatures make the I/O explicit in the type system and avoid blocking a
Tokio worker thread during startup.