### PR TITLE
feat(stresstest): Add optional JWT auth support

### DIFF
--- a/objectstore-server/tests/stresstest.rs
+++ b/objectstore-server/tests/stresstest.rs
@@ -46,7 +46,7 @@ async fn test_basic() {
     // Give the server time to start, or else stresstest might fail to connect.
     tokio::time::sleep(Duration::from_secs(1)).await;
 
-    let remote = HttpRemote::new(&format!("http://{addr}"));
+    let remote = HttpRemote::new(&format!("http://{addr}"), None);
     let workload = Workload::builder("test")
         .concurrency(10)
         .size_distribution(1000, 10_000)

--- a/stresstest/src/config.rs
+++ b/stresstest/src/config.rs
@@ -1,9 +1,16 @@
+use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::bail;
 use bytesize::ByteSize;
 use serde::Deserialize;
 use stresstest::workload::{self, WorkloadMode};
+
+#[derive(Debug, Deserialize)]
+pub struct Auth {
+    pub kid: String,
+    pub key_path: PathBuf,
+}
 
 #[derive(Debug, Deserialize)]
 pub struct Config {
@@ -16,6 +23,9 @@ pub struct Config {
 
     #[serde(default)]
     pub cleanup: bool,
+
+    #[serde(default)]
+    pub auth: Option<Auth>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/stresstest/src/http.rs
+++ b/stresstest/src/http.rs
@@ -3,7 +3,7 @@
 use anyhow::Context;
 use bytes::Bytes;
 use futures::{StreamExt, TryStreamExt};
-use objectstore_client::{Client, GetResponse, Session, Usecase};
+use objectstore_client::{Client, GetResponse, Session, TokenGenerator, Usecase};
 use tokio::io::AsyncReadExt;
 use tokio_util::io::{ReaderStream, StreamReader};
 
@@ -16,13 +16,16 @@ pub struct HttpRemote {
 }
 
 impl HttpRemote {
-    /// Creates a new `HttpRemote` instance with the given remote URL and a default client.
-    pub fn new(remote: &str) -> Self {
+    /// Creates a new `HttpRemote` instance with the given remote URL and optional token generator.
+    pub fn new(remote: &str, token: Option<TokenGenerator>) -> Self {
+        let mut builder = Client::builder(remote).configure_reqwest(|r| r.no_hickory_dns());
+        if let Some(t) = token {
+            builder = builder.token(t);
+        }
         Self {
-            client: Client::builder(remote)
-                .configure_reqwest(|r| r.no_hickory_dns())
-                .build()
-                .unwrap(),
+            // INVARIANT: builder is always valid — remote is a caller-supplied URL and no
+            // fallible configuration is applied.
+            client: builder.build().unwrap(),
         }
     }
 

--- a/stresstest/src/main.rs
+++ b/stresstest/src/main.rs
@@ -19,6 +19,7 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 use argh::FromArgs;
+use objectstore_client::{SecretKey, TokenGenerator};
 use stresstest::Workload;
 use stresstest::http::HttpRemote;
 use stresstest::stresstest::Stresstest;
@@ -46,7 +47,19 @@ async fn main() -> anyhow::Result<()> {
     let config: Config =
         serde_yaml::from_reader(config_file).context("failed to parse config YAML")?;
 
-    let remote = HttpRemote::new(&config.remote);
+    let token = if let Some(auth) = &config.auth {
+        let key = std::fs::read_to_string(&auth.key_path)
+            .with_context(|| format!("failed to read private key from {:?}", auth.key_path))?;
+        let generator = TokenGenerator::new(SecretKey {
+            kid: auth.kid.clone(),
+            secret_key: key,
+        })?;
+        Some(generator)
+    } else {
+        None
+    };
+
+    let remote = HttpRemote::new(&config.remote, token);
     let mut stresstest = Stresstest::new(remote)
         .duration(config.duration)
         .cleanup(config.cleanup);


### PR DESCRIPTION
Adds an optional `auth` block to the stresstest YAML config. When configured with a `kid` and `key_path`, the stresstest loads an EdDSA private key and signs a fresh JWT per request. Omitting `auth` keeps the existing unauthenticated behavior unchanged.

```yaml
auth:
  kid: "stresstest-permission-token-1"
  key_path: /var/secrets/stresstest-private-key.pem
```

This prepares the stresstest for environments where `OS__AUTH__ENFORCE` is enabled.