### PR TITLE
fix: Apply pedantic Clippy lints across workspace

### DIFF
--- a/bigtable-bench/src/main.rs
+++ b/bigtable-bench/src/main.rs
@@ -305,6 +305,6 @@ fn format_throughput(bytes_per_sec: f64) -> String {
     } else if bytes_per_sec >= 1e3 {
         format!("{:.2} kB/s", bytes_per_sec / 1e3)
     } else {
-        format!("{:.0} B/s", bytes_per_sec)
+        format!("{bytes_per_sec:.0} B/s")
     }
 }

--- a/clients/rust/src/auth.rs
+++ b/clients/rust/src/auth.rs
@@ -125,7 +125,7 @@ impl TokenGenerator {
 
     /// Set the permissions that will be granted to tokens signed by this generator.
     pub fn permissions(mut self, permissions: &[Permission]) -> Self {
-        self.permissions = HashSet::from_iter(permissions.iter().cloned());
+        self.permissions = HashSet::from_iter(permissions.iter().copied());
         self
     }
 

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -161,7 +161,7 @@ impl Usecase {
         Self {
             name: name.into(),
             compression: Some(Compression::Zstd),
-            expiration_policy: Default::default(),
+            expiration_policy: ExpirationPolicy::default(),
         }
     }
 
@@ -430,7 +430,7 @@ impl Session {
             .push("objects")
             .push(&self.scope.usecase.name)
             .push(&self.scope.scopes.as_api_path().to_string())
-            .extend(object_key.split("/"));
+            .extend(object_key.split('/'));
         drop(segments);
 
         url
@@ -486,7 +486,7 @@ impl Session {
             .push(&self.scope.usecase.name)
             .push(&self.scope.scopes.as_api_path().to_string());
         if let Some(object_key) = object_key.filter(|key| !key.is_empty()) {
-            segments.extend(object_key.split("/"));
+            segments.extend(object_key.split('/'));
         }
         drop(segments);
         if let Some(query_pairs) = query_pairs {

--- a/clients/rust/src/many.rs
+++ b/clients/rust/src/many.rs
@@ -444,9 +444,7 @@ impl OperationResults {
     ///
     /// Returns an error containing an iterator of all individual errors for the operations
     /// that failed, if any.
-    pub async fn error_for_failures(
-        mut self,
-    ) -> crate::Result<(), impl Iterator<Item = crate::Error>> {
+    pub async fn error_for_failures(mut self) -> crate::Result<(), impl Iterator<Item = Error>> {
         let mut errs = Vec::new();
         while let Some(res) = self.next().await {
             match res {
@@ -492,7 +490,7 @@ async fn send_batch(
     let num_operations = operations.len();
 
     let mut form = reqwest::multipart::Form::new();
-    for op in operations.into_iter() {
+    for op in operations {
         let part = op.into_part().await?;
         form = form.part("part", part);
     }

--- a/clients/rust/tests/e2e.rs
+++ b/clients/rust/tests/e2e.rs
@@ -273,14 +273,14 @@ async fn fails_with_insufficient_auth_token_perms() {
     let session = client.session(usecase.for_project(12345, 1337)).unwrap();
 
     let put_result = session.put("initial body").send().await;
-    println!("{:?}", put_result);
+    println!("{put_result:?}");
     match put_result {
         Err(Error::Reqwest(err)) => assert_eq!(err.status().unwrap(), StatusCode::FORBIDDEN),
         _ => panic!("Expected error"),
     }
 
     let delete_result = session.delete("some-key").send().await;
-    println!("{:?}", delete_result);
+    println!("{delete_result:?}");
     match delete_result {
         Err(Error::Reqwest(err)) => assert_eq!(err.status().unwrap(), StatusCode::FORBIDDEN),
         _ => panic!("Expected error"),
@@ -343,7 +343,7 @@ async fn batch_operations() {
         .iter()
         .map(|r| match r {
             OperationResult::Put(key, Ok(_)) => key.clone(),
-            other => panic!("Expected Put result, got: {:?}", other),
+            other => panic!("Expected Put result, got: {other:?}"),
         })
         .collect();
     keys.sort();
@@ -383,7 +383,7 @@ async fn batch_operations() {
             OperationResult::Put(key, Ok(_)) => {
                 puts.insert(key);
             }
-            other => panic!("Unexpected result: {:?}", other),
+            other => panic!("Unexpected result: {other:?}"),
         }
     }
 
@@ -447,7 +447,7 @@ async fn batch_insert_without_key() {
 
     let server_key = match &results[0] {
         OperationResult::Put(key, Ok(_)) => key.clone(),
-        other => panic!("Expected Put result, got: {:?}", other),
+        other => panic!("Expected Put result, got: {other:?}"),
     };
 
     // The server should have assigned a non-empty key
@@ -505,7 +505,7 @@ async fn batch_partial_failures() {
             OperationResult::Delete(key, inner) => {
                 deletes.insert(key, inner);
             }
-            other => panic!("Unexpected result: {:?}", other),
+            other => panic!("Unexpected result: {other:?}"),
         }
     }
 
@@ -519,14 +519,14 @@ async fn batch_partial_failures() {
     let put_result = puts.remove("write-key").expect("missing put result");
     match put_result {
         Err(Error::OperationFailure { status, .. }) => assert_eq!(status, 403),
-        other => panic!("Expected OperationFailure(403), got: {:?}", other),
+        other => panic!("Expected OperationFailure(403), got: {other:?}"),
     }
 
     // DELETE should fail with 403 (no delete permission)
     let delete_result = deletes.remove("delete-key").expect("missing delete result");
     match delete_result {
         Err(Error::OperationFailure { status, .. }) => assert_eq!(status, 403),
-        other => panic!("Expected OperationFailure(403), got: {:?}", other),
+        other => panic!("Expected OperationFailure(403), got: {other:?}"),
     }
 
     // GETs after the failures should still succeed
@@ -591,7 +591,7 @@ async fn batch_put_files() {
         .iter()
         .map(|r| match r {
             OperationResult::Put(key, Ok(_)) => key.clone(),
-            other => panic!("Expected successful Put result, got: {:?}", other),
+            other => panic!("Expected successful Put result, got: {other:?}"),
         })
         .collect();
     keys.sort();
@@ -746,7 +746,7 @@ async fn batch_head_operations() {
             OperationResult::Head(key, inner) => {
                 heads.insert(key, inner);
             }
-            other => panic!("Expected Head result, got: {:?}", other),
+            other => panic!("Expected Head result, got: {other:?}"),
         }
     }
 

--- a/objectstore-server/src/auth/context.rs
+++ b/objectstore-server/src/auth/context.rs
@@ -124,7 +124,7 @@ impl AuthContext {
             .claims
             .permissions
             .intersection(&key_config.max_permissions)
-            .cloned()
+            .copied()
             .collect();
 
         Ok(AuthContext {

--- a/objectstore-server/src/auth/key_directory.rs
+++ b/objectstore-server/src/auth/key_directory.rs
@@ -9,9 +9,9 @@ use crate::config::{AuthZ, AuthZVerificationKey};
 
 fn read_key_from_file(filename: &Path) -> anyhow::Result<DecodingKey> {
     let key_content = std::fs::read_to_string(filename)
-        .with_context(|| format!("reading key from {:?}", filename))?;
+        .with_context(|| format!("reading key from {filename:?}"))?;
     DecodingKey::from_ed_pem(key_content.as_bytes())
-        .with_context(|| format!("parsing key from {:?}", filename))
+        .with_context(|| format!("parsing key from {filename:?}"))
 }
 
 /// Configures the EdDSA public key(s) and permissions used to verify tokens from a single `kid`.

--- a/objectstore-server/src/config.rs
+++ b/objectstore-server/src/config.rs
@@ -58,7 +58,7 @@ const ENV_PREFIX: &str = "OS__";
 /// Newtype around `String` that may protect against accidental
 /// logging of secrets in our configuration struct. Use with
 /// [`secrecy::SecretBox`].
-#[derive(Clone, Default, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ConfigSecret(String);
 
 impl ConfigSecret {

--- a/objectstore-server/src/endpoints/multipart.rs
+++ b/objectstore-server/src/endpoints/multipart.rs
@@ -123,7 +123,7 @@ async fn upload_part(
     MeteredBody(body): MeteredBody,
 ) -> ApiResult<Response> {
     let content_length = headers
-        .get(axum::http::header::CONTENT_LENGTH)
+        .get(header::CONTENT_LENGTH)
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.parse::<u64>().ok())
         .ok_or_else(|| ApiError::Client("Content-Length header is required".into()))?;

--- a/objectstore-server/src/extractors/id.rs
+++ b/objectstore-server/src/extractors/id.rs
@@ -24,12 +24,12 @@ impl IntoResponse for ObjectRejection {
         match self {
             ObjectRejection::Path(rejection) => rejection.into_response(),
             ObjectRejection::Killswitched => (
-                axum::http::StatusCode::FORBIDDEN,
+                http::StatusCode::FORBIDDEN,
                 "Object access is disabled for this scope through killswitches",
             )
                 .into_response(),
             ObjectRejection::RateLimited => (
-                axum::http::StatusCode::TOO_MANY_REQUESTS,
+                http::StatusCode::TOO_MANY_REQUESTS,
                 "Object access is rate limited",
             )
                 .into_response(),
@@ -104,7 +104,7 @@ where
         .split(';')
         .map(|s| {
             let (key, value) = s
-                .split_once("=")
+                .split_once('=')
                 .ok_or_else(|| de::Error::custom("scope must be 'key=value'"))?;
 
             Scope::create(key, value).map_err(de::Error::custom)
@@ -276,7 +276,7 @@ mod tests {
             .with_state(state)
     }
 
-    async fn response_body(response: axum::http::Response<Body>) -> String {
+    async fn response_body(response: http::Response<Body>) -> String {
         let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
             .await
             .unwrap();

--- a/objectstore-server/src/extractors/id.rs
+++ b/objectstore-server/src/extractors/id.rs
@@ -221,7 +221,7 @@ mod tests {
     // --- Extractor integration tests ---
 
     use std::collections::BTreeMap;
-    use std::sync::Arc;
+    use std::sync::{Arc, OnceLock};
 
     use axum::Router;
     use axum::body::Body;
@@ -377,7 +377,7 @@ mod tests {
                 usecase: Some("blocked".into()),
                 scopes: BTreeMap::new(),
                 service: None,
-                service_matcher: Default::default(),
+                service_matcher: OnceLock::new(),
             }]),
             ..Config::default()
         };
@@ -406,7 +406,7 @@ mod tests {
                 usecase: Some("blocked".into()),
                 scopes: BTreeMap::new(),
                 service: None,
-                service_matcher: Default::default(),
+                service_matcher: OnceLock::new(),
             }]),
             ..Config::default()
         };
@@ -437,7 +437,7 @@ mod tests {
                 usecase: None,
                 scopes: BTreeMap::new(),
                 service: Some("test-*".into()),
-                service_matcher: Default::default(),
+                service_matcher: OnceLock::new(),
             }]),
             ..Config::default()
         };

--- a/objectstore-server/src/multipart.rs
+++ b/objectstore-server/src/multipart.rs
@@ -55,7 +55,7 @@ where
     T: Into<Part> + Send,
 {
     fn into_multipart_response(self, boundary: u128) -> Response {
-        let boundary_str = format!("os-boundary-{:032x}", boundary);
+        let boundary_str = format!("os-boundary-{boundary:032x}");
         let boundary = {
             let mut bytes = BytesMut::with_capacity(boundary_str.len() + 4);
             bytes.put(&b"--"[..]);
@@ -72,23 +72,22 @@ where
                 .expect("valid header value, as we just defined it as \"os-boundary-X\" where X are hex digits"),
         );
 
-        let body: BoxStream<Result<bytes::Bytes, std::convert::Infallible>> =
-            async_stream::try_stream! {
-                let items = self;
-                futures::pin_mut!(items);
-                while let Some(item) = items.next().await {
-                    yield boundary.clone();
-                    let part = item.into();
-                    yield serialize_headers(part.headers);
-                    yield serialize_body(part.body);
-                }
-
-                let mut closing = BytesMut::with_capacity(boundary.len());
-                closing.put(boundary.slice(..boundary.len() - 2)); // don't take trailing \r\n
-                closing.put(&b"--"[..]);
-                yield closing.freeze();
+        let body: BoxStream<Result<Bytes, std::convert::Infallible>> = async_stream::try_stream! {
+            let items = self;
+            futures::pin_mut!(items);
+            while let Some(item) = items.next().await {
+                yield boundary.clone();
+                let part = item.into();
+                yield serialize_headers(part.headers);
+                yield serialize_body(part.body);
             }
-            .boxed();
+
+            let mut closing = BytesMut::with_capacity(boundary.len());
+            closing.put(boundary.slice(..boundary.len() - 2)); // don't take trailing \r\n
+            closing.put(&b"--"[..]);
+            yield closing.freeze();
+        }
+        .boxed();
 
         (headers, Body::from_stream(body)).into_response()
     }
@@ -143,8 +142,8 @@ mod tests {
         let boundary: u128 = 0xdeadbeef;
         let response = futures::stream::iter(parts).into_multipart_response(boundary);
 
-        let boundary = format!("os-boundary-{:032x}", boundary);
-        let content_type_str = format!("multipart/form-data; boundary=\"{}\"", boundary);
+        let boundary = format!("os-boundary-{boundary:032x}");
+        let content_type_str = format!("multipart/form-data; boundary=\"{boundary}\"");
         assert_eq!(
             response
                 .headers()

--- a/objectstore-server/src/web/middleware.rs
+++ b/objectstore-server/src/web/middleware.rs
@@ -57,10 +57,7 @@ pub fn make_http_span(request: &Request) -> tracing::Span {
         client_addr = tracing::field::Empty,
     );
 
-    if let Some(ConnectInfo(addr)) = request
-        .extensions()
-        .get::<axum::extract::ConnectInfo<SocketAddr>>()
-    {
+    if let Some(ConnectInfo(addr)) = request.extensions().get::<ConnectInfo<SocketAddr>>() {
         span.record("client_addr", tracing::field::display(addr.ip()));
     }
 

--- a/objectstore-server/tests/limits.rs
+++ b/objectstore-server/tests/limits.rs
@@ -4,6 +4,7 @@
 //! maximum object sizes, rate limiting, and killswitches.
 
 use std::collections::{BTreeMap, HashMap};
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use anyhow::Result;
@@ -70,7 +71,7 @@ async fn test_killswitches() -> Result<()> {
             usecase: Some("blocked".to_string()),
             scopes: BTreeMap::from_iter([("org".to_string(), "42".to_string())]),
             service: Some("test-*".to_string()),
-            service_matcher: Default::default(),
+            service_matcher: OnceLock::new(),
         }]),
         auth: AuthZ {
             enforce: false,

--- a/objectstore-server/tests/limits.rs
+++ b/objectstore-server/tests/limits.rs
@@ -148,7 +148,7 @@ async fn test_throughput_global_rps_limit() -> Result<()> {
     assert_eq!(response.status(), reqwest::StatusCode::TOO_MANY_REQUESTS);
 
     // Refill bucket
-    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+    tokio::time::sleep(Duration::from_secs(1)).await;
 
     // After waiting, request succeeds
     let response = client
@@ -206,7 +206,7 @@ async fn test_throughput_usecase_pct_limit() -> Result<()> {
     assert_eq!(response.status(), reqwest::StatusCode::NOT_FOUND);
 
     // Refill bucket
-    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+    tokio::time::sleep(Duration::from_secs(1)).await;
 
     // After waiting, request to first usecase should succeed again
     let response = client
@@ -264,7 +264,7 @@ async fn test_throughput_scope_pct_limit() -> Result<()> {
     assert_eq!(response.status(), reqwest::StatusCode::NOT_FOUND);
 
     // Refill bucket
-    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+    tokio::time::sleep(Duration::from_secs(1)).await;
 
     // After waiting, request to first scope should succeed again
     let response = client
@@ -332,7 +332,7 @@ async fn test_throughput_rule() -> Result<()> {
     assert_eq!(response.status(), reqwest::StatusCode::NOT_FOUND);
 
     // Refill bucket
-    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+    tokio::time::sleep(Duration::from_secs(1)).await;
 
     // After waiting, request matching rule should succeed again
     let response = client
@@ -376,7 +376,7 @@ async fn test_bandwidth_global_bps_limit() -> Result<()> {
     assert_eq!(response.status(), reqwest::StatusCode::CREATED);
 
     // Wait a few EWMA ticks (50ms each) so the estimator incorporates the bandwidth.
-    tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
+    tokio::time::sleep(Duration::from_millis(150)).await;
 
     // The next request should be rejected with 429
     let response = client
@@ -389,7 +389,7 @@ async fn test_bandwidth_global_bps_limit() -> Result<()> {
     // Wait long enough for the EWMA to decay below the limit.
     // With alpha=0.2, EWMA decays as 0.8^n per tick. Peak ~16384 needs ~16 ticks (800ms)
     // to drop below 500. Use 2s for CI reliability.
-    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
 
     // After decay, the request should succeed again
     let response = client
@@ -435,7 +435,7 @@ async fn test_bandwidth_usecase_pct_limit() -> Result<()> {
     assert_eq!(response.status(), reqwest::StatusCode::CREATED);
 
     // Wait a few EWMA ticks so the estimator incorporates the bandwidth.
-    tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
+    tokio::time::sleep(Duration::from_millis(150)).await;
 
     // The next request to the same usecase should be rejected with 429
     let response = client
@@ -454,7 +454,7 @@ async fn test_bandwidth_usecase_pct_limit() -> Result<()> {
     assert_eq!(response.status(), reqwest::StatusCode::CREATED);
 
     // Wait for the EWMA to decay below the limit
-    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
 
     // After decay, the request to the original usecase should succeed again
     let response = client
@@ -500,7 +500,7 @@ async fn test_bandwidth_scope_pct_limit() -> Result<()> {
     assert_eq!(response.status(), reqwest::StatusCode::CREATED);
 
     // Wait a few EWMA ticks so the estimator incorporates the bandwidth.
-    tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
+    tokio::time::sleep(Duration::from_millis(150)).await;
 
     // The next request to the same scope should be rejected with 429
     let response = client
@@ -519,7 +519,7 @@ async fn test_bandwidth_scope_pct_limit() -> Result<()> {
     assert_eq!(response.status(), reqwest::StatusCode::CREATED);
 
     // Wait for the EWMA to decay below the limit
-    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
 
     // After decay, the request to the original scope should succeed again
     let response = client

--- a/objectstore-service/src/backend/bigtable.rs
+++ b/objectstore-service/src/backend/bigtable.rs
@@ -1156,7 +1156,7 @@ fn ttl_to_micros(ttl: Duration, from: SystemTime) -> Result<i64> {
         })?
         .as_millis();
     (millis * 1000).try_into().map_err(|e| Error::Generic {
-        context: format!("failed to convert {}ms to i64 microseconds", millis),
+        context: format!("failed to convert {millis}ms to i64 microseconds"),
         cause: Some(Box::new(e)),
     })
 }

--- a/objectstore-service/src/backend/changelog.rs
+++ b/objectstore-service/src/backend/changelog.rs
@@ -301,7 +301,7 @@ impl ChangeLog for NoopChangeLog {
 }
 
 /// Phase of a multi-step storage change.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ChangePhase {
     /// The change was recovered from changelog and the phase is unknown.
     Recovered,

--- a/objectstore-service/src/backend/common.rs
+++ b/objectstore-service/src/backend/common.rs
@@ -196,7 +196,7 @@ pub trait HighVolumeBackend: Backend {
 }
 
 /// Information about a redirect tombstone in the high-volume backend.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Tombstone {
     /// The [`ObjectId`] of the object in the long-term backend.
     ///

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -12,7 +12,9 @@ use gcp_auth::TokenProvider;
 use objectstore_types::metadata::{ExpirationPolicy, Metadata};
 use objectstore_types::range::{ByteRange, ContentRange};
 use reqwest::header::HeaderName;
-use reqwest::{Body, IntoUrl, Method, RequestBuilder, StatusCode, Url, header, multipart};
+use reqwest::{
+    Body, IntoUrl, Method, RequestBuilder, Response, StatusCode, Url, header, multipart,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::backend::common::{
@@ -209,8 +211,7 @@ impl GcsObject {
             } else {
                 return Err(Error::Generic {
                     context: format!(
-                        "GCS: unexpected built-in metadata key in object metadata: {}",
-                        key
+                        "GCS: unexpected built-in metadata key in object metadata: {key}"
                     ),
                     cause: None,
                 });
@@ -274,7 +275,7 @@ impl fmt::Display for GcsMetaKey {
     }
 }
 
-impl<'de> serde::Deserialize<'de> for GcsMetaKey {
+impl<'de> Deserialize<'de> for GcsMetaKey {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -284,7 +285,7 @@ impl<'de> serde::Deserialize<'de> for GcsMetaKey {
     }
 }
 
-impl serde::Serialize for GcsMetaKey {
+impl Serialize for GcsMetaKey {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -577,7 +578,7 @@ impl GcsBackend {
                 .json(&CustomTimeRequest { custom_time })
                 .send()
                 .await
-                .and_then(|r| r.error_for_status())
+                .and_then(Response::error_for_status)
                 .map_err(|e| Error::reqwest("GCS: update custom time", e))?;
             Ok(())
         })
@@ -649,7 +650,7 @@ impl Backend for GcsBackend {
             .header(header::CONTENT_TYPE, content_type)
             .send()
             .await
-            .and_then(|r| r.error_for_status())
+            .and_then(Response::error_for_status)
             .map_err(|e| match stream::unpack_client_error(&e) {
                 Some(ce) => Error::Client(ce),
                 _ => Error::reqwest("GCS: upload object", e),
@@ -692,8 +693,7 @@ impl Backend for GcsBackend {
                         None => {
                             return Err(Error::Generic {
                                 context: format!(
-                                    "GCS: 416 response with invalid Content-Range: {:?}",
-                                    raw
+                                    "GCS: 416 response with invalid Content-Range: {raw:?}"
                                 ),
                                 cause: None,
                             });
@@ -771,9 +771,9 @@ struct XmlInitiateMultipartUploadResponse {
 }
 
 impl TryFrom<XmlInitiateMultipartUploadResponse> for InitiateMultipartResponse {
-    type Error = crate::error::Error;
+    type Error = Error;
 
-    fn try_from(r: XmlInitiateMultipartUploadResponse) -> crate::error::Result<Self> {
+    fn try_from(r: XmlInitiateMultipartUploadResponse) -> Result<Self> {
         Ok(UploadId::new(r.upload_id)?)
     }
 }
@@ -897,7 +897,7 @@ impl MultipartUploadBackend for GcsBackend {
         let resp = builder
             .send()
             .await
-            .and_then(|r| r.error_for_status())
+            .and_then(Response::error_for_status)
             .map_err(|e| Error::reqwest("GCS: initiate multipart upload", e))?;
 
         let body = resp
@@ -943,7 +943,7 @@ impl MultipartUploadBackend for GcsBackend {
         let resp = builder
             .send()
             .await
-            .and_then(|r| r.error_for_status())
+            .and_then(Response::error_for_status)
             .map_err(|e| Error::reqwest("GCS: upload part", e))?;
 
         let etag = resp
@@ -982,7 +982,7 @@ impl MultipartUploadBackend for GcsBackend {
             .await?
             .send()
             .await
-            .and_then(|r| r.error_for_status())
+            .and_then(Response::error_for_status)
             .map_err(|e| Error::reqwest("GCS: list parts", e))?;
 
         let body = resp
@@ -1013,7 +1013,7 @@ impl MultipartUploadBackend for GcsBackend {
             .await?
             .send()
             .await
-            .and_then(|r| r.error_for_status())
+            .and_then(Response::error_for_status)
             .map_err(|e| Error::reqwest("GCS: abort multipart upload", e))?;
 
         Ok(())
@@ -1043,7 +1043,7 @@ impl MultipartUploadBackend for GcsBackend {
             .body(xml)
             .send()
             .await
-            .and_then(|r| r.error_for_status())
+            .and_then(Response::error_for_status)
             .map_err(|e| Error::reqwest("GCS: complete multipart upload", e))?;
 
         let body = resp

--- a/objectstore-service/src/backend/in_memory.rs
+++ b/objectstore-service/src/backend/in_memory.rs
@@ -469,7 +469,7 @@ impl Entry {
     pub fn expect_not_found(&self) {
         match self {
             Entry::NotFound => (),
-            _ => panic!("expected not found entry, got {:?}", self),
+            _ => panic!("expected not found entry, got {self:?}"),
         }
     }
 
@@ -477,7 +477,7 @@ impl Entry {
     pub fn expect_object(&self) -> (Metadata, Bytes) {
         match self {
             Entry::Object(metadata, bytes) => (metadata.clone(), bytes.clone()),
-            _ => panic!("expected object entry, got {:?}", self),
+            _ => panic!("expected object entry, got {self:?}"),
         }
     }
 
@@ -485,7 +485,7 @@ impl Entry {
     pub fn expect_tombstone(&self) -> Tombstone {
         match self {
             Entry::Tombstone(tombstone) => tombstone.clone(),
-            _ => panic!("expected tombstone entry, got {:?}", self),
+            _ => panic!("expected tombstone entry, got {self:?}"),
         }
     }
 }

--- a/objectstore-service/src/backend/local_fs.rs
+++ b/objectstore-service/src/backend/local_fs.rs
@@ -590,7 +590,7 @@ mod tests {
             .complete_multipart(
                 &id,
                 &upload_id,
-                vec![crate::multipart::CompletedPart {
+                vec![CompletedPart {
                     part_number: NonZeroU32::new(1).unwrap(),
                     etag,
                 }],
@@ -662,15 +662,15 @@ mod tests {
                 &id,
                 &upload_id,
                 vec![
-                    crate::multipart::CompletedPart {
+                    CompletedPart {
                         part_number: NonZeroU32::new(1).unwrap(),
                         etag: etag1,
                     },
-                    crate::multipart::CompletedPart {
+                    CompletedPart {
                         part_number: NonZeroU32::new(2).unwrap(),
                         etag: etag2,
                     },
-                    crate::multipart::CompletedPart {
+                    CompletedPart {
                         part_number: NonZeroU32::new(3).unwrap(),
                         etag: etag3,
                     },
@@ -897,7 +897,7 @@ mod tests {
             .complete_multipart(
                 &id,
                 &upload_id,
-                vec![crate::multipart::CompletedPart {
+                vec![CompletedPart {
                     part_number: NonZeroU32::new(1).unwrap(),
                     etag: "wrong-etag".into(),
                 }],
@@ -912,7 +912,7 @@ mod tests {
             .complete_multipart(
                 &id,
                 &upload_id,
-                vec![crate::multipart::CompletedPart {
+                vec![CompletedPart {
                     part_number: NonZeroU32::new(1).unwrap(),
                     etag,
                 }],
@@ -946,7 +946,7 @@ mod tests {
             .complete_multipart(
                 &id,
                 &upload_id,
-                vec![crate::multipart::CompletedPart {
+                vec![CompletedPart {
                     part_number: NonZeroU32::new(99).unwrap(),
                     etag: "whatever".into(),
                 }],
@@ -961,7 +961,7 @@ mod tests {
             .complete_multipart(
                 &id,
                 &upload_id,
-                vec![crate::multipart::CompletedPart {
+                vec![CompletedPart {
                     part_number: NonZeroU32::new(1).unwrap(),
                     etag,
                 }],

--- a/objectstore-service/src/backend/mod.rs
+++ b/objectstore-service/src/backend/mod.rs
@@ -100,7 +100,7 @@ pub enum HighVolumeStorageConfig {
 /// Constructs a type-erased [`common::HighVolumeBackend`] from the given config.
 async fn hv_from_config(
     config: HighVolumeStorageConfig,
-) -> anyhow::Result<Box<dyn common::HighVolumeBackend>> {
+) -> Result<Box<dyn common::HighVolumeBackend>> {
     Ok(match config {
         HighVolumeStorageConfig::BigTable(c) => Box::new(bigtable::BigTableBackend::new(c).await?),
     })
@@ -124,7 +124,7 @@ pub enum MultipartUploadStorageConfig {
 /// Constructs a type-erased [`common::MultipartUploadBackend`] from the given config.
 async fn lt_from_config(
     config: MultipartUploadStorageConfig,
-) -> anyhow::Result<Box<dyn common::MultipartUploadBackend>> {
+) -> Result<Box<dyn common::MultipartUploadBackend>> {
     Ok(match config {
         MultipartUploadStorageConfig::FileSystem(c) => Box::new(local_fs::LocalFsBackend::new(c)),
         MultipartUploadStorageConfig::Gcs(c) => Box::new(gcs::GcsBackend::new(c).await?),

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -7,7 +7,7 @@ use futures_util::{StreamExt, TryStreamExt};
 use objectstore_types::metadata::{ExpirationPolicy, Metadata};
 use objectstore_types::range::{ByteRange, ContentRange};
 use reqwest::header::HeaderMap;
-use reqwest::{Body, IntoUrl, Method, RequestBuilder, StatusCode};
+use reqwest::{Body, IntoUrl, Method, RequestBuilder, Response, StatusCode};
 
 use crate::backend::common::{
     self, Backend, DeleteResponse, GetResponse, MetadataResponse, PutResponse,
@@ -128,8 +128,7 @@ fn metadata_to_gcs_headers(
     let mut headers = metadata.to_headers(prefix)?;
     // GCS custom-time for lifecycle expiration
     if let Some(expires_in) = metadata.expiration_policy.expires_in() {
-        let expires_at =
-            humantime::format_rfc3339_seconds(std::time::SystemTime::now() + expires_in);
+        let expires_at = humantime::format_rfc3339_seconds(SystemTime::now() + expires_in);
         headers.append(GCS_CUSTOM_TIME, expires_at.to_string().parse()?);
     }
     Ok(headers)
@@ -165,7 +164,7 @@ where
         method: Method,
         id: &ObjectId,
         range: Option<ByteRange>,
-    ) -> Result<Option<(Metadata, Option<ContentRange>, reqwest::Response)>> {
+    ) -> Result<Option<(Metadata, Option<ContentRange>, Response)>> {
         let object_url = self.object_url(id);
 
         let mut builder = self.request(method, &object_url).await?;
@@ -192,7 +191,7 @@ where
                 Some(total) => return Err(Error::RangeNotSatisfiable { total }),
                 None => {
                     return Err(Error::Generic {
-                        context: format!("S3: 416 response with invalid Content-Range: {:?}", raw),
+                        context: format!("S3: 416 response with invalid Content-Range: {raw:?}"),
                         cause: None,
                     });
                 }
@@ -318,7 +317,7 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
             .body(Body::wrap_stream(stream))
             .send()
             .await
-            .and_then(|response| response.error_for_status())
+            .and_then(Response::error_for_status)
             .map_err(|cause| match stream::unpack_client_error(&cause) {
                 Some(ce) => Error::Client(ce),
                 _ => Error::Reqwest {

--- a/objectstore-service/src/backend/tiered.rs
+++ b/objectstore-service/src/backend/tiered.rs
@@ -1352,9 +1352,13 @@ mod tests {
         let payload = vec![0xABu8; 100];
 
         // Write the object under the LT id and a tombstone pointing to it from HV.
-        lt.put_object(&lt_id, &Metadata::default(), stream::single(payload.clone()))
-            .await
-            .unwrap();
+        lt.put_object(
+            &lt_id,
+            &Metadata::default(),
+            stream::single(payload.clone()),
+        )
+        .await
+        .unwrap();
         let tombstone = Tombstone {
             target: lt_id.clone(),
             expiration_policy: ExpirationPolicy::Manual,

--- a/objectstore-service/src/backend/tiered.rs
+++ b/objectstore-service/src/backend/tiered.rs
@@ -959,7 +959,7 @@ mod tests {
         let payload = b"small payload".to_vec();
 
         storage
-            .put_object(&id, &Default::default(), stream::single(payload.clone()))
+            .put_object(&id, &Metadata::default(), stream::single(payload.clone()))
             .await
             .unwrap();
 
@@ -985,7 +985,7 @@ mod tests {
             content_type: "image/png".into(),
             expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_hours(1)),
             origin: Some("10.0.0.1".into()),
-            ..Default::default()
+            ..Metadata::default()
         };
 
         storage
@@ -1028,7 +1028,7 @@ mod tests {
         // First: insert a large object → creates tombstone in hv, payload in lt at lt_id
         let large_payload = vec![0xABu8; 2 * 1024 * 1024];
         storage
-            .put_object(&id, &Default::default(), stream::single(large_payload))
+            .put_object(&id, &Metadata::default(), stream::single(large_payload))
             .await
             .unwrap();
 
@@ -1038,7 +1038,7 @@ mod tests {
         // The CAS-swap puts the small object inline in HV and schedules background cleanup.
         let small_payload = vec![0xCDu8; 100]; // well under 1 MiB threshold
         storage
-            .put_object(&id, &Default::default(), stream::single(small_payload))
+            .put_object(&id, &Metadata::default(), stream::single(small_payload))
             .await
             .unwrap();
 
@@ -1059,14 +1059,14 @@ mod tests {
 
         let payload1 = vec![0xAAu8; 2 * 1024 * 1024];
         storage
-            .put_object(&id, &Default::default(), stream::single(payload1))
+            .put_object(&id, &Metadata::default(), stream::single(payload1))
             .await
             .unwrap();
         let lt_id_1 = hv.get(&id).expect_tombstone().target;
 
         let payload2 = vec![0xBBu8; 2 * 1024 * 1024];
         storage
-            .put_object(&id, &Default::default(), stream::single(payload2.clone()))
+            .put_object(&id, &Metadata::default(), stream::single(payload2.clone()))
             .await
             .unwrap();
         let lt_id_2 = hv.get(&id).expect_tombstone().target;
@@ -1095,7 +1095,7 @@ mod tests {
         let id = make_id("delete-small");
 
         storage
-            .put_object(&id, &Default::default(), stream::single("tiny"))
+            .put_object(&id, &Metadata::default(), stream::single("tiny"))
             .await
             .unwrap();
 
@@ -1112,7 +1112,7 @@ mod tests {
         let payload = vec![0u8; 2 * 1024 * 1024]; // 2 MiB
 
         storage
-            .put_object(&id, &Default::default(), stream::single(payload))
+            .put_object(&id, &Metadata::default(), stream::single(payload))
             .await
             .unwrap();
 
@@ -1158,7 +1158,7 @@ mod tests {
         let id = make_id("fail-delete");
         let payload = vec![0xABu8; 2 * 1024 * 1024]; // 2 MiB -> goes to long-term
         storage
-            .put_object(&id, &Default::default(), stream::single(payload))
+            .put_object(&id, &Metadata::default(), stream::single(payload))
             .await
             .unwrap();
 
@@ -1211,7 +1211,7 @@ mod tests {
         let payload = vec![0xABu8; 2 * 1024 * 1024]; // 2 MiB -> long-term path
 
         storage
-            .put_object(&id, &Default::default(), stream::single(payload))
+            .put_object(&id, &Metadata::default(), stream::single(payload))
             .await
             .unwrap();
 
@@ -1251,7 +1251,7 @@ mod tests {
         // Writing a small object over a tombstone should succeed even when CAS
         // conflicts — the other writer's write is accepted.
         storage
-            .put_object(&id, &Default::default(), stream::single("tiny"))
+            .put_object(&id, &Metadata::default(), stream::single("tiny"))
             .await
             .unwrap();
     }
@@ -1295,7 +1295,7 @@ mod tests {
         let id = make_id("orphan-test");
         let payload = vec![0xABu8; 2 * 1024 * 1024]; // 2 MiB -> long-term path
         let result = storage
-            .put_object(&id, &Default::default(), stream::single(payload))
+            .put_object(&id, &Metadata::default(), stream::single(payload))
             .await;
 
         assert!(result.is_err());
@@ -1316,7 +1316,7 @@ mod tests {
         let payload = vec![0xCDu8; 2 * 1024 * 1024]; // 2 MiB
 
         storage
-            .put_object(&id, &Default::default(), stream::single(payload))
+            .put_object(&id, &Metadata::default(), stream::single(payload))
             .await
             .unwrap();
 
@@ -1352,7 +1352,7 @@ mod tests {
         let payload = vec![0xABu8; 100];
 
         // Write the object under the LT id and a tombstone pointing to it from HV.
-        lt.put_object(&lt_id, &Default::default(), stream::single(payload.clone()))
+        lt.put_object(&lt_id, &Metadata::default(), stream::single(payload.clone()))
             .await
             .unwrap();
         let tombstone = Tombstone {
@@ -1387,12 +1387,12 @@ mod tests {
         let chunk_size = 512 * 1024; // 512 KiB per chunk
         let chunk_count = 4; // 4 × 512 KiB = 2 MiB total
         let stream: ClientStream = futures_util::stream::iter(
-            (0..chunk_count).map(move |i| Ok(bytes::Bytes::from(vec![i as u8; chunk_size]))),
+            (0..chunk_count).map(move |i| Ok(Bytes::from(vec![i as u8; chunk_size]))),
         )
         .boxed();
 
         storage
-            .put_object(&id, &Default::default(), stream)
+            .put_object(&id, &Metadata::default(), stream)
             .await
             .unwrap();
 
@@ -1426,7 +1426,7 @@ mod tests {
         // First put: establishes tombstone
         let payload = vec![0xAAu8; 2 * 1024 * 1024];
         storage
-            .put_object(&id, &Default::default(), stream::single(payload.clone()))
+            .put_object(&id, &Metadata::default(), stream::single(payload.clone()))
             .await
             .unwrap();
         let tombstone1 = hv.get(&id).expect_tombstone().target;
@@ -1438,7 +1438,7 @@ mod tests {
             Box::new(log.clone()),
         );
         broken_storage
-            .put_object(&id, &Default::default(), stream::single(payload.clone()))
+            .put_object(&id, &Metadata::default(), stream::single(payload.clone()))
             .await
             .unwrap_err(); // must fail
         let tombstone2 = hv.get(&id).expect_tombstone().target;
@@ -1458,14 +1458,14 @@ mod tests {
         // Create a fresh large object
         let id = make_id("obj2");
         storage
-            .put_object(&id, &Default::default(), stream::single(payload.clone()))
+            .put_object(&id, &Metadata::default(), stream::single(payload.clone()))
             .await
             .unwrap();
         let tombstone3 = hv.get(&id).expect_tombstone().target;
 
         // Overwrite it with a small object and check again for cleanup
         broken_storage
-            .put_object(&id, &Default::default(), stream::single(&b"small"[..]))
+            .put_object(&id, &Metadata::default(), stream::single(&b"small"[..]))
             .await
             .unwrap_err(); // must fail
         hv.get(&id).expect_object();
@@ -1625,7 +1625,7 @@ mod tests {
         let metadata = Metadata {
             content_type: "application/octet-stream".into(),
             expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_hours(1)),
-            ..Default::default()
+            ..Metadata::default()
         };
         let payload = vec![0xABu8; 2 * 1024 * 1024]; // 2 MiB
 
@@ -1680,7 +1680,7 @@ mod tests {
         let id = make_id("multipart");
 
         let upload_id = storage
-            .initiate_multipart(&id, &Default::default())
+            .initiate_multipart(&id, &Metadata::default())
             .await
             .unwrap();
 
@@ -1761,7 +1761,7 @@ mod tests {
         let id = make_id("mp-abort");
 
         let upload_id = storage
-            .initiate_multipart(&id, &Default::default())
+            .initiate_multipart(&id, &Metadata::default())
             .await
             .unwrap();
 
@@ -1794,7 +1794,7 @@ mod tests {
         let id = make_id("mp-list");
 
         let upload_id = storage
-            .initiate_multipart(&id, &Default::default())
+            .initiate_multipart(&id, &Metadata::default())
             .await
             .unwrap();
 
@@ -1842,14 +1842,14 @@ mod tests {
         // Put a large object via the normal path.
         let payload1 = vec![0xAAu8; 2 * 1024 * 1024];
         storage
-            .put_object(&id, &Default::default(), stream::single(payload1))
+            .put_object(&id, &Metadata::default(), stream::single(payload1))
             .await
             .unwrap();
         let old_lt_id = hv.get(&id).expect_tombstone().target;
 
         // Overwrite via multipart.
         let upload_id = storage
-            .initiate_multipart(&id, &Default::default())
+            .initiate_multipart(&id, &Metadata::default())
             .await
             .unwrap();
 
@@ -1959,7 +1959,7 @@ mod tests {
 
         let id = make_id("mp-orphan");
         let upload_id = storage
-            .initiate_multipart(&id, &Default::default())
+            .initiate_multipart(&id, &Metadata::default())
             .await
             .unwrap();
 
@@ -2074,7 +2074,7 @@ mod tests {
 
         let id = make_id("mp-retry");
         let upload_id = storage
-            .initiate_multipart(&id, &Default::default())
+            .initiate_multipart(&id, &Metadata::default())
             .await
             .unwrap();
 
@@ -2210,7 +2210,7 @@ mod tests {
 
         let id = make_id("mp-retry-meta");
         let upload_id = storage
-            .initiate_multipart(&id, &Default::default())
+            .initiate_multipart(&id, &Metadata::default())
             .await
             .unwrap();
 

--- a/objectstore-service/src/gcp_auth.rs
+++ b/objectstore-service/src/gcp_auth.rs
@@ -238,7 +238,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl gcp_auth::TokenProvider for MockTokenProvider {
+    impl TokenProvider for MockTokenProvider {
         async fn token(&self, _scopes: &[&str]) -> Result<Arc<gcp_auth::Token>, gcp_auth::Error> {
             let mut responses = self.responses.lock().expect("lock poisoned");
             responses

--- a/objectstore-service/src/service.rs
+++ b/objectstore-service/src/service.rs
@@ -395,7 +395,7 @@ mod tests {
             .insert_object(
                 make_context(),
                 None,
-                Default::default(),
+                Metadata::default(),
                 stream::single("auto-keyed"),
             )
             .await
@@ -412,7 +412,7 @@ mod tests {
             .insert_object(
                 make_context(),
                 Some("testing".into()),
-                Default::default(),
+                Metadata::default(),
                 stream::single("oh hai!"),
             )
             .await
@@ -438,7 +438,7 @@ mod tests {
             .insert_object(
                 make_context(),
                 Some("testing".into()),
-                Default::default(),
+                Metadata::default(),
                 stream::single("oh hai!"),
             )
             .await
@@ -480,7 +480,7 @@ mod tests {
             .insert_object(
                 make_context(),
                 Some("delete-cleanup-test".into()),
-                Default::default(),
+                Metadata::default(),
                 stream::single(payload),
             )
             .await

--- a/objectstore-service/src/streaming.rs
+++ b/objectstore-service/src/streaming.rs
@@ -352,9 +352,7 @@ mod tests {
     }
 
     // Wraps a plain `Vec<Operation>` as an indexed `Ok`-stream for `execute`.
-    fn indexed_ok(
-        ops: Vec<Operation>,
-    ) -> impl futures_util::Stream<Item = (usize, Result<Operation, Error>)> {
+    fn indexed_ok(ops: Vec<Operation>) -> impl Stream<Item = (usize, Result<Operation, Error>)> {
         futures_util::stream::iter(ops.into_iter().enumerate().map(|(i, op)| (i, Ok(op))))
     }
 
@@ -578,8 +576,7 @@ mod tests {
         for (_, result) in &outcomes {
             assert!(
                 matches!(result, Ok(OpResponse::Inserted { .. })),
-                "unexpected result: {:?}",
-                result
+                "unexpected result: {result:?}",
             );
         }
     }

--- a/objectstore-types/src/metadata.rs
+++ b/objectstore-types/src/metadata.rs
@@ -70,18 +70,18 @@ pub enum Error {
     #[error("invalid creation time")]
     CreationTime(#[from] humantime::TimestampError),
 }
-impl From<http::header::InvalidHeaderValue> for Error {
-    fn from(err: http::header::InvalidHeaderValue) -> Self {
+impl From<header::InvalidHeaderValue> for Error {
+    fn from(err: header::InvalidHeaderValue) -> Self {
         Self::Header(Some(err.into()))
     }
 }
-impl From<http::header::InvalidHeaderName> for Error {
-    fn from(err: http::header::InvalidHeaderName) -> Self {
+impl From<header::InvalidHeaderName> for Error {
+    fn from(err: header::InvalidHeaderName) -> Self {
         Self::Header(Some(err.into()))
     }
 }
-impl From<http::header::ToStrError> for Error {
-    fn from(_err: http::header::ToStrError) -> Self {
+impl From<header::ToStrError> for Error {
+    fn from(_err: header::ToStrError) -> Self {
         // the error happens when converting a header value back to a `str`
         Self::Header(None)
     }

--- a/objectstore-types/src/multipart.rs
+++ b/objectstore-types/src/multipart.rs
@@ -72,7 +72,7 @@ impl fmt::Display for UploadId {
 }
 
 impl<'de> Deserialize<'de> for UploadId {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {

--- a/objectstore-types/src/scope.rs
+++ b/objectstore-types/src/scope.rs
@@ -163,7 +163,7 @@ impl Scopes {
 
     /// Returns the value of the scope with the given key, if it exists.
     pub fn get_value(&self, key: &str) -> Option<&str> {
-        self.get(key).map(|s| s.value())
+        self.get(key).map(Scope::value)
     }
 
     /// Returns an iterator over all scopes.

--- a/stresstest/src/workload.rs
+++ b/stresstest/src/workload.rs
@@ -139,7 +139,7 @@ impl WorkloadBuilder {
             start_time: None,
             totals: Totals::default(),
 
-            existing_files: Default::default(),
+            existing_files: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
Applies a batch of pedantic Clippy lints across the workspace. Some occurrences were intentionally skipped where the suggested change would reduce readability or break forward compatibility (e.g. deriving `Eq` on types that may gain non-`Eq` fields).

Lints addressed:

- `uninlined_format_args` — inline format arguments
- `cloned_instead_of_copied` — use `.copied()` for `Copy` types
- `default_trait_access` — use `Type::default()` instead of `Default::default()`
- `single_char_pattern` — char literals instead of single-char string slices
- `explicit_into_iter_loop` — drop redundant `.into_iter()` in for loops
- `derive_partial_eq_without_eq` — add `Eq` when `PartialEq` is derived and all fields support it
- `redundant_closure_for_method_calls` — method references instead of closures
- `needless_qualified_path` — use already-imported names without full path prefix