### PR TITLE
fix: Use jemalloc only on linux

### DIFF
--- a/bigtable-bench/Cargo.toml
+++ b/bigtable-bench/Cargo.toml
@@ -20,7 +20,9 @@ rand = { workspace = true }
 rand_distr = { workspace = true }
 rustls = { workspace = true }
 sketches-ddsketch = { workspace = true }
-tikv-jemallocator = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync", "macros", "signal"] }
 tokio-util = { workspace = true }
 yansi = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tikv-jemallocator = { workspace = true }

--- a/bigtable-bench/src/main.rs
+++ b/bigtable-bench/src/main.rs
@@ -62,6 +62,7 @@ struct Args {
     table: String,
 }
 
+#[cfg(target_os = "linux")]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 

--- a/objectstore-server/Cargo.toml
+++ b/objectstore-server/Cargo.toml
@@ -40,11 +40,13 @@ sentry = { workspace = true, features = ["tower-axum-matched-path", "tracing", "
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tikv-jemallocator = { workspace = true }
-tikv-jemalloc-ctl = { workspace = true }
 tokio = { workspace = true, features = ["fs", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tower = { workspace = true }
 tower-http = { workspace = true, features = ["catch-panic", "metrics", "set-header", "trace"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tikv-jemallocator = { workspace = true }
+tikv-jemalloc-ctl = { workspace = true }
 
 [dev-dependencies]
 nix = { workspace = true, features = ["signal"] }

--- a/objectstore-server/src/main.rs
+++ b/objectstore-server/src/main.rs
@@ -8,6 +8,7 @@
 
 use objectstore_server::cli;
 
+#[cfg(target_os = "linux")]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 

--- a/objectstore-server/src/state.rs
+++ b/objectstore-server/src/state.rs
@@ -57,6 +57,7 @@ impl Services {
     /// use in the web server.
     pub async fn spawn(config: Config) -> Result<ServiceState> {
         tokio::spawn(track_runtime_metrics(config.runtime.metrics_interval));
+        #[cfg(target_os = "linux")]
         tokio::spawn(track_allocator_metrics(config.runtime.metrics_interval));
 
         let backend = backend::from_config(config.storage.clone()).await?;
@@ -110,6 +111,7 @@ impl Services {
 }
 
 /// Periodically captures and reports jemalloc stats.
+#[cfg(target_os = "linux")]
 async fn track_allocator_metrics(interval: Duration) {
     // INVARIANT: MIB resolution only fails if jemalloc is not the active allocator,
     // which would be a misconfigured build. Panic early to surface the problem.

--- a/stresstest/Cargo.toml
+++ b/stresstest/Cargo.toml
@@ -23,7 +23,9 @@ rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }
 sketches-ddsketch = { workspace = true }
-tikv-jemallocator = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync", "macros"] }
 tokio-util = { workspace = true, features = ["io"] }
 yansi = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tikv-jemallocator = { workspace = true }

--- a/stresstest/src/main.rs
+++ b/stresstest/src/main.rs
@@ -36,6 +36,7 @@ pub struct Args {
     pub config: PathBuf,
 }
 
+#[cfg(target_os = "linux")]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 


### PR DESCRIPTION
`tikv-jemallocator` was pulled in unconditionally on all platforms. On macOS, every startup printed:

```
<jemalloc>: option background_thread currently supports pthread only
```

jemalloc's background-thread purging requires pthread (Linux only); on macOS the option is silently ignored but the warning still fires. On Windows (MSVC), `jemalloc-sys` has no support at all and the build fails.

objectstore runs as a Linux service in production, so the fix is to gate both the Cargo dependencies and all code references behind `cfg(target_os = "linux")`, falling back to the system allocator on other platforms.