### PR TITLE
fix: Replace lossy casts with safer integer idioms

### DIFF
--- a/objectstore-server/src/config.rs
+++ b/objectstore-server/src/config.rs
@@ -508,7 +508,7 @@ pub struct Service {
     /// # Default
     ///
     /// [`DEFAULT_CONCURRENCY_LIMIT`](objectstore_service::service::DEFAULT_CONCURRENCY_LIMIT)
-    pub max_concurrency: usize,
+    pub max_concurrency: u32,
 }
 
 impl Default for Service {

--- a/objectstore-server/src/rate_limits.rs
+++ b/objectstore-server/src/rate_limits.rs
@@ -338,6 +338,18 @@ impl EwmaEstimator {
     }
 }
 
+/// Returns `value * pct / 100`, saturating at `u32::MAX`.
+fn pct_of_u32(value: u32, pct: u8) -> u32 {
+    let scaled = u64::from(value) * u64::from(pct) / 100;
+    u32::try_from(scaled).unwrap_or(u32::MAX)
+}
+
+/// Returns `value * pct / 100`, saturating at `u64::MAX`.
+fn pct_of_u64(value: u64, pct: u8) -> u64 {
+    let scaled = u128::from(value) * u128::from(pct) / 100;
+    u64::try_from(scaled).unwrap_or(u64::MAX)
+}
+
 #[derive(Debug)]
 struct BandwidthRateLimiter {
     config: BandwidthLimits,
@@ -513,14 +525,14 @@ impl BandwidthRateLimiter {
     fn usecase_bps(&self) -> Option<u64> {
         let global_bps = self.config.global_bps?;
         let pct = self.config.usecase_pct?;
-        Some(((global_bps as f64) * (pct as f64 / 100.0)) as u64)
+        Some(pct_of_u64(global_bps, pct))
     }
 
     /// Returns the effective BPS for per-scope limiting, if configured.
     fn scope_bps(&self) -> Option<u64> {
         let global_bps = self.config.global_bps?;
         let pct = self.config.scope_pct?;
-        Some(((global_bps as f64) * (pct as f64 / 100.0)) as u64)
+        Some(pct_of_u64(global_bps, pct))
     }
 }
 
@@ -658,23 +670,21 @@ impl ThroughputRateLimiter {
     fn usecase_rps(&self) -> Option<u32> {
         let global_rps = self.config.global_rps?;
         let pct = self.config.usecase_pct?;
-        Some(((global_rps as f64) * (pct as f64 / 100.0)) as u32)
+        Some(pct_of_u32(global_rps, pct))
     }
 
     /// Returns the effective RPS for per-scope limiting, if configured.
     fn scope_rps(&self) -> Option<u32> {
         let global_rps = self.config.global_rps?;
         let pct = self.config.scope_pct?;
-        Some(((global_rps as f64) * (pct as f64 / 100.0)) as u32)
+        Some(pct_of_u32(global_rps, pct))
     }
 
     /// Returns the effective RPS for a rule, if it has a valid limit.
     fn rule_rps(&self, rule: &ThroughputRule) -> Option<u32> {
-        let pct_limit = rule.pct.and_then(|p| {
-            self.config
-                .global_rps
-                .map(|g| ((g as f64) * (p as f64 / 100.0)) as u32)
-        });
+        let pct_limit = rule
+            .pct
+            .and_then(|p| self.config.global_rps.map(|g| pct_of_u32(g, p)));
 
         match (rule.rps, pct_limit) {
             (Some(r), Some(p)) => Some(r.min(p)),

--- a/objectstore-service/src/backend/bigtable.rs
+++ b/objectstore-service/src/backend/bigtable.rs
@@ -213,11 +213,7 @@ fn legacy_tombstone_filter() -> v2::RowFilter {
 
 /// Wraps `inner` so that it only matches live (non-expired) cells.
 fn live_row_filter(inner: v2::RowFilter) -> v2::RowFilter {
-    let now_micros = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as i64
-        * 1000;
+    let now_micros = time_to_micros_saturating(SystemTime::now());
 
     v2::RowFilter {
         filter: Some(v2::row_filter::Filter::Interleave(
@@ -1161,6 +1157,16 @@ fn ttl_to_micros(ttl: Duration, from: SystemTime) -> Result<i64> {
     })
 }
 
+/// Converts a wall-clock time to Bigtable's microsecond timestamp, saturating at `i64::MAX`
+/// (unreachable until approximately year 294,247).
+fn time_to_micros_saturating(t: SystemTime) -> i64 {
+    let millis = t
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    i64::try_from(millis * 1000).unwrap_or(i64::MAX)
+}
+
 /// Converts a microsecond-precision unix timestamp to a `SystemTime`.
 fn micros_to_time(micros: i64) -> Option<SystemTime> {
     let micros = u64::try_from(micros).ok()?;
@@ -1321,11 +1327,7 @@ mod tests {
         } else {
             let t =
                 time_expires.unwrap_or(SystemTime::now() + expiration_policy.expires_in().unwrap());
-            let timestamp = t
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap()
-                .as_millis();
-            (FAMILY_GC, timestamp as i64 * 1000)
+            (FAMILY_GC, time_to_micros_saturating(t))
         };
 
         let path = id.as_storage_path().to_string().into_bytes();

--- a/objectstore-service/src/backend/local_fs.rs
+++ b/objectstore-service/src/backend/local_fs.rs
@@ -154,9 +154,8 @@ impl Backend for LocalFsBackend {
                         .ok_or(Error::RangeNotSatisfiable {
                             total: payload_size,
                         })?;
-                reader
-                    .seek(std::io::SeekFrom::Current(content_range.start as i64))
-                    .await?;
+                let payload_start = metadata_line.len() as u64 + content_range.start;
+                reader.seek(std::io::SeekFrom::Start(payload_start)).await?;
                 let limited = reader.take(content_range.len());
                 (Some(content_range), ReaderStream::new(limited).boxed())
             }

--- a/objectstore-service/src/concurrency.rs
+++ b/objectstore-service/src/concurrency.rs
@@ -28,15 +28,15 @@ const EMITTER_INTERVAL: Duration = Duration::from_secs(1);
 #[derive(Clone, Debug)]
 pub struct ConcurrencyLimiter {
     semaphore: Arc<Semaphore>,
-    max: usize,
+    max: u32,
     released: Arc<Notify>,
 }
 
 impl ConcurrencyLimiter {
     /// Creates a new limiter with the given maximum number of permits.
-    pub fn new(max: usize) -> Self {
+    pub fn new(max: u32) -> Self {
         Self {
-            semaphore: Arc::new(Semaphore::new(max)),
+            semaphore: Arc::new(Semaphore::new(max as usize)),
             max,
             released: Arc::new(Notify::new()),
         }
@@ -48,11 +48,11 @@ impl ConcurrencyLimiter {
     /// notifies waiters on drop, just like single-permit acquisition.
     ///
     /// Returns [`Error::AtCapacity`] when fewer than `count` permits are available.
-    pub fn try_acquire_many(&self, count: usize) -> Result<ConcurrencyPermit> {
+    pub fn try_acquire_many(&self, count: u32) -> Result<ConcurrencyPermit> {
         let permit = self
             .semaphore
             .clone()
-            .try_acquire_many_owned(count as u32)
+            .try_acquire_many_owned(count)
             .map_err(|_| Error::AtCapacity)?;
         Ok(ConcurrencyPermit {
             permit: Some(permit),
@@ -70,17 +70,17 @@ impl ConcurrencyLimiter {
     }
 
     /// Returns the number of permits currently available.
-    pub fn available_permits(&self) -> usize {
-        self.semaphore.available_permits()
+    pub fn available_permits(&self) -> u32 {
+        u32::try_from(self.semaphore.available_permits()).unwrap_or(self.max)
     }
 
     /// Returns the number of permits currently held.
-    pub fn used_permits(&self) -> usize {
-        self.max - self.semaphore.available_permits()
+    pub fn used_permits(&self) -> u32 {
+        self.max - self.available_permits()
     }
 
     /// Returns the total number of permits.
-    pub fn total_permits(&self) -> usize {
+    pub fn total_permits(&self) -> u32 {
         self.max
     }
 
@@ -102,7 +102,7 @@ impl ConcurrencyLimiter {
     /// task alongside the service.
     pub async fn run_emitter<F, Fut>(&self, mut emit: F)
     where
-        F: FnMut(usize) -> Fut,
+        F: FnMut(u32) -> Fut,
         Fut: Future<Output = ()>,
     {
         let mut ticker = tokio::time::interval(EMITTER_INTERVAL);
@@ -198,7 +198,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicU32, Ordering};
 
     use super::*;
     use crate::error::Error;
@@ -270,7 +270,7 @@ mod tests {
         let limiter = ConcurrencyLimiter::new(5);
         let _permit = limiter.try_acquire().unwrap();
 
-        let emitted = Arc::new(AtomicUsize::new(0));
+        let emitted = Arc::new(AtomicU32::new(0));
         let emitted_clone = Arc::clone(&emitted);
 
         let emitter = limiter.run_emitter(move |count| {

--- a/objectstore-service/src/service.rs
+++ b/objectstore-service/src/service.rs
@@ -36,7 +36,7 @@ pub type DeleteResponse = ();
 ///
 /// This value is used when no explicit limit is set via
 /// [`StorageService::with_concurrency_limit`].
-pub const DEFAULT_CONCURRENCY_LIMIT: usize = 500;
+pub const DEFAULT_CONCURRENCY_LIMIT: u32 = 500;
 
 /// Asynchronous storage service wrapping a single [`Backend`].
 ///
@@ -95,23 +95,23 @@ impl StorageService {
     ///
     /// Must be called before [`start`](Self::start). Operations beyond this
     /// limit are rejected with [`Error::AtCapacity`].
-    pub fn with_concurrency_limit(mut self, max: usize) -> Self {
+    pub fn with_concurrency_limit(mut self, max: u32) -> Self {
         self.concurrency = ConcurrencyLimiter::new(max);
         self
     }
 
     /// Returns the number of backend task slots currently available.
-    pub fn tasks_available(&self) -> usize {
+    pub fn tasks_available(&self) -> u32 {
         self.concurrency.available_permits()
     }
 
     /// Returns the number of backend tasks currently running.
-    pub fn tasks_running(&self) -> usize {
+    pub fn tasks_running(&self) -> u32 {
         self.concurrency.used_permits()
     }
 
     /// Returns the configured limit for concurrent backend tasks.
-    pub fn tasks_limit(&self) -> usize {
+    pub fn tasks_limit(&self) -> u32 {
         self.concurrency.total_permits()
     }
 
@@ -123,7 +123,7 @@ impl StorageService {
     /// [`Error::AtCapacity`] immediately before any operations are read.
     pub fn stream(&self) -> Result<StreamExecutor> {
         let available = self.tasks_available();
-        let window = (available as f64 * 0.10).ceil() as usize;
+        let window = available.div_ceil(10);
 
         let acquire_result = match window {
             0 => Err(Error::AtCapacity),
@@ -674,7 +674,7 @@ mod tests {
 
     // --- Concurrency limit tests ---
 
-    fn make_limited_service(limit: usize) -> (StorageService, TestBackend<GateOnPut>) {
+    fn make_limited_service(limit: u32) -> (StorageService, TestBackend<GateOnPut>) {
         let backend = TestBackend::new(GateOnPut::with_pause());
         let service = StorageService::new(Box::new(backend.clone())).with_concurrency_limit(limit);
         (service, backend)

--- a/objectstore-service/src/streaming.rs
+++ b/objectstore-service/src/streaming.rs
@@ -219,13 +219,13 @@ impl std::fmt::Debug for OpResponse {
 #[derive(Debug)]
 pub struct StreamExecutor {
     pub(crate) backend: Arc<dyn Backend>,
-    pub(crate) window: usize,
+    pub(crate) window: u32,
     pub(crate) reservation: ConcurrencyPermit,
 }
 
 impl StreamExecutor {
     /// Returns the concurrency window computed at construction.
-    pub fn window(&self) -> usize {
+    pub fn window(&self) -> u32 {
         self.window
     }
 
@@ -277,7 +277,7 @@ impl StreamExecutor {
                     (idx, spawn.await.map_err(E::from))
                 }
             })
-            .buffer_unordered(window)
+            .buffer_unordered(window as usize)
     }
 }
 
@@ -342,7 +342,7 @@ mod tests {
         }
     }
 
-    fn make_service_with_limit(limit: usize) -> StorageService {
+    fn make_service_with_limit(limit: u32) -> StorageService {
         StorageService::new(Box::new(InMemoryBackend::new("in-memory")))
             .with_concurrency_limit(limit)
     }


### PR DESCRIPTION
Replaces unchecked `as` casts and float round-trips with precise integer arithmetic and saturating conversions in four independent spots across the service and server crates.