### PR TITLE
ref(server): Skip auth checks when not configured

### DIFF
--- a/objectstore-server/src/auth/error.rs
+++ b/objectstore-server/src/auth/error.rs
@@ -1,4 +1,3 @@
-use objectstore_types::auth::Permission;
 use thiserror::Error;
 
 /// Error type for different authorization failure scenarios.
@@ -39,18 +38,17 @@ impl AuthError {
         }
     }
 
-    /// Increment a counter and emit a debug log for this auth failure.
+    /// Increment a counter and emit a log for this auth failure.
     ///
-    /// If `enforce` is false, authentication failures will be logged as warnings to ensure they
-    /// are found and fixed to unblock enabling enforcement.
-    pub fn log(&self, permission: Option<Permission>, usecase: Option<&str>, enforce: bool) {
+    /// If `warn` is true, the log will be at WARN level; otherwise it will be at DEBUG level.`
+    pub fn log(&self, warn: bool) {
         let code = self.code();
         objectstore_metrics::count!("server.auth.failure", code = code);
-        let msg = self.to_string();
-        if !enforce {
-            objectstore_log::warn!(?permission, ?usecase, ?code, ?msg, "Auth failure");
+
+        if warn {
+            objectstore_log::warn!(code, reason=%self, "Auth failure");
         } else {
-            objectstore_log::debug!(?permission, ?usecase, ?code, ?msg, "Auth failure");
+            objectstore_log::debug!(code, reason=%self, "Auth failure");
         }
     }
 }

--- a/objectstore-server/src/auth/error.rs
+++ b/objectstore-server/src/auth/error.rs
@@ -21,7 +21,7 @@ pub enum AuthError {
     #[error("failed to verify token")]
     VerificationFailure,
 
-    /// Indicates that the requested operation is not authorized and auth enforcement is enabled.
+    /// Indicates that the requested operation is not permitted on the resource.
     #[error("operation not allowed")]
     NotPermitted,
 }
@@ -40,7 +40,7 @@ impl AuthError {
 
     /// Increment a counter and emit a log for this auth failure.
     ///
-    /// If `warn` is true, the log will be at WARN level; otherwise it will be at DEBUG level.`
+    /// If `warn` is true, the log will be at WARN level; otherwise it will be at DEBUG level.
     pub fn log(&self, warn: bool) {
         let code = self.code();
         objectstore_metrics::count!("server.auth.failure", code = code);

--- a/objectstore-server/src/auth/service.rs
+++ b/objectstore-server/src/auth/service.rs
@@ -9,7 +9,7 @@ use objectstore_types::auth::Permission;
 use objectstore_types::metadata::Metadata;
 use objectstore_types::range::ByteRange;
 
-use crate::auth::{AuthContext, AuthError};
+use crate::auth::AuthContext;
 use crate::endpoints::common::ApiResult;
 
 /// Wrapper around [`StorageService`] that ensures each operation is authorized.
@@ -49,44 +49,32 @@ impl AuthAwareService {
     ///
     /// If enforcement is disabled, an `AuthContext` is not required. If one is provided, its
     /// checks will be run but their results ignored. All operations will be permitted.
-    pub fn new(
-        service: StorageService,
-        context: Option<AuthContext>,
-        enforce: bool,
-    ) -> ApiResult<Self> {
-        if enforce && context.is_none() {
-            let err = AuthError::InternalError("Missing auth context".into());
-            err.log(None, None, enforce);
-            Err(err.into())
-        } else {
-            Ok(Self {
-                service,
-                context,
-                enforce,
-            })
-        }
-    }
-
-    fn assert_authorized(&self, perm: Permission, context: &ObjectContext) -> ApiResult<()> {
-        let auth_result = match &self.context {
-            Some(auth) => auth.assert_authorized(perm, context),
-            None => Ok(()),
-        }
-        .inspect_err(|err| err.log(Some(perm), Some(context.usecase.as_str()), self.enforce));
-
-        match self.enforce {
-            true => Ok(auth_result?),
-            false => Ok(()),
+    pub fn new(service: StorageService, context: Option<AuthContext>, enforce: bool) -> Self {
+        Self {
+            service,
+            context,
+            enforce,
         }
     }
 
     /// Checks whether the request is authorized for the given permission on the given context.
     ///
-    /// Returns `Ok(())` if authorized, or otherwise an error indicating the reason.
-    /// Equivalent to the internal `assert_authorized` check but exposed for callers
-    /// that validate operations individually before delegating to a lower-level service.
+    /// Returns `Ok(())` if authorized, or an error indicating the reason.
     pub fn check_permission(&self, perm: Permission, context: &ObjectContext) -> ApiResult<()> {
-        self.assert_authorized(perm, context)
+        if let Some(auth) = &self.context
+            && let Err(error) = auth.assert_authorized(perm, context)
+        {
+            sentry::with_scope(
+                |s| s.set_tag("perm", perm.to_string()),
+                || error.log(!self.enforce),
+            );
+
+            if self.enforce {
+                return Err(error.into());
+            }
+        }
+
+        Ok(())
     }
 
     /// Auth-aware wrapper around [`StorageService::insert_object`].
@@ -97,7 +85,7 @@ impl AuthAwareService {
         metadata: Metadata,
         stream: ClientStream,
     ) -> ApiResult<InsertResponse> {
-        self.assert_authorized(Permission::ObjectWrite, &context)?;
+        self.check_permission(Permission::ObjectWrite, &context)?;
         Ok(self
             .service
             .insert_object(context, key, metadata, stream)
@@ -106,7 +94,7 @@ impl AuthAwareService {
 
     /// Auth-aware wrapper around [`StorageService::get_metadata`].
     pub async fn get_metadata(&self, id: ObjectId) -> ApiResult<MetadataResponse> {
-        self.assert_authorized(Permission::ObjectRead, id.context())?;
+        self.check_permission(Permission::ObjectRead, id.context())?;
         Ok(self.service.get_metadata(id).await?)
     }
 
@@ -116,13 +104,13 @@ impl AuthAwareService {
         id: ObjectId,
         range: Option<ByteRange>,
     ) -> ApiResult<GetResponse> {
-        self.assert_authorized(Permission::ObjectRead, id.context())?;
+        self.check_permission(Permission::ObjectRead, id.context())?;
         Ok(self.service.get_object(id, range).await?)
     }
 
     /// Auth-aware wrapper around [`StorageService::delete_object`].
     pub async fn delete_object(&self, id: ObjectId) -> ApiResult<DeleteResponse> {
-        self.assert_authorized(Permission::ObjectDelete, id.context())?;
+        self.check_permission(Permission::ObjectDelete, id.context())?;
         Ok(self.service.delete_object(id).await?)
     }
 
@@ -134,7 +122,7 @@ impl AuthAwareService {
         id: ObjectId,
         metadata: Metadata,
     ) -> ApiResult<InitiateMultipartResponse> {
-        self.assert_authorized(Permission::ObjectWrite, id.context())?;
+        self.check_permission(Permission::ObjectWrite, id.context())?;
         Ok(self.service.initiate_multipart(id, metadata).await?)
     }
 
@@ -148,7 +136,7 @@ impl AuthAwareService {
         content_md5: Option<String>,
         body: ClientStream,
     ) -> ApiResult<UploadPartResponse> {
-        self.assert_authorized(Permission::ObjectWrite, id.context())?;
+        self.check_permission(Permission::ObjectWrite, id.context())?;
         Ok(self
             .service
             .upload_part(
@@ -170,7 +158,7 @@ impl AuthAwareService {
         max_parts: Option<u32>,
         part_number_marker: Option<PartNumber>,
     ) -> ApiResult<ListPartsResponse> {
-        self.assert_authorized(Permission::ObjectWrite, id.context())?;
+        self.check_permission(Permission::ObjectWrite, id.context())?;
         Ok(self
             .service
             .list_parts(id, upload_id, max_parts, part_number_marker)
@@ -183,7 +171,7 @@ impl AuthAwareService {
         id: ObjectId,
         upload_id: UploadId,
     ) -> ApiResult<AbortMultipartResponse> {
-        self.assert_authorized(Permission::ObjectWrite, id.context())?;
+        self.check_permission(Permission::ObjectWrite, id.context())?;
         Ok(self.service.abort_multipart(id, upload_id).await?)
     }
 
@@ -194,7 +182,7 @@ impl AuthAwareService {
         upload_id: UploadId,
         parts: Vec<CompletedPart>,
     ) -> ApiResult<CompleteMultipartResponse> {
-        self.assert_authorized(Permission::ObjectWrite, id.context())?;
+        self.check_permission(Permission::ObjectWrite, id.context())?;
         Ok(self
             .service
             .complete_multipart(id, upload_id, parts)

--- a/objectstore-server/src/auth/service.rs
+++ b/objectstore-server/src/auth/service.rs
@@ -44,11 +44,11 @@ impl AuthAwareService {
     /// Creates a new `AuthAwareService` using the given [`StorageService`], [`AuthContext`], and
     /// enforcement setting.
     ///
-    /// If enforcement is enabled, an `AuthContext` must be provided and its checks must succeed
-    /// for an operation to be permitted.
+    /// If a `context` is provided, it will be used to check whether each operation is authorized.
+    /// `enforce` controls whether authorization failures will result in an error response or be
+    /// ignored.
     ///
-    /// If enforcement is disabled, an `AuthContext` is not required. If one is provided, its
-    /// checks will be run but their results ignored. All operations will be permitted.
+    /// Without a `context`, all operations are permitted.
     pub fn new(service: StorageService, context: Option<AuthContext>, enforce: bool) -> Self {
         Self {
             service,

--- a/objectstore-server/src/config.rs
+++ b/objectstore-server/src/config.rs
@@ -337,8 +337,9 @@ pub struct AuthZVerificationKey {
 pub struct AuthZ {
     /// Whether to enforce content-based authorization or not.
     ///
-    /// Defaults to `true`. If this is set to `false`, checks are still performed but failures
-    /// will not result in `403 Unauthorized` responses.
+    /// Defaults to `true`, resulting in `403 Unauthorized` responses for unauthorized requests. Set
+    /// to `false` to permit unauthorized requests. Authorization checks are still performed if
+    /// keys are configured, but only result in warnings.
     #[serde(default = "default_enforce")]
     pub enforce: bool,
 

--- a/objectstore-server/src/config.rs
+++ b/objectstore-server/src/config.rs
@@ -357,6 +357,17 @@ fn default_enforce() -> bool {
     true
 }
 
+impl AuthZ {
+    /// Returns whether content-based authorization is active.
+    ///
+    /// Authorization is considered active if enforcement is enabled or at least one key is
+    /// configured. Without enforcement, authorization checks are still performed and reported but
+    /// failures will not result in `403 Unauthorized`
+    pub fn is_active(&self) -> bool {
+        self.enforce || !self.keys.is_empty()
+    }
+}
+
 impl Default for AuthZ {
     fn default() -> Self {
         Self {

--- a/objectstore-server/src/extractors/service.rs
+++ b/objectstore-server/src/extractors/service.rs
@@ -20,31 +20,30 @@ impl FromRequestParts<ServiceState> for AuthAwareService {
         parts: &mut Parts,
         state: &ServiceState,
     ) -> Result<Self, Self::Rejection> {
-        let encoded_token = parts
+        let enforce = state.config.auth.enforce;
+        if !state.config.auth.is_active() {
+            return Ok(AuthAwareService::new(state.service.clone(), None, enforce));
+        }
+
+        let token = parts
             .headers
             .get(OBJECTSTORE_AUTH_HEADER)
             .or_else(|| parts.headers.get(header::AUTHORIZATION))
             .and_then(|v| v.to_str().ok())
             .and_then(strip_bearer);
 
-        let enforce = state.config.auth.enforce;
         // Attempt to decode / verify the JWT, logging failure
-        let auth_result = AuthContext::from_encoded_jwt(encoded_token, &state.key_directory)
-            .inspect_err(|err| err.log(None, None, enforce));
+        let auth_result = AuthContext::from_encoded_jwt(token, &state.key_directory)
+            .inspect_err(|e| e.log(!enforce));
 
-        // If auth enforcement is enabled, `from_encoded_jwt()` must have succeeded.
-        // If auth enforcement is disabled, we'll pass the context along if it succeeded but will
-        // still proceed with `None` if it failed.
-        let auth_context = match enforce {
-            true => Some(auth_result?),
-            false => auth_result.ok(),
+        // If enforcement is disabled, proceed without an auth context even on failure
+        let auth = match auth_result {
+            Ok(auth) => Some(auth),
+            Err(error) if enforce => return Err(ApiError::Auth(error)),
+            Err(_) => None,
         };
 
-        AuthAwareService::new(
-            state.service.clone(),
-            auth_context,
-            state.config.auth.enforce,
-        )
+        Ok(AuthAwareService::new(state.service.clone(), auth, enforce))
     }
 }
 


### PR DESCRIPTION
Auth checks previously ran on every request regardless of server-side configuration, producing noisy warnings in environments without auth (e.g. local development). Auth is now skipped entirely when it is not configured — meaning no keys are present and enforcement is off (`AuthZ::is_active()`).

When auth is active, `enforce` controls whether failures reject the request (debug log) or just warn. `AuthAwareService::new` is now infallible since the "enforcement enabled but no context" error state is no longer reachable.

Ref FS-344
Ref FS-313