### PR TITLE
docs: Fix and expand documentation across the workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ The platform is split into the following core components:
   including metadata, scopes, expiration, and permissions.
 - `objectstore-metrics`: Metrics macros and DogStatsD initialization shared
   across service components.
+- `objectstore-log`: Logging macros and subscriber initialization shared across
+  service components.
+- `objectstore-test`: Test utilities shared across the workspace.
 - `clients`: The Rust and Python client library SDKs, which expose
   high-performance blob storage access.
 

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -32,7 +32,7 @@ Within a Usecase, Scopes provide further isolation — typically keyed by organi
 and project IDs. A Session ties a Client to a specific Usecase + Scope for operations.
 
 Scope components form a hierarchical path, so their order matters:
-`org=42/project=1337` and `project=1337/org=42` are different scopes. We recommend
+`org=42;project=1337` and `project=1337;org=42` are different scopes. We recommend
 using `org` and `project` as the first two components.
 
 ```python

--- a/clients/rust/README.md
+++ b/clients/rust/README.md
@@ -273,7 +273,7 @@ session
     .await
     .error_for_failures()
     .await
-    .map_err(|errors| { /* errors: Vec<Error> */ })?;
+    .map_err(|errors| { /* Iterator<Item = objectstore_client::Error> */ })?;
 ```
 
 ### Authentication

--- a/clients/rust/README.md
+++ b/clients/rust/README.md
@@ -38,7 +38,7 @@ Within a Usecase, [`Scope`]s provide further isolation — typically keyed by or
 and project IDs. A [`Session`] ties a Client to a specific Usecase + Scope for operations.
 
 Scope components form a hierarchical path, so their order matters:
-`org=42/project=1337` and `project=1337/org=42` are different scopes. The convenience
+`org=42;project=1337` and `project=1337;org=42` are different scopes. The convenience
 method [`Usecase::for_project`] pushes `org` then `project` in the recommended order.
 
 ```rust,ignore

--- a/objectstore-server/docs/architecture.md
+++ b/objectstore-server/docs/architecture.md
@@ -12,10 +12,10 @@ All object operations live under the `/v1/` prefix:
 | Method   | Path                                      | Description                  |
 |----------|-------------------------------------------|------------------------------|
 | `POST`   | `/v1/objects/{usecase}/{scopes}/`         | Insert with server-generated key |
-| `GET`    | `/v1/objects/{usecase}/{scopes}/{key}`    | Retrieve object              |
-| `HEAD`   | `/v1/objects/{usecase}/{scopes}/{key}`    | Retrieve metadata only       |
-| `PUT`    | `/v1/objects/{usecase}/{scopes}/{key}`    | Insert or overwrite with key |
-| `DELETE` | `/v1/objects/{usecase}/{scopes}/{key}`    | Delete object                |
+| `GET`    | `/v1/objects/{usecase}/{scopes}/{*key}`   | Retrieve object              |
+| `HEAD`   | `/v1/objects/{usecase}/{scopes}/{*key}`   | Retrieve metadata only       |
+| `PUT`    | `/v1/objects/{usecase}/{scopes}/{*key}`   | Insert or overwrite with key |
+| `DELETE` | `/v1/objects/{usecase}/{scopes}/{*key}`   | Delete object                |
 | `POST`   | `/v1/objects:batch/{usecase}/{scopes}/`   | Batch operations (multipart) |
 
 ### Multipart Upload Endpoints
@@ -24,10 +24,10 @@ All object operations live under the `/v1/` prefix:
 |-----------|--------------------------------------------------------------|--------------------------------------|
 | `POST`    | `/v1/objects:multipart/{usecase}/{scopes}/`                  | Initiate upload (server-generated key) |
 | `PUT`     | `/v1/objects:multipart/{usecase}/{scopes}/{*key}`            | Initiate upload (user-provided key)  |
-| `PUT`     | `/v1/objects:multipart:parts/{usecase}/{scopes}/{key}`       | Upload a part (`uploadId`, `partNumber` query params) |
-| `GET`     | `/v1/objects:multipart:parts/{usecase}/{scopes}/{key}`       | List uploaded parts (`uploadId` query param) |
-| `POST`    | `/v1/objects:multipart:complete/{usecase}/{scopes}/{key}`    | Complete upload (`uploadId` query param) |
-| `DELETE`  | `/v1/objects:multipart/{usecase}/{scopes}/{key}`             | Abort upload (`uploadId` query param) |
+| `PUT`     | `/v1/objects:multipart:parts/{usecase}/{scopes}/{*key}`      | Upload a part (`uploadId`, `partNumber` query params) |
+| `GET`     | `/v1/objects:multipart:parts/{usecase}/{scopes}/{*key}`      | List uploaded parts (`uploadId` query param) |
+| `POST`    | `/v1/objects:multipart:complete/{usecase}/{scopes}/{*key}`   | Complete upload (`uploadId` query param) |
+| `DELETE`  | `/v1/objects:multipart/{usecase}/{scopes}/{*key}`            | Abort upload (`uploadId` query param) |
 
 The initiate POST endpoint accepts both trailing-slash and non-trailing-slash forms.
 
@@ -89,8 +89,7 @@ unauthenticated development setups.
 
 Tokens must include:
 - **Header**: `kid` (key ID) and `alg: EdDSA`
-- **Claims**: `aud: "objectstore"`, `iss: "sentry"` or `"relay"`, `exp`
-  (expiration timestamp)
+- **Claims**: `exp` (expiration timestamp)
 - **Resource claims** (`res`): the usecase and scope values the token grants
   access to (e.g., `{"os:usecase": "attachments", "org": "123"}`)
 - **Permissions**: array of granted operations (`object.read`, `object.write`,

--- a/objectstore-types/src/lib.rs
+++ b/objectstore-types/src/lib.rs
@@ -1,38 +1,7 @@
 //! # Shared Types
 //!
 //! This crate defines the types shared between the objectstore server, service,
-//! and client libraries. It is the common vocabulary that ensures all components
-//! agree on how metadata is represented, how scopes work, what permissions exist,
-//! and how objects expire.
-//!
-//! ## Metadata
-//!
-//! The [`metadata`] module defines [`Metadata`](metadata::Metadata), the
-//! per-object metadata structure carried alongside every object. It travels
-//! through the entire system: clients set it via HTTP headers, the server parses
-//! and validates it, the service passes it to backends, and backends persist it.
-//! The module also defines [`ExpirationPolicy`](metadata::ExpirationPolicy) for
-//! automatic object cleanup and [`Compression`](metadata::Compression) for payload
-//! encoding.
-//!
-//! ## Scopes
-//!
-//! The [`scope`] module defines [`Scope`](scope::Scope) (a single key-value pair)
-//! and [`Scopes`](scope::Scopes) (an ordered collection). Scopes organize objects
-//! into hierarchical namespaces and double as the authorization boundary checked
-//! against JWT claims.
-//!
-//! ## Multipart
-//!
-//! The [`multipart`] module defines the request and response types for the
-//! multipart upload protocol, which splits large objects into independently
-//! uploaded parts that are assembled server-side on completion.
-//!
-//! ## Auth
-//!
-//! The [`auth`] module defines [`Permission`](auth::Permission), the set of
-//! operations that can be granted in a JWT token and checked by the server before
-//! each request.
+//! and client libraries. Refer to each module's documentation for details.
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
 

--- a/objectstore-types/src/metadata.rs
+++ b/objectstore-types/src/metadata.rs
@@ -1,8 +1,11 @@
 //! Per-object metadata types and HTTP header serialization.
 //!
 //! This module defines [`Metadata`], the per-object metadata structure that
-//! accompanies every stored object, along with [`ExpirationPolicy`] and
-//! [`Compression`].
+//! travels through the entire system: clients set it via HTTP headers, the
+//! server parses and validates it, the service passes it to backends, and
+//! backends persist it alongside the stored object.
+//!
+//! The module also defines further types used in metadata.
 //!
 //! # Serialization
 //!

--- a/objectstore-types/src/range.rs
+++ b/objectstore-types/src/range.rs
@@ -1,4 +1,16 @@
-//! Types for HTTP range requests.
+//! Types for HTTP byte-range requests and responses.
+//!
+//! HTTP range requests ([RFC 9110 §14.2](https://www.rfc-editor.org/rfc/rfc9110#section-14.2))
+//! allow a client to request a partial transfer of a resource instead of the full content.
+//! The client expresses the desired byte range in a `Range` request header; the server
+//! responds with the selected bytes and a `Content-Range` header that identifies which
+//! portion of the object is being returned along with its total size.
+//!
+//! This module provides two types that mirror that request/response split:
+//!
+//! - [`ByteRange`] — a range *request*: which bytes the client wants.
+//! - [`ContentRange`] — a range *response*: which bytes the server is returning, plus
+//!   the total object size.
 
 use std::fmt;
 use std::str::FromStr;
@@ -6,7 +18,12 @@ use std::str::FromStr;
 use http::header::HeaderValue;
 use thiserror::Error;
 
-/// Specifier for a single byte range.
+/// Byte range requested by the client via a `Range` header.
+///
+/// Parse from a `Range` header string via [`FromStr`] or construct a variant
+/// directly. Serialize back to a header with [`to_header_value`](Self::to_header_value).
+/// Once the total object size is known, call [`resolve`](Self::resolve) to
+/// validate the range and convert it into a [`ContentRange`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ByteRange {
     /// Bounded range with start and end, inclusive
@@ -110,7 +127,12 @@ impl FromStr for ByteRange {
     }
 }
 
-/// Describes which bytes of the full object are present in the response body.
+/// Byte range returned by the server in a `Content-Range` response header.
+///
+/// Describes which bytes of the full object are present in the response body
+/// ([`start`](Self::start)–[`end`](Self::end), inclusive) and the total object
+/// size ([`total`](Self::total)). Produced by [`ByteRange::resolve`] or parsed
+/// from a `Content-Range` header string via [`FromStr`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ContentRange {
     /// Byte offset of the first byte in the body (inclusive).


### PR DESCRIPTION
Fixes a few inaccuracies and gaps in documentation across the workspace.

- `README.md` — added missing crates to the component list
- `clients/python/README.md` — fixed scope separator in examples
- `clients/rust/README.md` — corrected `error_for_failures` return type
- `objectstore-server/docs/architecture.md` — fixed auth token requirements and improved endpoint docs
- `objectstore-types/src/lib.rs` — removed redundant per-module summaries and improved module-level docs