### PR TITLE
build: Disable in-process symbolication for heap profiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3072,7 +3072,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eea0cc524de808a6d98d192a3d99fe95617031ad4a52ec0a0f987ef4432e8fe1"
 dependencies = [
  "anyhow",
- "backtrace",
  "flate2",
  "num",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ serde_yaml = "0.9.34-deprecated"
 sketches-ddsketch = "0.3.1"
 tempfile = "3.27.0"
 thiserror = "2.0.18"
-jemalloc_pprof = { version = "0.9.0", features = ["symbolize"] }
+jemalloc_pprof = { version = "0.9.0" }
 tikv-jemallocator = { version = "0.7.0", features = ["background_threads", "override_allocator_on_supported_platforms"] }
 tikv-jemalloc-ctl = { version = "0.7.0", features = ["stats"] }
 tokio = "1.52.3"

--- a/README.md
+++ b/README.md
@@ -262,22 +262,34 @@ curl -X POST http://localhost:8888/debug/pprof/disable
 ```
 
 Profiles are unsymbolicated — you need the server binary to resolve stack
-frames. Copy it from the Docker image with `docker cp <image>:/bin/entrypoint
-./objectstore`.
-
-Analyze the profile dump with `go tool pprof`:
+frames. Copy it from the Docker image with:
 
 ```sh
-go tool pprof objectstore heap.pb.gz
-
-# To isolate growth between two snapshots, use the -base flag:
-go tool pprof -base before.pb.gz after.pb.gz objectstore
-
-# Web UI with flame graph:
-go tool pprof -http=:8080 objectstore heap.pb.gz
+docker create --name tmp <image>
+docker cp tmp:/bin/entrypoint ./objectstore
+docker rm tmp
 ```
 
-The sampling overhead is expected to be low, so profiling can be left enabled
+To analyze profile dumps, use the standalone `pprof` tool. The go builtin tool
+does not support symbolizing ELF files on macOS hosts:
+
+```sh
+go install github.com/google/pprof@latest
+```
+
+Then point pprof at the binary and the heap dump(s) you want to analyze:
+
+```sh
+$(go env GOPATH)/bin/pprof -top objectstore heap.pb.gz
+
+# To isolate growth between two snapshots, use the -diff_base flag:
+$(go env GOPATH)/bin/pprof -top -diff_base before.pb.gz objectstore after.pb.gz
+
+# Interactive browser UI with flamegraph:
+$(go env GOPATH)/bin/pprof -http=:8080 objectstore heap.pb.gz
+```
+
+The sampling overhead is around 5%, so profiling can be left enabled
 for an extended capture window safely.
 
 ### Tests

--- a/README.md
+++ b/README.md
@@ -261,13 +261,20 @@ curl http://localhost:8888/debug/pprof/heap > heap.pb.gz
 curl -X POST http://localhost:8888/debug/pprof/disable
 ```
 
+Profiles are unsymbolicated — you need the server binary to resolve stack
+frames. Copy it from the Docker image with `docker cp <image>:/bin/entrypoint
+./objectstore`.
+
 Analyze the profile dump with `go tool pprof`:
 
 ```sh
-go tool pprof heap.pb.gz
+go tool pprof objectstore heap.pb.gz
 
 # To isolate growth between two snapshots, use the -base flag:
-go tool pprof -base before.pb.gz after.pb.gz
+go tool pprof -base before.pb.gz after.pb.gz objectstore
+
+# Web UI with flame graph:
+go tool pprof -http=:8080 objectstore heap.pb.gz
 ```
 
 The sampling overhead is expected to be low, so profiling can be left enabled


### PR DESCRIPTION
In-process symbolication via `addr2line`/`gimli` allocates ~400MB of memory when resolving DWARF debug info during a heap dump. This dominated heap profiles, making them useless for finding actual leaks.

Drop the `symbolize` feature from `jemalloc_pprof` so profiles contain raw addresses. Local symbolication requires a standalone installation of the latest `pprof` version.

Ref FS-318