### PR TITLE
fix(server): Remove service tag from request metric

### DIFF
--- a/objectstore-server/src/web/middleware.rs
+++ b/objectstore-server/src/web/middleware.rs
@@ -111,7 +111,6 @@ pub async fn emit_request_metrics(mut request: Request, next: Next) -> Response 
 struct EmitMetricsGuard<'a> {
     route: &'a str,
     method: Method,
-    service: DownstreamService,
     start: Instant,
     status: Option<StatusCode>,
 }
@@ -128,7 +127,6 @@ impl<'a> EmitMetricsGuard<'a> {
         Self {
             route,
             method: method.clone(),
-            service,
             start: Instant::now(),
             status: None,
         }
@@ -147,7 +145,7 @@ impl Drop for EmitMetricsGuard<'_> {
             route = self.route.to_owned(),
             method = self.method.as_str().to_owned(),
             status = status,
-            service = self.service.to_string(),
+            // service omitted to limit cardinality
         );
     }
 }


### PR DESCRIPTION
Investigations of memory increase over time revealed the top contributor is the
metric captured by `EmitMetricsGuard::drop`. We suspect this is the `service`
tag, which comes through the `x-downstream-service` request header and contains
the full K8S pod name. This creates a high number of aggregator buckets for the
metrics exporter's reservoir sampler.

We still have the same tag on the `server.requests` counter metric, so it is
safe to remove from the duration.

Ref FS-318
