### PR TITLE
fix(server): Strip Kubernetes hashes from downstream service

### DIFF
--- a/objectstore-server/docs/architecture.md
+++ b/objectstore-server/docs/architecture.md
@@ -66,8 +66,10 @@ A request flows through several layers before reaching the storage service:
    The optional `x-downstream-service` header is extracted for killswitch
    matching and metric tagging. Its value is normalized on ingest by stripping
    any trailing Kubernetes ReplicaSet hash and pod suffix (e.g.
-   `getsentry-incinerator-7d8f9c5b6d-abc12` becomes `getsentry-incinerator`) to
-   avoid high metric cardinality.
+   `getsentry-incinerator-7d8f9c5b6d-abc12` becomes `getsentry-incinerator`) or
+   StatefulSet ordinal (e.g. `web-0` becomes `web`) to avoid high metric
+   cardinality. The raw pod name is still recorded on the Sentry
+   `downstream_service` tag for per-instance debugging.
 3. **Admission control**: [killswitches](killswitches) and
    [rate limits](rate_limits) are checked during extraction. Rejected requests
    never reach the handler.

--- a/objectstore-server/docs/architecture.md
+++ b/objectstore-server/docs/architecture.md
@@ -64,12 +64,7 @@ A request flows through several layers before reaching the storage service:
    `Authorization` header (fallback), then validated and decoded into an
    [`AuthContext`](auth::AuthContext).
    The optional `x-downstream-service` header is extracted for killswitch
-   matching and metric tagging. Its value is normalized on ingest by stripping
-   any trailing Kubernetes ReplicaSet hash and pod suffix (e.g.
-   `getsentry-incinerator-7d8f9c5b6d-abc12` becomes `getsentry-incinerator`) or
-   StatefulSet ordinal (e.g. `web-0` becomes `web`) to avoid high metric
-   cardinality. The raw pod name is still recorded on the Sentry
-   `downstream_service` tag for per-instance debugging.
+   matching.
 3. **Admission control**: [killswitches](killswitches) and
    [rate limits](rate_limits) are checked during extraction. Rejected requests
    never reach the handler.

--- a/objectstore-server/docs/architecture.md
+++ b/objectstore-server/docs/architecture.md
@@ -64,7 +64,10 @@ A request flows through several layers before reaching the storage service:
    `Authorization` header (fallback), then validated and decoded into an
    [`AuthContext`](auth::AuthContext).
    The optional `x-downstream-service` header is extracted for killswitch
-   matching.
+   matching and metric tagging. Its value is normalized on ingest by stripping
+   any trailing Kubernetes ReplicaSet hash and pod suffix (e.g.
+   `getsentry-incinerator-7d8f9c5b6d-abc12` becomes `getsentry-incinerator`) to
+   avoid high metric cardinality.
 3. **Admission control**: [killswitches](killswitches) and
    [rate limits](rate_limits) are checked during extraction. Rejected requests
    never reach the handler.
@@ -287,8 +290,9 @@ matched, cause requests to be rejected with HTTP 403:
 
 - **Usecase**: exact match on the usecase string
 - **Scopes**: all specified scope key-value pairs must be present
-- **Service**: a glob pattern matched against the `x-downstream-service`
-  request header (e.g., `"relay-*"` to block all relay instances)
+- **Service**: a glob pattern matched against the normalized
+  `x-downstream-service` value (Kubernetes hash/pod suffixes are stripped on
+  ingest, so patterns match the base service name, e.g. `"relay*"`)
 
 A killswitch with no conditions matches all traffic. Multiple killswitches are
 evaluated with OR semantics — any match triggers rejection. Killswitches are

--- a/objectstore-server/src/extractors/downstream_service.rs
+++ b/objectstore-server/src/extractors/downstream_service.rs
@@ -28,6 +28,40 @@ impl std::fmt::Display for DownstreamService {
     }
 }
 
+/// Strips a Kubernetes ReplicaSet hash and pod suffix from a service name.
+///
+/// Deployment pods are named `<deployment>-<replicaset-hash>-<pod-suffix>`, where the hash
+/// and suffix are random lowercase-alphanumeric strings. These create extremely high metric
+/// cardinality and carry no useful information, so they are dropped here.
+///
+/// The suffix is only stripped when the trailing two `-`-separated segments match the shape
+/// `<hash>-<5-char suffix>` (both non-empty, lowercase alphanumeric). Values that do not
+/// match are returned unchanged.
+fn strip_pod_suffix(service: &str) -> &str {
+    let is_hash = |segment: &str| {
+        !segment.is_empty()
+            && segment
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+    };
+
+    let Some((rest, pod_suffix)) = service.rsplit_once('-') else {
+        return service;
+    };
+    if pod_suffix.len() != 5 || !is_hash(pod_suffix) {
+        return service;
+    }
+
+    let Some((deployment, replicaset_hash)) = rest.rsplit_once('-') else {
+        return service;
+    };
+    if deployment.is_empty() || !is_hash(replicaset_hash) {
+        return service;
+    }
+
+    deployment
+}
+
 impl<S: Send + Sync> FromRequestParts<S> for DownstreamService {
     type Rejection = std::convert::Infallible;
 
@@ -36,7 +70,8 @@ impl<S: Send + Sync> FromRequestParts<S> for DownstreamService {
             .headers
             .get(HEADER_SERVICE)
             .and_then(|v| v.to_str().ok())
-            .map(|s| s.to_string());
+            .map(strip_pod_suffix)
+            .map(str::to_owned);
 
         if let Some(ref service) = service {
             sentry::configure_scope(|s| {
@@ -45,5 +80,54 @@ impl<S: Send + Sync> FromRequestParts<S> for DownstreamService {
         }
 
         Ok(DownstreamService(service))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_typical_pod_name() {
+        assert_eq!(
+            strip_pod_suffix("getsentry-incinerator-7d8f9c5b6d-abc12"),
+            "getsentry-incinerator"
+        );
+    }
+
+    #[test]
+    fn strips_single_segment_deployment() {
+        assert_eq!(strip_pod_suffix("service-7d8f9c5b6d-abcde"), "service");
+    }
+
+    #[test]
+    fn keeps_plain_name() {
+        assert_eq!(strip_pod_suffix("relay"), "relay");
+    }
+
+    #[test]
+    fn keeps_name_without_pod_suffix() {
+        assert_eq!(
+            strip_pod_suffix("getsentry-incinerator"),
+            "getsentry-incinerator"
+        );
+    }
+
+    #[test]
+    fn keeps_short_trailing_segment() {
+        assert_eq!(strip_pod_suffix("my-service"), "my-service");
+    }
+
+    #[test]
+    fn keeps_uppercase_suffix() {
+        assert_eq!(
+            strip_pod_suffix("my-svc-7d8f9c5b6d-ABC12"),
+            "my-svc-7d8f9c5b6d-ABC12"
+        );
+    }
+
+    #[test]
+    fn keeps_empty_deployment() {
+        assert_eq!(strip_pod_suffix("-abcde-fghij"), "-abcde-fghij");
     }
 }

--- a/objectstore-server/src/extractors/downstream_service.rs
+++ b/objectstore-server/src/extractors/downstream_service.rs
@@ -28,38 +28,43 @@ impl std::fmt::Display for DownstreamService {
     }
 }
 
-/// Strips a Kubernetes ReplicaSet hash and pod suffix from a service name.
+/// Strips a Kubernetes pod suffix from a service name, leaving the base workload name.
 ///
-/// Deployment pods are named `<deployment>-<replicaset-hash>-<pod-suffix>`, where the hash
-/// and suffix are random lowercase-alphanumeric strings. These create extremely high metric
-/// cardinality and carry no useful information, so they are dropped here.
-///
-/// The suffix is only stripped when the trailing two `-`-separated segments match the shape
-/// `<hash>-<5-char suffix>` (both non-empty, lowercase alphanumeric). Values that do not
-/// match are returned unchanged.
+/// Deployment pods are named `<deployment>-<replicaset-hash>-<pod-suffix>` and StatefulSet
+/// pods `<name>-<ordinal>`. The hash/suffix and ordinal change on every rollout, creating
+/// useless metric cardinality. Segment lengths follow the Kubernetes naming rules to limit
+/// false positives; anything else is returned unchanged.
 fn strip_pod_suffix(service: &str) -> &str {
     let is_hash = |segment: &str| {
-        !segment.is_empty()
-            && segment
-                .chars()
-                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+        segment
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
     };
 
-    let Some((rest, pod_suffix)) = service.rsplit_once('-') else {
+    let Some((rest, last)) = service.rsplit_once('-') else {
         return service;
     };
-    if pod_suffix.len() != 5 || !is_hash(pod_suffix) {
+    if rest.is_empty() {
         return service;
     }
 
-    let Some((deployment, replicaset_hash)) = rest.rsplit_once('-') else {
-        return service;
-    };
-    if deployment.is_empty() || !is_hash(replicaset_hash) {
-        return service;
+    // Deployment: the pod suffix is 5 chars and the ReplicaSet hash is 7-10 chars.
+    if last.len() == 5
+        && is_hash(last)
+        && let Some((deployment, hash)) = rest.rsplit_once('-')
+        && !deployment.is_empty()
+        && (7..=10).contains(&hash.len())
+        && is_hash(hash)
+    {
+        return deployment;
     }
 
-    deployment
+    // StatefulSet: the pod suffix is a numeric ordinal.
+    if !last.is_empty() && last.bytes().all(|b| b.is_ascii_digit()) {
+        return rest;
+    }
+
+    service
 }
 
 impl<S: Send + Sync> FromRequestParts<S> for DownstreamService {
@@ -73,6 +78,8 @@ impl<S: Send + Sync> FromRequestParts<S> for DownstreamService {
             .map(str::to_owned);
 
         if let Some(ref service) = service {
+            // Tag the raw pod name intentionally: it pinpoints the exact instance when
+            // debugging, and tag cardinality is not a concern here.
             sentry::configure_scope(|s| {
                 s.set_tag("downstream_service", service);
             });
@@ -129,5 +136,30 @@ mod tests {
     #[test]
     fn keeps_empty_deployment() {
         assert_eq!(strip_pod_suffix("-abcde-fghij"), "-abcde-fghij");
+    }
+
+    #[test]
+    fn keeps_wrong_length_hash() {
+        // Hash segment is just outside the 7-10 char range, so it is not a ReplicaSet hash.
+        assert_eq!(strip_pod_suffix("foo-sixchr-abcde"), "foo-sixchr-abcde");
+        assert_eq!(
+            strip_pod_suffix("foo-abcdefghijk-abcde"),
+            "foo-abcdefghijk-abcde"
+        );
+    }
+
+    #[test]
+    fn strips_min_length_hash() {
+        // A 7-char hash is the shortest that is still treated as a ReplicaSet hash.
+        assert_eq!(strip_pod_suffix("svc-abcdefg-hijkl"), "svc");
+    }
+
+    #[test]
+    fn strips_statefulset_ordinal() {
+        assert_eq!(
+            strip_pod_suffix("getsentry-incinerator-0"),
+            "getsentry-incinerator"
+        );
+        assert_eq!(strip_pod_suffix("web-12"), "web");
     }
 }

--- a/objectstore-server/src/extractors/downstream_service.rs
+++ b/objectstore-server/src/extractors/downstream_service.rs
@@ -70,7 +70,6 @@ impl<S: Send + Sync> FromRequestParts<S> for DownstreamService {
             .headers
             .get(HEADER_SERVICE)
             .and_then(|v| v.to_str().ok())
-            .map(strip_pod_suffix)
             .map(str::to_owned);
 
         if let Some(ref service) = service {
@@ -79,7 +78,8 @@ impl<S: Send + Sync> FromRequestParts<S> for DownstreamService {
             });
         }
 
-        Ok(DownstreamService(service))
+        let normalized = service.as_deref().map(strip_pod_suffix).map(str::to_owned);
+        Ok(DownstreamService(normalized))
     }
 }
 

--- a/objectstore-server/src/killswitches.rs
+++ b/objectstore-server/src/killswitches.rs
@@ -64,7 +64,10 @@ pub struct Killswitch {
     /// Optional service glob pattern to match.
     ///
     /// If `None`, matches any service (or absence of service header).
-    /// If specified, the request must have a matching `x-downstream-service` header.
+    /// If specified, the request must have a matching `x-downstream-service` header. The header
+    /// value is normalized before matching: any trailing Kubernetes ReplicaSet hash and pod
+    /// suffix are stripped, so patterns should match the base service name (e.g. `relay*`, not
+    /// `relay-7d8f9c5b6d-*`).
     #[serde(default)]
     pub service: Option<String>,
 


### PR DESCRIPTION
Kubernetes callers send their pod name in the `x-downstream-service`
header ("deployment-replicaset_hash-pod_suffix"). The random hash and
pod suffix change on every rollout, creating extremely high, useless
cardinality wherever the value is recorded as a metric or Sentry tag.

This PR normalizes the value in the extractor so all consumers see the
clean base service name. The suffix is only stripped when the trailing
two segments look like a hash and pod suffix; plain service names pass
through unchanged.

Killswitch service patterns now match the normalized base name, so globs
that relied on the hash suffix should target the base name instead.