### PR TITLE
build(client): Remove version pin notice on tokio dependency

### DIFF
--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -25,7 +25,6 @@ reqwest = { version = "0.13.1", default-features = false, features = ["charset",
 sentry-core = { version = ">=0.41", default-features = false, features = ["client"] }
 serde = { workspace = true }
 thiserror = { workspace = true }
-# See https://github.com/getsentry/relay/blob/9c491a185a289e09ee9d3f56d89bd9d1fa71d815/Cargo.toml#L211
 tokio = { version = "1.45.0", default-features = false, features = ["fs"] }
 tokio-util = { workspace = true, features = ["io"] }
 url = { workspace = true }


### PR DESCRIPTION
Relay no longer requires the old version pinned, so we can remove the
notice about it. We still keep the old version for the client, as there
is no reason to force an upgrade.
