### PR TITLE
fix(stresstest): Use `put_path` for `many` requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4306,6 +4306,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "sketches-ddsketch",
+ "tempfile",
  "tikv-jemallocator",
  "tokio",
  "tokio-util",

--- a/stresstest/Cargo.toml
+++ b/stresstest/Cargo.toml
@@ -23,7 +23,8 @@ rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }
 sketches-ddsketch = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "sync", "macros"] }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "sync", "macros", "fs"] }
 tokio-util = { workspace = true, features = ["io"] }
 yansi = { workspace = true }
 

--- a/stresstest/src/stresstest.rs
+++ b/stresstest/src/stresstest.rs
@@ -12,8 +12,8 @@ use futures::StreamExt;
 use indicatif::{ProgressBar, ProgressStyle};
 use objectstore_client::{ExpirationPolicy, Usecase};
 use sketches_ddsketch::DDSketch;
+use tokio::io::AsyncReadExt;
 use tokio::sync::Semaphore;
-use tokio_util::io::ReaderStream;
 use yansi::Paint;
 
 use crate::http::HttpRemote;
@@ -420,16 +420,17 @@ async fn run_batch_workload(
 
                     let mut payload_info = HashMap::with_capacity(payloads.len());
 
-                    for (internal_id, payload) in payloads {
+                    for (internal_id, mut payload) in payloads {
                         let key = internal_id.to_string();
-                        payload_info.insert(key.clone(), (internal_id, payload.len));
-                        let stream = ReaderStream::new(payload).boxed();
-                        many = many.push(
-                            session
-                                .put_stream(stream)
-                                .compression(None)
-                                .key(key),
-                        );
+                        let size = payload.len;
+                        payload_info.insert(key.clone(), (internal_id, size));
+                        // Buffer the payload to ensure the operation can be classified as batchable.
+                        let mut body = Vec::with_capacity(size as usize);
+                        payload
+                            .read_to_end(&mut body)
+                            .await
+                            .expect("reading an in-memory payload cannot fail");
+                        many = many.push(session.put(body).compression(None).key(key));
                     }
 
                     metrics.lock().unwrap().many_requests += 1;

--- a/stresstest/src/stresstest.rs
+++ b/stresstest/src/stresstest.rs
@@ -12,7 +12,6 @@ use futures::StreamExt;
 use indicatif::{ProgressBar, ProgressStyle};
 use objectstore_client::{ExpirationPolicy, Usecase};
 use sketches_ddsketch::DDSketch;
-use tokio::io::AsyncReadExt;
 use tokio::sync::Semaphore;
 use yansi::Paint;
 
@@ -420,17 +419,29 @@ async fn run_batch_workload(
 
                     let mut payload_info = HashMap::with_capacity(payloads.len());
 
+                    // Write each payload to a temp file so the batch client can classify it as
+                    // batchable (streamed bodies are treated as unknown-size and skip batching)
+                    // without buffering every body in memory. `put_path` defers opening each file
+                    // until the request is sent, keeping file descriptor usage within the active
+                    // concurrency window rather than opening the whole batch at once.
+                    let temp_dir = tempfile::Builder::new()
+                        .prefix("objectstore-stresstest-")
+                        .tempdir()
+                        .expect("failed to create temp dir for batch payloads")
+                        .keep();
+
                     for (internal_id, mut payload) in payloads {
                         let key = internal_id.to_string();
                         let size = payload.len;
                         payload_info.insert(key.clone(), (internal_id, size));
-                        // Buffer the payload to ensure the operation can be classified as batchable.
-                        let mut body = Vec::with_capacity(size as usize);
-                        payload
-                            .read_to_end(&mut body)
+                        let path = temp_dir.join(&key);
+                        let mut file = tokio::fs::File::create(&path)
                             .await
-                            .expect("reading an in-memory payload cannot fail");
-                        many = many.push(session.put(body).compression(None).key(key));
+                            .expect("failed to create temp file for batch payload");
+                        tokio::io::copy(&mut payload, &mut file)
+                            .await
+                            .expect("writing an in-memory payload to a temp file cannot fail");
+                        many = many.push(session.put_path(path).compression(None).key(key));
                     }
 
                     metrics.lock().unwrap().many_requests += 1;
@@ -473,6 +484,15 @@ async fn run_batch_workload(
                         .unwrap()
                         .batch_timing
                         .add(batch_start.elapsed().as_secs_f64());
+
+                    // Remove the temp files now that the batch has been uploaded.
+                    if let Err(err) = tokio::fs::remove_dir_all(&temp_dir).await {
+                        eprintln!(
+                            "failed to clean up batch temp dir {}: {err}",
+                            temp_dir.display()
+                        );
+                    }
+
                     drop(permit);
                 };
                 tokio::spawn(task);


### PR DESCRIPTION
The batch workload built its requests through `put_stream()`, which always produces a `PutBody::Stream`. The client's batch classifier treats streamed bodies as unknown-size and routes them down the individual (non-batch) path, so every "batch" put in this workload was silently sent as an individual request — the batch endpoint was never actually being stress-tested.

To be classifiable as batchable, an operation needs a known body size. Rather than buffer each payload into a `Vec<u8>` in memory (which would make peak memory scale with `concurrency * batch_size * payload_size` — tens of MiB per in-flight batch at large batch sizes), each generated payload is streamed to a temp file and enqueued with `put_path()`.