### PR TITLE
ci: Scope sentry-options secrets instead of inherit

### DIFF
--- a/.github/workflows/validate-sentry-options.yml
+++ b/.github/workflows/validate-sentry-options.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   validate:
-    uses: getsentry/sentry-options/.github/workflows/validate-schema.yml@586df8a9214a4bb7d5cf0a39b6bb3887ddab70c6 # v1.0.1
+    uses: getsentry/sentry-options/.github/workflows/validate-schema.yml@5ae5958b3c4bf104efc46d61e9d155f45cefe1d8 # TODO: Replace!
     secrets:
       SENTRY_INTERNAL_APP_PRIVATE_KEY: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
     with:

--- a/.github/workflows/validate-sentry-options.yml
+++ b/.github/workflows/validate-sentry-options.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   validate:
     uses: getsentry/sentry-options/.github/workflows/validate-schema.yml@586df8a9214a4bb7d5cf0a39b6bb3887ddab70c6 # v1.0.1
-    secrets: inherit
+    secrets:
+      SENTRY_INTERNAL_APP_PRIVATE_KEY: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
     with:
       schemas-path: sentry-options/schemas

--- a/.github/workflows/validate-sentry-options.yml
+++ b/.github/workflows/validate-sentry-options.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   validate:
-    uses: getsentry/sentry-options/.github/workflows/validate-schema.yml@5ae5958b3c4bf104efc46d61e9d155f45cefe1d8 # TODO: Replace!
+    uses: getsentry/sentry-options/.github/workflows/validate-schema.yml@5792fdd90e854b6aa4747e89d61df07bfa6beaa6 # 1.1.3
     secrets:
       SENTRY_INTERNAL_APP_PRIVATE_KEY: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
     with:

--- a/sentry-options/schemas/objectstore/schema.json
+++ b/sentry-options/schemas/objectstore/schema.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0",
+  "version": "0.1",
   "type": "object",
   "properties": {}
 }

--- a/sentry-options/schemas/objectstore/schema.json
+++ b/sentry-options/schemas/objectstore/schema.json
@@ -1,5 +1,6 @@
 {
   "version": "1.0",
   "type": "object",
+  "description": "Active killswitches that may disable access to specific object contexts.",
   "properties": {}
 }

--- a/sentry-options/schemas/objectstore/schema.json
+++ b/sentry-options/schemas/objectstore/schema.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1",
+  "version": "1.0",
   "type": "object",
   "properties": {}
 }

--- a/sentry-options/schemas/objectstore/schema.json
+++ b/sentry-options/schemas/objectstore/schema.json
@@ -1,6 +1,5 @@
 {
   "version": "1.0",
   "type": "object",
-  "description": "Active killswitches that may disable access to specific object contexts.",
   "properties": {}
 }


### PR DESCRIPTION
Replaces `secrets: inherit` on the sentry-options validation workflow with an explicit map passing only `SENTRY_INTERNAL_APP_PRIVATE_KEY`, the single secret the reusable workflow uses.

Closes FS-396