### PR TITLE
fix(server): Ignore client-supplied read-only metadata on writes

### DIFF
--- a/objectstore-server/src/endpoints/batch.rs
+++ b/objectstore-server/src/endpoints/batch.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::time::SystemTime;
 
 use axum::Router;
 use axum::extract::{DefaultBodyLimit, State};
@@ -109,13 +108,12 @@ async fn batch(
         }
     });
 
-    // Step 5: stamp inserts with time_created and record bandwidth
-    let stamped = policy_checked.map({
+    // Step 5: record bandwidth for inserts
+    let metered = policy_checked.map({
         let state = Arc::clone(&state);
         let context = context.clone();
-        move |(idx, mut item)| {
-            if let Ok(Operation::Insert(ins)) = &mut item {
-                ins.metadata.time_created = Some(SystemTime::now());
+        move |(idx, item)| {
+            if let Ok(Operation::Insert(ins)) = &item {
                 state.record_bandwidth(&context, ins.payload.len() as u64);
             }
             (idx, item)
@@ -125,7 +123,7 @@ async fn batch(
     // Step 6: execute concurrently, then convert each result to a multipart Part
     let state_ref = Arc::clone(&state);
     let context_ref = context.clone();
-    let responses = batch.execute(context, stamped).then(move |(idx, result)| {
+    let responses = batch.execute(context, metered).then(move |(idx, result)| {
         let state = Arc::clone(&state_ref);
         let context = context_ref.clone();
         async move { convert_to_part(idx, result, &state, &context).await }

--- a/objectstore-server/src/endpoints/multipart.rs
+++ b/objectstore-server/src/endpoints/multipart.rs
@@ -1,5 +1,5 @@
 use std::convert::Infallible;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 use crate::auth::AuthAwareService;
 use crate::endpoints::common::{ApiError, ApiResult};
@@ -95,9 +95,8 @@ async fn initiate_inner(
     id: ObjectId,
     headers: HeaderMap,
 ) -> ApiResult<Response> {
-    let mut metadata = Metadata::from_headers(&headers, "").map_err(ServiceError::from)?;
-    // TODO: Do this in `complete` instead, when we have a Service API to mutate metadata.
-    metadata.time_created = Some(SystemTime::now());
+    // TODO: Update time_created in `complete`, when we have a Service API to mutate metadata.
+    let metadata = Metadata::from_insert_headers(&headers, "").map_err(ServiceError::from)?;
 
     state
         .config

--- a/objectstore-server/src/endpoints/objects.rs
+++ b/objectstore-server/src/endpoints/objects.rs
@@ -1,5 +1,3 @@
-use std::time::SystemTime;
-
 use axum::body::Body;
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
@@ -45,8 +43,7 @@ async fn objects_post(
     headers: HeaderMap,
     MeteredBody(body): MeteredBody,
 ) -> ApiResult<Response> {
-    let mut metadata = Metadata::from_headers(&headers, "").map_err(ServiceError::from)?;
-    metadata.time_created = Some(SystemTime::now());
+    let metadata = Metadata::from_insert_headers(&headers, "").map_err(ServiceError::from)?;
 
     state
         .config
@@ -178,8 +175,7 @@ async fn object_put(
     headers: HeaderMap,
     MeteredBody(body): MeteredBody,
 ) -> ApiResult<Response> {
-    let mut metadata = Metadata::from_headers(&headers, "").map_err(ServiceError::from)?;
-    metadata.time_created = Some(SystemTime::now());
+    let metadata = Metadata::from_insert_headers(&headers, "").map_err(ServiceError::from)?;
 
     let ObjectId { context, key } = id;
 

--- a/objectstore-server/src/extractors/batch.rs
+++ b/objectstore-server/src/extractors/batch.rs
@@ -110,7 +110,7 @@ async fn try_operation_from_field(mut field: Field<'_>) -> Result<Operation, Bat
             })?,
         }),
         "insert" => {
-            let metadata = Metadata::from_headers(field.headers(), "")?;
+            let metadata = Metadata::from_insert_headers(field.headers(), "")?;
             let mut payload = BytesMut::new();
             while let Some(chunk) = field.chunk().await? {
                 if payload.len() + chunk.len() > MAX_FIELD_SIZE {

--- a/objectstore-types/src/metadata.rs
+++ b/objectstore-types/src/metadata.rs
@@ -287,10 +287,35 @@ pub struct Metadata {
 }
 
 impl Metadata {
+    /// Parses the metadata headers accepted from writing endpoints.
+    ///
+    /// Unlike [`from_headers`](Self::from_headers), this skips read-only and output attributes so
+    /// clients cannot set them via headers.
+    ///
+    /// A prefix can also be provided which is stripped from custom non-standard headers.
+    pub fn from_insert_headers(headers: &HeaderMap, prefix: &str) -> Result<Self, Error> {
+        let mut metadata = Self::parse_headers(headers, prefix, true)?;
+        metadata.time_created = Some(SystemTime::now());
+        Ok(metadata)
+    }
+
     /// Extracts public API metadata from the given [`HeaderMap`].
     ///
     /// A prefix can be also be provided which is being stripped from custom non-standard headers.
     pub fn from_headers(headers: &HeaderMap, prefix: &str) -> Result<Self, Error> {
+        Self::parse_headers(headers, prefix, false)
+    }
+
+    /// Parses metadata from the given [`HeaderMap`].
+    ///
+    /// When `skip_read_only` is set, read-only attributes are not parsed off the headers, so a
+    /// malformed client-supplied value cannot fail the parse. A prefix can also be provided which
+    /// is stripped from custom non-standard headers.
+    fn parse_headers(
+        headers: &HeaderMap,
+        prefix: &str,
+        skip_read_only: bool,
+    ) -> Result<Self, Error> {
         let mut metadata = Metadata::default();
 
         for (name, value) in headers {
@@ -317,12 +342,12 @@ impl Metadata {
                             metadata.expiration_policy =
                                 ExpirationPolicy::from_str(expiration_policy)?;
                         }
-                        HEADER_TIME_CREATED => {
+                        HEADER_TIME_CREATED if !skip_read_only => {
                             let timestamp = value.to_str()?;
                             let time = parse_rfc3339(timestamp)?;
                             metadata.time_created = Some(time);
                         }
-                        HEADER_TIME_EXPIRES => {
+                        HEADER_TIME_EXPIRES if !skip_read_only => {
                             let timestamp = value.to_str()?;
                             let time = parse_rfc3339(timestamp)?;
                             metadata.time_expires = Some(time);
@@ -568,6 +593,41 @@ mod tests {
         let metadata = Metadata::from_headers(&headers, "").unwrap();
         assert!(metadata.time_created.is_some());
         assert!(metadata.time_expires.is_some());
+    }
+
+    #[test]
+    fn from_insert_headers_ignores_read_only_fields() {
+        // Read-only and output attributes must never be taken from an untrusted
+        // client request, even if the client supplies the headers.
+        let forged_created = "2024-01-15T12:00:00.000000Z";
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", "text/plain".parse().unwrap());
+        headers.insert(HEADER_TIME_CREATED, forged_created.parse().unwrap());
+        headers.insert(
+            HEADER_TIME_EXPIRES,
+            "2024-01-16T12:00:00.000000Z".parse().unwrap(),
+        );
+
+        let metadata = Metadata::from_insert_headers(&headers, "").unwrap();
+        // `time_created` is stamped by the server, not the client's forged value.
+        let created = metadata.time_created.unwrap();
+        assert_ne!(created, parse_rfc3339(forged_created).unwrap());
+        assert!(metadata.time_expires.is_none());
+        assert!(metadata.size.is_none());
+        // Client-settable fields are still parsed.
+        assert_eq!(metadata.content_type, "text/plain");
+    }
+
+    #[test]
+    fn from_insert_headers_ignores_malformed_read_only_fields() {
+        // A malformed read-only header must not fail the write: it is skipped, not parsed.
+        let mut headers = HeaderMap::new();
+        headers.insert(HEADER_TIME_CREATED, "not-a-timestamp".parse().unwrap());
+        headers.insert(HEADER_TIME_EXPIRES, "not-a-timestamp".parse().unwrap());
+
+        let metadata = Metadata::from_insert_headers(&headers, "").unwrap();
+        assert!(metadata.time_created.is_some());
+        assert!(metadata.time_expires.is_none());
     }
 
     #[test]


### PR DESCRIPTION
`Metadata` carries fields a client must not set on a write: `time_created` and
`time_expires` are server-computed and `size` is resolved by the backend. The write
endpoints parsed request metadata with `Metadata::from_headers`, which reads every
field, so a client could supply e.g. `x-sn-time-expires` on a write. On the local_fs
backend that forged expiration was persisted and echoed back verbatim, decoupled from
the object's actual expiration policy.

This adds `Metadata::from_insert_headers`, a parser for the untrusted write direction:
it stamps `time_created` and drops the read-only/output attributes clients cannot set,
so they can no longer be forged via headers. The create, overwrite, multipart, and
batch paths now use it, which also removes the previous per-endpoint `time_created`
stamping. `from_headers` stays the full, trusted parser for server-emitted metadata —
GET/HEAD/batch responses in the client and backend storage reads — so callers still
receive the resolved `time_expires`.

A follow-up will make this safer structurally by splitting the incoming
(client-provided) and outgoing (server-emitted) metadata into distinct types, so
read-only fields and required normalizations are enforced by the type system rather
than by hand.