### PR TITLE
fix(service): Resolve object expiration once on write

### DIFF
--- a/objectstore-server/docs/architecture.md
+++ b/objectstore-server/docs/architecture.md
@@ -57,24 +57,22 @@ A request flows through several layers before reaching the storage service:
 
 1. **Middleware**: metrics collection, in-flight request tracking, panic
    recovery, Sentry transaction tracing, distributed tracing.
-2. **Extractors**: path parameters are parsed into an
-   [`ObjectId`](objectstore_service::id::ObjectId) or
-   [`ObjectContext`](objectstore_service::id::ObjectContext). The auth token is
-   read from the `X-Os-Auth` header (preferred) or the standard
-   `Authorization` header (fallback), then validated and decoded into an
-   [`AuthContext`](auth::AuthContext).
-   The optional `x-downstream-service` header is extracted for killswitch
-   matching.
-3. **Admission control**: [killswitches](killswitches) and
-   [rate limits](rate_limits) are checked during extraction. Rejected requests
-   never reach the handler.
-4. **Handler**: the endpoint handler calls the
+2. **Extractors**: extracts object context from path parameters and then
+   constructs a service wrapper that authorizes all operations on the target
+   resource. Other endpoint-specific extractors also run at this stage.
+3. **Admission control**: As part of the extractors,
+   [killswitches](killswitches) and [rate limits](rate_limits) are evaluated.
+   Rejected requests never reach the handler.
+4. **Metadata**: Another extractor constructs inbound `Metadata` from request
+   headers. At this point, certain server-side fields are materialized, so they
+   are provided consistently to the service and backends.
+5. **Handler**: the endpoint handler calls the
    [`AuthAwareService`](auth::AuthAwareService), which checks permissions
    before delegating to the underlying
    [`StorageService`](objectstore_service::StorageService). The service
    enforces its own backpressure before executing the
    operation.
-5. **Response**: metadata is mapped to HTTP headers (see
+6. **Response**: metadata is mapped to HTTP headers (see
    [`objectstore-types` docs](objectstore_types) for the header mapping) and
    the payload is streamed back.
 

--- a/objectstore-service/docs/architecture.md
+++ b/objectstore-service/docs/architecture.md
@@ -169,11 +169,9 @@ capabilities. For example, BigTable has built-in TTL via garbage collection
 policies, and GCS supports object lifecycle management. The service does not
 perform active garbage collection.
 
-The absolute expiration timestamp (`time_expires`) is resolved **once** on write
-from the policy and creation time (see
-[`Metadata::from_insert_headers`](objectstore_types::metadata::Metadata::from_insert_headers)),
-so every backend persists the same deadline instead of each recomputing it. On a
-time-to-idle access, backends refresh this timestamp as part of the idle bump.
+Apart from the expiration policy, metadata during object creation must carry a
+`time_expires` field with the correct expiration timestamp. This is ensured
+during metadata creation by the server.
 
 # Backpressure
 

--- a/objectstore-service/docs/architecture.md
+++ b/objectstore-service/docs/architecture.md
@@ -169,6 +169,12 @@ capabilities. For example, BigTable has built-in TTL via garbage collection
 policies, and GCS supports object lifecycle management. The service does not
 perform active garbage collection.
 
+The absolute expiration timestamp (`time_expires`) is resolved **once** on write
+from the policy and creation time (see
+[`Metadata::from_insert_headers`](objectstore_types::metadata::Metadata::from_insert_headers)),
+so every backend persists the same deadline instead of each recomputing it. On a
+time-to-idle access, backends refresh this timestamp as part of the idle bump.
+
 # Backpressure
 
 The service applies backpressure to protect backends from overload. Rather than

--- a/objectstore-service/src/backend/bigtable.rs
+++ b/objectstore-service/src/backend/bigtable.rs
@@ -438,7 +438,7 @@ fn delete_row_mutation() -> v2::Mutation {
     ))
 }
 
-/// Returns a copy of `metadata` with `time_expires` refreshed for a TTI bump.
+/// Returns a clone of `metadata` with `time_expires` refreshed for a TTI bump.
 ///
 /// [`object_mutations`] persists `time_expires` verbatim, so the bumped deadline must be applied
 /// to the metadata before rewriting the row.
@@ -457,15 +457,9 @@ fn bumped_tti_metadata(metadata: &Metadata) -> Metadata {
 /// Used by both [`BigTableBackend::put_row`] (unconditional write) and
 /// [`BigTableBackend::put_non_tombstone`] (conditional write).
 fn object_mutations(mut metadata: Metadata, payload: Vec<u8>) -> Result<[v2::Mutation; 3]> {
-    let (family, timestamp_micros) = match metadata.expiration_policy {
-        ExpirationPolicy::Manual => (FAMILY_MANUAL, -1),
-        ExpirationPolicy::TimeToLive(_) | ExpirationPolicy::TimeToIdle(_) => {
-            let deadline = metadata.time_expires.ok_or_else(|| Error::Generic {
-                context: "BigTable: timeout expiration policy without resolved time_expires".into(),
-                cause: None,
-            })?;
-            (FAMILY_GC, deadline_to_micros(deadline)?)
-        }
+    let (family, timestamp_micros) = match metadata.time_expires {
+        None => (FAMILY_MANUAL, -1),
+        Some(deadline) => (FAMILY_GC, system_time_to_micros(deadline)?),
     };
 
     // Record the payload size in the metadata before persisting it.
@@ -806,11 +800,11 @@ impl BigTableBackend {
     async fn put_row(
         &self,
         path: Vec<u8>,
-        metadata: &Metadata,
+        metadata: Metadata,
         payload: Vec<u8>,
         action: &'static str,
     ) -> Result<v2::MutateRowResponse> {
-        let mutations = object_mutations(metadata.clone(), payload)?;
+        let mutations = object_mutations(metadata, payload)?;
         self.mutate(path, mutations, action).await
     }
 
@@ -827,7 +821,6 @@ impl BigTableBackend {
     /// Best-effort TTI bump for a row.
     ///
     /// If the payload isn't loaded, it will be fetched. Failures are ignored silently.
-    // TODO: extract into dedicated call from service
     async fn bump_tti(&self, path: Vec<u8>, row: &RowData, loaded: bool, hv_id: &ObjectId) {
         let expiration_policy = row.expiration_policy();
 
@@ -850,7 +843,7 @@ impl BigTableBackend {
             RowData::Object { metadata, payload } if loaded => {
                 let bumped = bumped_tti_metadata(metadata);
                 let _ = self
-                    .put_row(path, &bumped, payload.clone(), "tti-bump")
+                    .put_row(path, bumped, payload.clone(), "tti-bump")
                     .await;
             }
             RowData::Object { metadata, .. } => {
@@ -860,7 +853,7 @@ impl BigTableBackend {
 
                 if let Ok(Some(RowData::Object { payload, .. })) = payload_read {
                     let bumped = bumped_tti_metadata(metadata);
-                    let _ = self.put_row(path, &bumped, payload, "tti-bump").await;
+                    let _ = self.put_row(path, bumped, payload, "tti-bump").await;
                 }
             }
         }
@@ -920,8 +913,9 @@ impl Backend for BigTableBackend {
             payload.push(chunk);
         }
 
-        self.put_row(path, metadata, payload.into_bytes().into(), "put")
+        self.put_row(path, metadata.clone(), payload.into_bytes().into(), "put")
             .await?;
+
         Ok(())
     }
 
@@ -1019,6 +1013,7 @@ impl HighVolumeBackend for BigTableBackend {
             return Ok(TieredGet::NotFound);
         };
 
+        // TODO: extract into dedicated call from service
         if row.needs_tti_bump() {
             self.bump_tti(path.clone(), &row, true, id).await;
         }
@@ -1057,6 +1052,7 @@ impl HighVolumeBackend for BigTableBackend {
             return Ok(TieredMetadata::NotFound);
         };
 
+        // TODO: extract into dedicated call from service
         if row.needs_tti_bump() {
             self.bump_tti(path.clone(), &row, false, id).await;
         }
@@ -1158,14 +1154,15 @@ fn ttl_to_micros(ttl: Duration, from: SystemTime) -> Result<i64> {
         ),
         cause: None,
     })?;
-    deadline_to_micros(deadline)
+
+    system_time_to_micros(deadline)
 }
 
-/// Converts an absolute expiration timestamp to a microsecond-precision unix timestamp.
+/// Converts a [`SystemTime`] to a microsecond-precision unix timestamp.
 ///
 /// As required by BigTable, the resulting timestamp has millisecond precision, with the last digits
 /// at 0.
-fn deadline_to_micros(deadline: SystemTime) -> Result<i64> {
+fn system_time_to_micros(deadline: SystemTime) -> Result<i64> {
     let millis = deadline
         .duration_since(SystemTime::UNIX_EPOCH)
         .map_err(|e| Error::Generic {
@@ -1176,6 +1173,7 @@ fn deadline_to_micros(deadline: SystemTime) -> Result<i64> {
             cause: Some(Box::new(e)),
         })?
         .as_millis();
+
     (millis * 1000).try_into().map_err(|e| Error::Generic {
         context: format!("failed to convert {millis}ms to i64 microseconds"),
         cause: Some(Box::new(e)),

--- a/objectstore-service/src/backend/bigtable.rs
+++ b/objectstore-service/src/backend/bigtable.rs
@@ -438,20 +438,34 @@ fn delete_row_mutation() -> v2::Mutation {
     ))
 }
 
+/// Returns a copy of `metadata` with `time_expires` refreshed for a TTI bump.
+///
+/// [`object_mutations`] persists `time_expires` verbatim, so the bumped deadline must be applied
+/// to the metadata before rewriting the row.
+fn bumped_tti_metadata(metadata: &Metadata) -> Metadata {
+    let mut metadata = metadata.clone();
+    metadata.time_expires = metadata
+        .expiration_policy
+        .expires_in()
+        .map(|tti| SystemTime::now() + tti);
+    metadata
+}
+
 /// Builds the three mutations that write an object row: clear existing data,
 /// then set the payload and metadata cells.
 ///
 /// Used by both [`BigTableBackend::put_row`] (unconditional write) and
 /// [`BigTableBackend::put_non_tombstone`] (conditional write).
-fn object_mutations(
-    mut metadata: Metadata,
-    payload: Vec<u8>,
-    now: SystemTime,
-) -> Result<[v2::Mutation; 3]> {
+fn object_mutations(mut metadata: Metadata, payload: Vec<u8>) -> Result<[v2::Mutation; 3]> {
     let (family, timestamp_micros) = match metadata.expiration_policy {
         ExpirationPolicy::Manual => (FAMILY_MANUAL, -1),
-        ExpirationPolicy::TimeToLive(ttl) => (FAMILY_GC, ttl_to_micros(ttl, now)?),
-        ExpirationPolicy::TimeToIdle(tti) => (FAMILY_GC, ttl_to_micros(tti, now)?),
+        ExpirationPolicy::TimeToLive(_) | ExpirationPolicy::TimeToIdle(_) => {
+            let deadline = metadata.time_expires.ok_or_else(|| Error::Generic {
+                context: "BigTable: timeout expiration policy without resolved time_expires".into(),
+                cause: None,
+            })?;
+            (FAMILY_GC, deadline_to_micros(deadline)?)
+        }
     };
 
     // Record the payload size in the metadata before persisting it.
@@ -796,7 +810,7 @@ impl BigTableBackend {
         payload: Vec<u8>,
         action: &'static str,
     ) -> Result<v2::MutateRowResponse> {
-        let mutations = object_mutations(metadata.clone(), payload, SystemTime::now())?;
+        let mutations = object_mutations(metadata.clone(), payload)?;
         self.mutate(path, mutations, action).await
     }
 
@@ -813,6 +827,7 @@ impl BigTableBackend {
     /// Best-effort TTI bump for a row.
     ///
     /// If the payload isn't loaded, it will be fetched. Failures are ignored silently.
+    // TODO: extract into dedicated call from service
     async fn bump_tti(&self, path: Vec<u8>, row: &RowData, loaded: bool, hv_id: &ObjectId) {
         let expiration_policy = row.expiration_policy();
 
@@ -833,8 +848,9 @@ impl BigTableBackend {
                 let _ = self.put_tombstone_row(path, &tombstone, "tti-bump").await;
             }
             RowData::Object { metadata, payload } if loaded => {
+                let bumped = bumped_tti_metadata(metadata);
                 let _ = self
-                    .put_row(path, metadata, payload.clone(), "tti-bump")
+                    .put_row(path, &bumped, payload.clone(), "tti-bump")
                     .await;
             }
             RowData::Object { metadata, .. } => {
@@ -843,7 +859,8 @@ impl BigTableBackend {
                     .await;
 
                 if let Ok(Some(RowData::Object { payload, .. })) = payload_read {
-                    let _ = self.put_row(path, metadata, payload, "tti-bump").await;
+                    let bumped = bumped_tti_metadata(metadata);
+                    let _ = self.put_row(path, &bumped, payload, "tti-bump").await;
                 }
             }
         }
@@ -951,7 +968,7 @@ impl HighVolumeBackend for BigTableBackend {
         objectstore_log::debug!("Conditional put to Bigtable backend");
 
         let path = id.as_storage_path().to_string().into_bytes();
-        let mutations = object_mutations(metadata.clone(), payload.to_vec(), SystemTime::now())?;
+        let mutations = object_mutations(metadata.clone(), payload.to_vec())?;
 
         for _ in 0..CAS_RETRY_COUNT {
             let write_succeeded = self
@@ -1118,7 +1135,7 @@ impl HighVolumeBackend for BigTableBackend {
 
         let mutations = match write {
             TieredWrite::Tombstone(tombstone) => tombstone_mutations(&tombstone, now)?.into(),
-            TieredWrite::Object(m, p) => object_mutations(m, p.to_vec(), now)?.into(),
+            TieredWrite::Object(m, p) => object_mutations(m, p.to_vec())?.into(),
             TieredWrite::Delete => vec![delete_row_mutation()],
         };
 
@@ -1141,6 +1158,14 @@ fn ttl_to_micros(ttl: Duration, from: SystemTime) -> Result<i64> {
         ),
         cause: None,
     })?;
+    deadline_to_micros(deadline)
+}
+
+/// Converts an absolute expiration timestamp to a microsecond-precision unix timestamp.
+///
+/// As required by BigTable, the resulting timestamp has millisecond precision, with the last digits
+/// at 0.
+fn deadline_to_micros(deadline: SystemTime) -> Result<i64> {
     let millis = deadline
         .duration_since(SystemTime::UNIX_EPOCH)
         .map_err(|e| Error::Generic {
@@ -1291,7 +1316,13 @@ mod tests {
         now: SystemTime,
     ) -> Result<()> {
         let path = id.as_storage_path().to_string().into_bytes();
-        let mutations = object_mutations(metadata.clone(), payload.to_vec(), now)?;
+        // Resolve `time_expires` from `now` (as `from_insert_headers` does) unless the test set
+        // it explicitly, so `object_mutations` has an expiration to persist.
+        let mut metadata = metadata.clone();
+        if metadata.time_expires.is_none() {
+            metadata.time_expires = metadata.expiration_policy.expires_in().map(|ttl| now + ttl);
+        }
+        let mutations = object_mutations(metadata, payload.to_vec())?;
         backend.mutate(path, mutations, "test-setup").await?;
         Ok(())
     }
@@ -1398,6 +1429,34 @@ mod tests {
         let head_meta = backend.get_metadata(&id).await?.unwrap();
         assert_eq!(head_meta.content_type, metadata.content_type);
         assert_eq!(head_meta.custom, metadata.custom);
+
+        Ok(())
+    }
+
+    /// Verifies that a server-resolved `time_expires` is persisted verbatim, not recomputed.
+    #[tokio::test]
+    async fn test_time_expires_roundtrip() -> Result<()> {
+        let backend = create_test_backend().await?;
+
+        let id = make_id();
+        let ttl = Duration::from_hours(2 * 24);
+        let expires = SystemTime::now() + ttl;
+        let metadata = Metadata {
+            expiration_policy: ExpirationPolicy::TimeToLive(ttl),
+            time_expires: Some(expires),
+            ..Default::default()
+        };
+        create_object(&backend, &id, &metadata, b"data", SystemTime::now()).await?;
+
+        let meta = backend.get_metadata(&id).await?.unwrap();
+        // Bigtable stores the deadline as the GC cell timestamp at millisecond precision.
+        let stored_ms = meta
+            .time_expires
+            .unwrap()
+            .duration_since(SystemTime::UNIX_EPOCH)?
+            .as_millis();
+        let expected_ms = expires.duration_since(SystemTime::UNIX_EPOCH)?.as_millis();
+        assert_eq!(stored_ms, expected_ms);
 
         Ok(())
     }

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -146,9 +146,7 @@ impl GcsObject {
         // For time-based expiration, set the `customTime` field. The bucket must have a
         // `daysSinceCustomTime` lifecycle rule configured to delete objects with this field set.
         // This rule automatically skips objects without `customTime` set.
-        if let Some(expires_in) = metadata.expiration_policy.expires_in() {
-            gcs_object.custom_time = Some(SystemTime::now() + expires_in);
-        }
+        gcs_object.custom_time = metadata.time_expires;
 
         if let Some(compression) = metadata.compression {
             gcs_object.content_encoding = Some(compression.to_string());
@@ -309,8 +307,7 @@ impl Serialize for GcsMetaKey {
 fn metadata_to_gcs_headers(metadata: &Metadata) -> Result<header::HeaderMap> {
     let mut headers = header::HeaderMap::new();
 
-    if let Some(expires_in) = metadata.expiration_policy.expires_in() {
-        let custom_time = SystemTime::now() + expires_in;
+    if let Some(custom_time) = metadata.time_expires {
         let formatted = humantime::format_rfc3339_seconds(custom_time);
         headers.insert(
             HeaderName::from_static("x-goog-custom-time"),
@@ -1137,6 +1134,22 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn from_metadata_uses_provided_time_expires() {
+        let expires = SystemTime::now() + Duration::from_hours(1);
+        let metadata = Metadata {
+            expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_hours(1)),
+            time_expires: Some(expires),
+            ..Default::default()
+        };
+
+        let gcs_object = GcsObject::from_metadata(&metadata);
+        assert_eq!(gcs_object.custom_time, Some(expires));
+
+        let roundtripped = gcs_object.into_metadata().unwrap();
+        assert_eq!(roundtripped.time_expires, Some(expires));
+    }
+
     #[tokio::test]
     async fn test_get_nonexistent() -> Result<()> {
         let backend = create_test_backend().await?;
@@ -1220,6 +1233,7 @@ mod tests {
         let id = make_id();
         let metadata = Metadata {
             expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_secs(0)),
+            time_expires: Some(SystemTime::now()),
             ..Default::default()
         };
 
@@ -1243,6 +1257,7 @@ mod tests {
         let id = make_id();
         let metadata = Metadata {
             expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_secs(0)),
+            time_expires: Some(SystemTime::now()),
             ..Default::default()
         };
 
@@ -1301,6 +1316,7 @@ mod tests {
         let metadata = Metadata {
             content_type: "text/plain".into(),
             expiration_policy: ExpirationPolicy::TimeToIdle(tti),
+            time_expires: Some(SystemTime::now() + tti),
             ..Default::default()
         };
 
@@ -1344,6 +1360,7 @@ mod tests {
         let metadata = Metadata {
             content_type: "text/plain".into(),
             expiration_policy: ExpirationPolicy::TimeToIdle(tti),
+            time_expires: Some(SystemTime::now() + tti),
             ..Default::default()
         };
 
@@ -1741,6 +1758,7 @@ mod tests {
         let id = make_id();
         let metadata = Metadata {
             expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_secs(0)),
+            time_expires: Some(SystemTime::now()),
             ..Default::default()
         };
 
@@ -1758,6 +1776,7 @@ mod tests {
         let id = make_id();
         let metadata = Metadata {
             expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_secs(0)),
+            time_expires: Some(SystemTime::now()),
             ..Default::default()
         };
 

--- a/objectstore-service/src/backend/local_fs.rs
+++ b/objectstore-service/src/backend/local_fs.rs
@@ -469,7 +469,7 @@ mod tests {
             content_type: "text/plain".into(),
             expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_hours(1)),
             time_created: Some(SystemTime::now()),
-            time_expires: None,
+            time_expires: Some(SystemTime::now() + Duration::from_hours(1)),
             compression: Some(Compression::Zstd),
             origin: Some("203.0.113.42".into()),
             filename: Some("hello.txt".into()),

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -128,8 +128,8 @@ fn metadata_to_gcs_headers(
 ) -> Result<HeaderMap, objectstore_types::metadata::Error> {
     let mut headers = metadata.to_headers(prefix)?;
     // GCS custom-time for lifecycle expiration
-    if let Some(expires_in) = metadata.expiration_policy.expires_in() {
-        let expires_at = humantime::format_rfc3339_seconds(SystemTime::now() + expires_in);
+    if let Some(expires_at) = metadata.time_expires {
+        let expires_at = humantime::format_rfc3339_seconds(expires_at);
         headers.append(GCS_CUSTOM_TIME, expires_at.to_string().parse()?);
     }
     Ok(headers)
@@ -224,6 +224,7 @@ where
             None
         };
 
+        // TODO: extract into dedicated call from service
         // TODO: Schedule into background persistently so this doesn't get lost on restarts
         if let ExpirationPolicy::TimeToIdle(tti) = metadata.expiration_policy {
             // TODO: Inject the access time from the request.
@@ -236,7 +237,11 @@ where
                 .unwrap_or(access_time);
 
             if expire_at < access_time + tti - TTI_DEBOUNCE {
-                self.update_metadata(id, &metadata).await?;
+                // The write helper persists `time_expires` verbatim, so refresh it to the bumped
+                // deadline here. The returned `metadata` keeps the pre-access value.
+                let mut bumped = metadata.clone();
+                bumped.time_expires = Some(access_time + tti);
+                self.update_metadata(id, &bumped).await?;
             }
         }
 
@@ -381,6 +386,23 @@ mod tests {
             usecase: "testing".into(),
             scopes: Scopes::from_iter([Scope::create("testing", "value").unwrap()]),
         })
+    }
+
+    #[test]
+    fn metadata_to_gcs_headers_uses_time_expires() {
+        let expires = SystemTime::now() + Duration::from_hours(1);
+        let metadata = Metadata {
+            expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_hours(1)),
+            time_expires: Some(expires),
+            ..Default::default()
+        };
+
+        let headers = metadata_to_gcs_headers(&metadata, GCS_CUSTOM_PREFIX).unwrap();
+
+        // The lifecycle custom-time is the server-resolved expiry (second precision).
+        let custom_time = headers.get(GCS_CUSTOM_TIME).unwrap().to_str().unwrap();
+        let expected = humantime::format_rfc3339_seconds(expires).to_string();
+        assert_eq!(custom_time, expected);
     }
 
     #[tokio::test]

--- a/objectstore-service/src/service.rs
+++ b/objectstore-service/src/service.rs
@@ -200,6 +200,7 @@ impl StorageService {
         metadata: Metadata,
         stream: ClientStream,
     ) -> Result<InsertResponse> {
+        metadata.validate()?;
         let id = ObjectId::optional(context, key);
         let inner = Arc::clone(&self.inner);
         self.spawn("insert", async move {
@@ -253,6 +254,7 @@ impl StorageService {
         id: ObjectId,
         metadata: Metadata,
     ) -> Result<InitiateMultipartResponse> {
+        metadata.validate()?;
         self.inner.as_multipart_upload_backend()?; // Fail before clone/spawn if unsupported
         let inner = self.inner.clone();
         self.spawn("initiate_multipart", async move {

--- a/objectstore-types/src/metadata.rs
+++ b/objectstore-types/src/metadata.rs
@@ -290,12 +290,20 @@ impl Metadata {
     /// Parses the metadata headers accepted from writing endpoints.
     ///
     /// Unlike [`from_headers`](Self::from_headers), this skips read-only and output attributes so
-    /// clients cannot set them via headers.
+    /// clients cannot set them via headers. It stamps [`time_created`](Self::time_created) and
+    /// resolves [`time_expires`](Self::time_expires) from the expiration policy, giving every
+    /// backend a single, consistent expiration to persist.
     ///
     /// A prefix can also be provided which is stripped from custom non-standard headers.
     pub fn from_insert_headers(headers: &HeaderMap, prefix: &str) -> Result<Self, Error> {
         let mut metadata = Self::parse_headers(headers, prefix, true)?;
-        metadata.time_created = Some(SystemTime::now());
+
+        // Resolve both timestamps from a single `now` so every backend persists the same
+        // expiration instead of each recomputing it at write time.
+        let now = SystemTime::now();
+        metadata.time_created = Some(now);
+        metadata.time_expires = metadata.expiration_policy.expires_in().map(|ttl| now + ttl);
+
         Ok(metadata)
     }
 
@@ -627,6 +635,37 @@ mod tests {
 
         let metadata = Metadata::from_insert_headers(&headers, "").unwrap();
         assert!(metadata.time_created.is_some());
+        assert!(metadata.time_expires.is_none());
+    }
+
+    #[test]
+    fn from_insert_headers_resolves_time_expires_for_ttl() {
+        let mut headers = HeaderMap::new();
+        headers.insert(HEADER_EXPIRATION, "ttl:30s".parse().unwrap());
+
+        let metadata = Metadata::from_insert_headers(&headers, "").unwrap();
+        let created = metadata.time_created.unwrap();
+        let expires = metadata.time_expires.unwrap();
+        // Both timestamps derive from the same `now`, so the expiry is exact.
+        assert_eq!(expires, created + Duration::from_secs(30));
+    }
+
+    #[test]
+    fn from_insert_headers_resolves_time_expires_for_tti() {
+        let mut headers = HeaderMap::new();
+        headers.insert(HEADER_EXPIRATION, "tti:1h".parse().unwrap());
+
+        let metadata = Metadata::from_insert_headers(&headers, "").unwrap();
+        let created = metadata.time_created.unwrap();
+        let expires = metadata.time_expires.unwrap();
+        assert_eq!(expires, created + Duration::from_hours(1));
+    }
+
+    #[test]
+    fn from_insert_headers_manual_leaves_time_expires_none() {
+        let headers = HeaderMap::new();
+        let metadata = Metadata::from_insert_headers(&headers, "").unwrap();
+        assert_eq!(metadata.expiration_policy, ExpirationPolicy::Manual);
         assert!(metadata.time_expires.is_none());
     }
 

--- a/objectstore-types/src/metadata.rs
+++ b/objectstore-types/src/metadata.rs
@@ -74,6 +74,9 @@ pub enum Error {
     /// The creation time is invalid.
     #[error("invalid creation time")]
     CreationTime(#[from] humantime::TimestampError),
+    /// An internal consistency invariant on the metadata was violated.
+    #[error("invariant violation: {0}")]
+    Invariant(&'static str),
 }
 impl From<header::InvalidHeaderValue> for Error {
     fn from(err: header::InvalidHeaderValue) -> Self {
@@ -289,22 +292,36 @@ pub struct Metadata {
 impl Metadata {
     /// Parses the metadata headers accepted from writing endpoints.
     ///
-    /// Unlike [`from_headers`](Self::from_headers), this skips read-only and output attributes so
-    /// clients cannot set them via headers. It stamps [`time_created`](Self::time_created) and
-    /// resolves [`time_expires`](Self::time_expires) from the expiration policy, giving every
-    /// backend a single, consistent expiration to persist.
+    /// Unlike [`from_headers`](Self::from_headers), this skips parsing read-only attributes so
+    /// clients cannot set them via headers.
+    ///
+    /// This materializes the following attributes:
+    /// - [`time_created`](Self::time_created)
+    /// - [`time_expires`](Self::time_expires)
     ///
     /// A prefix can also be provided which is stripped from custom non-standard headers.
     pub fn from_insert_headers(headers: &HeaderMap, prefix: &str) -> Result<Self, Error> {
         let mut metadata = Self::parse_headers(headers, prefix, true)?;
 
-        // Resolve both timestamps from a single `now` so every backend persists the same
-        // expiration instead of each recomputing it at write time.
         let now = SystemTime::now();
         metadata.time_created = Some(now);
         metadata.time_expires = metadata.expiration_policy.expires_in().map(|ttl| now + ttl);
 
         Ok(metadata)
+    }
+
+    /// Validates internal consistency of the metadata.
+    ///
+    /// A time-based [`expiration_policy`](Self::expiration_policy) must carry a resolved
+    /// [`time_expires`](Self::time_expires); backends rely on this to persist a concrete
+    /// expiration.
+    pub fn validate(&self) -> Result<(), Error> {
+        if self.expiration_policy.is_timeout() && self.time_expires.is_none() {
+            return Err(Error::Invariant(
+                "expiration policy requires a resolved expiration time",
+            ));
+        }
+        Ok(())
     }
 
     /// Extracts public API metadata from the given [`HeaderMap`].
@@ -667,6 +684,32 @@ mod tests {
         let metadata = Metadata::from_insert_headers(&headers, "").unwrap();
         assert_eq!(metadata.expiration_policy, ExpirationPolicy::Manual);
         assert!(metadata.time_expires.is_none());
+    }
+
+    #[test]
+    fn validate_accepts_resolved_timeout() {
+        let metadata = Metadata {
+            expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_secs(30)),
+            time_expires: Some(SystemTime::now() + Duration::from_secs(30)),
+            ..Default::default()
+        };
+        assert!(metadata.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_manual_without_expiry() {
+        let metadata = Metadata::default();
+        assert!(metadata.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_timeout_without_expiry() {
+        let metadata = Metadata {
+            expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_hours(1)),
+            time_expires: None,
+            ..Default::default()
+        };
+        assert!(matches!(metadata.validate(), Err(Error::Invariant(_))));
     }
 
     #[test]


### PR DESCRIPTION
Object expiration timestamps were resolved independently by each backend, which
recomputed `now() + ttl` at write time. That let the persisted `time_created` and
the effective `time_expires` drift apart, and in a tiered setup the high-volume and
long-term backends could stamp different expirations for the same object.

`time_expires` is now resolved once directly when constructing metadata from
headers (`Metadata::from_insert_headers`) — from the expiration policy and the same
`now` used for `time_created` — and every backend persists that value verbatim (GCS
`customTime`, the S3 custom-time header, and the Bigtable GC cell timestamp).
Objects without a timeout policy carry no expiration, as before. This ensures the
timestamps stay consistent across tiered storage.

TTI idle bumps are intentionally out of scope. They still recompute `now() + tti`
at the bump site and write the refreshed value into `time_expires` so the shared
write helpers stay uniform; making the bump path itself the single source of truth
is left to a follow-up (marked with TODOs).

Stacked on #535.