### PR TITLE
fix(gcs+s3): Drain response bodies

### DIFF
--- a/objectstore-service/src/backend/common.rs
+++ b/objectstore-service/src/backend/common.rs
@@ -264,6 +264,15 @@ impl TieredWrite {
     }
 }
 
+/// Drains the body of a response we are otherwise done with.
+///
+/// reqwest only returns a connection to its pool once the response body has been fully read, so we
+/// need to explicitly drain it.
+/// Errors are swallowed, since the caller has already obtained everything it needs from the response.
+pub async fn consume_body(mut response: reqwest::Response) {
+    while let Ok(Some(_)) = response.chunk().await {}
+}
+
 /// Creates a reqwest client with required defaults.
 ///
 /// Automatic decompression is disabled because backends store pre-compressed

--- a/objectstore-service/src/backend/common.rs
+++ b/objectstore-service/src/backend/common.rs
@@ -264,15 +264,6 @@ impl TieredWrite {
     }
 }
 
-/// Drains the body of a response we are otherwise done with.
-///
-/// reqwest only returns a connection to its pool once the response body has been fully read, so we
-/// need to explicitly drain it.
-/// Errors are swallowed, since the caller has already obtained everything it needs from the response.
-pub async fn consume_body(mut response: reqwest::Response) {
-    while let Ok(Some(_)) = response.chunk().await {}
-}
-
 /// Creates a reqwest client with required defaults.
 ///
 /// Automatic decompression is disabled because backends store pre-compressed

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use super::response::ResponseExt;
 use crate::backend::common::{
     self, Backend, DeleteResponse, GetResponse, MetadataResponse, MultipartUploadBackend,
-    PutResponse, consume_body,
+    PutResponse,
 };
 use crate::error::{Error, Result};
 use crate::gcp_auth::PrefetchingTokenProvider;
@@ -540,7 +540,7 @@ impl GcsBackend {
                     .map_err(|e| Error::reqwest("GCS: get metadata request", e))?;
 
                 if resp.status() == StatusCode::NOT_FOUND {
-                    consume_body(resp).await;
+                    resp.drain_body().await;
                     return Ok(None);
                 }
 
@@ -593,15 +593,15 @@ impl GcsBackend {
         }
 
         self.with_retry("update_custom_time", || async {
-            let resp = self
-                .request(Method::PATCH, object_url.clone())
+            self.request(Method::PATCH, object_url.clone())
                 .await?
                 .json(&CustomTimeRequest { custom_time })
                 .send()
                 .await
                 .check_error("GCS: update custom time")
-                .await?;
-            consume_body(resp).await;
+                .await?
+                .drain_body()
+                .await;
             Ok(())
         })
         .await
@@ -666,16 +666,16 @@ impl Backend for GcsBackend {
         // set the header *after* writing the multipart form into the request.
         let content_type = format!("multipart/related; boundary={}", multipart.boundary());
 
-        let resp = self
-            .request(Method::POST, self.upload_url(id, "multipart")?)
+        self.request(Method::POST, self.upload_url(id, "multipart")?)
             .await?
             .multipart(multipart)
             .header(header::CONTENT_TYPE, content_type)
             .send()
             .await
             .check_error("GCS: upload object")
-            .await?;
-        consume_body(resp).await;
+            .await?
+            .drain_body()
+            .await;
 
         Ok(())
     }
@@ -711,14 +711,11 @@ impl Backend for GcsBackend {
                     let total = raw.and_then(ContentRange::parse_unsatisfiable_total);
                     let err = match total {
                         Some(total) => Error::RangeNotSatisfiable { total },
-                        None => Error::Generic {
-                            context: format!(
-                                "GCS: 416 response with invalid Content-Range: {raw:?}"
-                            ),
-                            cause: None,
-                        },
+                        None => Error::generic(format!(
+                            "GCS: 416 response with invalid Content-Range: {raw:?}"
+                        )),
                     };
-                    consume_body(resp).await;
+                    resp.drain_body().await;
                     return Err(err);
                 }
 
@@ -772,12 +769,14 @@ impl Backend for GcsBackend {
 
             // Do not error for objects that do not exist
             if resp.status() == StatusCode::NOT_FOUND {
-                consume_body(resp).await;
+                resp.drain_body().await;
                 return Ok(());
             }
 
-            let resp = resp.check_error("GCS: delete object").await?;
-            consume_body(resp).await;
+            resp.check_error("GCS: delete object")
+                .await?
+                .drain_body()
+                .await;
 
             Ok(())
         })
@@ -970,7 +969,7 @@ impl MultipartUploadBackend for GcsBackend {
             .map(|s| s.to_owned())
             .ok_or_else(|| Error::generic("GCS: upload part response missing ETag header"))?;
 
-        consume_body(resp).await;
+        resp.drain_body().await;
 
         Ok(etag)
     }
@@ -1028,14 +1027,14 @@ impl MultipartUploadBackend for GcsBackend {
         let mut url = self.xml_object_url(id)?;
         url.query_pairs_mut().append_pair("uploadId", upload_id);
 
-        let resp = self
-            .request(Method::DELETE, url)
+        self.request(Method::DELETE, url)
             .await?
             .send()
             .await
             .check_error("GCS: abort multipart upload")
-            .await?;
-        consume_body(resp).await;
+            .await?
+            .drain_body()
+            .await;
 
         Ok(())
     }

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use super::response::ResponseExt;
 use crate::backend::common::{
     self, Backend, DeleteResponse, GetResponse, MetadataResponse, MultipartUploadBackend,
-    PutResponse,
+    PutResponse, consume_body,
 };
 use crate::error::{Error, Result};
 use crate::gcp_auth::PrefetchingTokenProvider;
@@ -540,6 +540,7 @@ impl GcsBackend {
                     .map_err(|e| Error::reqwest("GCS: get metadata request", e))?;
 
                 if resp.status() == StatusCode::NOT_FOUND {
+                    consume_body(resp).await;
                     return Ok(None);
                 }
 
@@ -592,13 +593,15 @@ impl GcsBackend {
         }
 
         self.with_retry("update_custom_time", || async {
-            self.request(Method::PATCH, object_url.clone())
+            let resp = self
+                .request(Method::PATCH, object_url.clone())
                 .await?
                 .json(&CustomTimeRequest { custom_time })
                 .send()
                 .await
                 .check_error("GCS: update custom time")
                 .await?;
+            consume_body(resp).await;
             Ok(())
         })
         .await
@@ -663,7 +666,8 @@ impl Backend for GcsBackend {
         // set the header *after* writing the multipart form into the request.
         let content_type = format!("multipart/related; boundary={}", multipart.boundary());
 
-        self.request(Method::POST, self.upload_url(id, "multipart")?)
+        let resp = self
+            .request(Method::POST, self.upload_url(id, "multipart")?)
             .await?
             .multipart(multipart)
             .header(header::CONTENT_TYPE, content_type)
@@ -671,6 +675,7 @@ impl Backend for GcsBackend {
             .await
             .check_error("GCS: upload object")
             .await?;
+        consume_body(resp).await;
 
         Ok(())
     }
@@ -704,17 +709,17 @@ impl Backend for GcsBackend {
                         .get(header::CONTENT_RANGE)
                         .and_then(|v| v.to_str().ok());
                     let total = raw.and_then(ContentRange::parse_unsatisfiable_total);
-                    match total {
-                        Some(total) => return Err(Error::RangeNotSatisfiable { total }),
-                        None => {
-                            return Err(Error::Generic {
-                                context: format!(
-                                    "GCS: 416 response with invalid Content-Range: {raw:?}"
-                                ),
-                                cause: None,
-                            });
-                        }
-                    }
+                    let err = match total {
+                        Some(total) => Error::RangeNotSatisfiable { total },
+                        None => Error::Generic {
+                            context: format!(
+                                "GCS: 416 response with invalid Content-Range: {raw:?}"
+                            ),
+                            cause: None,
+                        },
+                    };
+                    consume_body(resp).await;
+                    return Err(err);
                 }
 
                 resp.check_error("GCS: get payload").await
@@ -767,10 +772,12 @@ impl Backend for GcsBackend {
 
             // Do not error for objects that do not exist
             if resp.status() == StatusCode::NOT_FOUND {
+                consume_body(resp).await;
                 return Ok(());
             }
 
-            resp.check_error("GCS: delete object").await?;
+            let resp = resp.check_error("GCS: delete object").await?;
+            consume_body(resp).await;
 
             Ok(())
         })
@@ -963,6 +970,8 @@ impl MultipartUploadBackend for GcsBackend {
             .map(|s| s.to_owned())
             .ok_or_else(|| Error::generic("GCS: upload part response missing ETag header"))?;
 
+        consume_body(resp).await;
+
         Ok(etag)
     }
 
@@ -1019,12 +1028,14 @@ impl MultipartUploadBackend for GcsBackend {
         let mut url = self.xml_object_url(id)?;
         url.query_pairs_mut().append_pair("uploadId", upload_id);
 
-        self.request(Method::DELETE, url)
+        let resp = self
+            .request(Method::DELETE, url)
             .await?
             .send()
             .await
             .check_error("GCS: abort multipart upload")
             .await?;
+        consume_body(resp).await;
 
         Ok(())
     }

--- a/objectstore-service/src/backend/response.rs
+++ b/objectstore-service/src/backend/response.rs
@@ -8,7 +8,6 @@
 use reqwest::{Response, header};
 use serde::Deserialize;
 
-use crate::backend::common::consume_body;
 use crate::error::{BackendDetail, Error, Result};
 use crate::stream;
 
@@ -67,6 +66,13 @@ pub trait ResponseExt {
     /// When called on `Result<Response, reqwest::Error>`, transport errors are
     /// wrapped as [`Error::Reqwest`] with the same context string.
     async fn check_error(self, context: &'static str) -> Result<Response>;
+
+    /// Drains the response body of a response we are otherwise done with.
+    ///
+    /// reqwest only returns a connection to its pool once the response body has been fully read, so
+    /// we need to explicitly drain it. Errors are swallowed, since the caller has already obtained
+    /// everything it needs from the response.
+    async fn drain_body(self);
 }
 
 impl ResponseExt for Response {
@@ -90,7 +96,7 @@ impl ResponseExt for Response {
             let Err(e) = self.error_for_status_ref() else {
                 return Ok(self);
             };
-            consume_body(self).await;
+            self.drain_body().await;
             return Err(Error::reqwest(context, e));
         };
 
@@ -99,6 +105,10 @@ impl ResponseExt for Response {
             status,
             detail,
         })
+    }
+
+    async fn drain_body(mut self) {
+        while let Ok(Some(_)) = self.chunk().await {}
     }
 }
 
@@ -110,6 +120,12 @@ impl ResponseExt for Result<Response, reqwest::Error> {
                 Some(ce) => Error::Client(ce),
                 None => Error::reqwest(context, e),
             }),
+        }
+    }
+
+    async fn drain_body(self) {
+        if let Ok(resp) = self {
+            resp.drain_body().await;
         }
     }
 }

--- a/objectstore-service/src/backend/response.rs
+++ b/objectstore-service/src/backend/response.rs
@@ -8,6 +8,7 @@
 use reqwest::{Response, header};
 use serde::Deserialize;
 
+use crate::backend::common::consume_body;
 use crate::error::{BackendDetail, Error, Result};
 use crate::stream;
 
@@ -86,9 +87,11 @@ impl ResponseExt for Response {
         } else if ct.starts_with("application/xml") || ct.starts_with("text/xml") {
             parse_xml_error(self).await
         } else {
-            return self
-                .error_for_status()
-                .map_err(|e| Error::reqwest(context, e));
+            let Err(e) = self.error_for_status_ref() else {
+                return Ok(self);
+            };
+            consume_body(self).await;
+            return Err(Error::reqwest(context, e));
         };
 
         Err(Error::BackendResponse {

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -179,6 +179,7 @@ where
 
         if response.status() == StatusCode::NOT_FOUND {
             objectstore_log::debug!("Object not found");
+            response.drain_body().await;
             return Ok(None);
         }
 
@@ -188,15 +189,14 @@ where
                 .get(reqwest::header::CONTENT_RANGE)
                 .and_then(|v| v.to_str().ok());
             let total = raw.and_then(ContentRange::parse_unsatisfiable_total);
-            match total {
-                Some(total) => return Err(Error::RangeNotSatisfiable { total }),
-                None => {
-                    return Err(Error::Generic {
-                        context: format!("S3: 416 response with invalid Content-Range: {raw:?}"),
-                        cause: None,
-                    });
-                }
-            }
+            let err = match total {
+                Some(total) => Error::RangeNotSatisfiable { total },
+                None => Error::generic(format!(
+                    "S3: 416 response with invalid Content-Range: {raw:?}"
+                )),
+            };
+            response.drain_body().await;
+            return Err(err);
         }
 
         let response = response.check_error("S3: failed to get object").await?;
@@ -258,7 +258,9 @@ where
             .send()
             .await
             .check_error("S3: update expiration time")
-            .await?;
+            .await?
+            .drain_body()
+            .await;
 
         Ok(())
     }
@@ -307,7 +309,9 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
             .send()
             .await
             .check_error("S3: failed to put object")
-            .await?;
+            .await?
+            .drain_body()
+            .await;
 
         Ok(())
     }
@@ -347,9 +351,16 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
             })?;
 
         // Do not error for objects that do not exist.
-        if response.status() != StatusCode::NOT_FOUND {
-            response.check_error("S3: failed to delete object").await?;
+        if response.status() == StatusCode::NOT_FOUND {
+            response.drain_body().await;
+            return Ok(());
         }
+
+        response
+            .check_error("S3: failed to delete object")
+            .await?
+            .drain_body()
+            .await;
 
         Ok(())
     }


### PR DESCRIPTION
Introduces a `drain_body` util on our extension trait to consume reqwests' response bodies (works on `reqwest::Response` and `Result<reqwest::Response, reqwest::Error`, and uses it where needed.
This is needed to allow `reqwest` to reuse a connection cleanly, without an explicit reset.

Without this, too many calls where the body is ignored in a short time would result in an internal error from `h2` itself: `too_many_internal_resets`. This was tested with PUT requests to GCS, where we observed around 1% of requests in the test failing due to that error.