### PR TITLE
feat(types): Add pre-signed URL utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2784,7 +2784,6 @@ dependencies = [
  "humantime-serde",
  "insta",
  "mediatype",
- "percent-encoding",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,15 +456,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,15 +734,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,24 +742,8 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest 0.10.7",
- "fiat-crypto 0.2.9",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "curve25519-dalek-derive",
- "digest 0.11.3",
- "fiat-crypto 0.3.0",
+ "digest",
+ "fiat-crypto",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -895,20 +861,10 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.1.6",
+ "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.1",
- "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -951,10 +907,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
- "signature 2.2.0",
+ "signature",
  "spki",
 ]
 
@@ -965,16 +921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
- "signature 2.2.0",
-]
-
-[[package]]
-name = "ed25519"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
-dependencies = [
- "signature 3.0.0",
+ "signature",
 ]
 
 [[package]]
@@ -983,23 +930,10 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek 4.1.3",
- "ed25519 2.2.3",
+ "curve25519-dalek",
+ "ed25519",
  "serde",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
-dependencies = [
- "curve25519-dalek 5.0.0",
- "ed25519 3.0.0",
- "sha2 0.11.0",
+ "sha2",
  "subtle",
  "zeroize",
 ]
@@ -1030,7 +964,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
@@ -1112,12 +1046,6 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
-name = "fiat-crypto"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "figment"
@@ -1559,7 +1487,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1643,15 +1571,6 @@ checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
 dependencies = [
  "humantime",
  "serde",
-]
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
-dependencies = [
- "typenum",
 ]
 
 [[package]]
@@ -2122,7 +2041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "base64",
- "ed25519-dalek 2.2.0",
+ "ed25519-dalek",
  "getrandom 0.2.17",
  "hmac",
  "js-sys",
@@ -2133,8 +2052,8 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2 0.10.9",
- "signature 2.2.0",
+ "sha2",
+ "signature",
  "simple_asn1",
  "zeroize",
 ]
@@ -2859,7 +2778,7 @@ name = "objectstore-types"
 version = "0.1.12"
 dependencies = [
  "base64",
- "ed25519-dalek 3.0.0",
+ "ed25519-dalek",
  "http 1.4.2",
  "humantime",
  "humantime-serde",
@@ -2958,7 +2877,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -2970,7 +2889,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -3720,14 +3639,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
  "const-oid",
- "digest 0.10.7",
+ "digest",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
- "signature 2.2.0",
+ "signature",
  "spki",
  "subtle",
  "zeroize",
@@ -4235,18 +4154,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -4280,15 +4188,9 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "rand_core 0.6.4",
 ]
-
-[[package]]
-name = "signature"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
 name = "simd-adler32"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2777,11 +2777,14 @@ dependencies = [
 name = "objectstore-types"
 version = "0.1.12"
 dependencies = [
+ "base64",
+ "ed25519-dalek",
  "http 1.4.2",
  "humantime",
  "humantime-serde",
  "insta",
  "mediatype",
+ "percent-encoding",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,6 +456,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,6 +743,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,8 +760,24 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
+ "digest 0.10.7",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -861,10 +895,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -907,10 +951,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "signature",
+ "signature 2.2.0",
  "spki",
 ]
 
@@ -921,7 +965,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
- "signature",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "signature 3.0.0",
 ]
 
 [[package]]
@@ -930,10 +983,23 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
  "serde",
- "sha2",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "ed25519 3.0.0",
+ "sha2 0.11.0",
  "subtle",
  "zeroize",
 ]
@@ -964,7 +1030,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -1046,6 +1112,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "figment"
@@ -1487,7 +1559,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1571,6 +1643,15 @@ checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
 dependencies = [
  "humantime",
  "serde",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -2041,7 +2122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "base64",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "getrandom 0.2.17",
  "hmac",
  "js-sys",
@@ -2052,8 +2133,8 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2",
- "signature",
+ "sha2 0.10.9",
+ "signature 2.2.0",
  "simple_asn1",
  "zeroize",
 ]
@@ -2778,7 +2859,7 @@ name = "objectstore-types"
 version = "0.1.12"
 dependencies = [
  "base64",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "http 1.4.2",
  "humantime",
  "humantime-serde",
@@ -2877,7 +2958,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2889,7 +2970,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3639,14 +3720,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
  "const-oid",
- "digest",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
- "signature",
+ "signature 2.2.0",
  "spki",
  "subtle",
  "zeroize",
@@ -4154,7 +4235,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4188,9 +4280,15 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
 name = "simd-adler32"
@@ -4845,9 +4943,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typetag"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ bytes = "1.12.0"
 bytesize = "2.4.0"
 chrono = "0.4.45"
 console = "0.16.3"
+ed25519-dalek = { version = "2.2.0", features = ["pkcs8", "pem"] }
 elegant-departure = "0.3.2"
 figment = "0.10.19"
 futures = "0.3.32"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ bytes = "1.12.0"
 bytesize = "2.4.0"
 chrono = "0.4.45"
 console = "0.16.3"
-ed25519-dalek = { version = "3.0.0" }
+ed25519-dalek = { version = "2.2.0" }
 elegant-departure = "0.3.2"
 figment = "0.10.19"
 futures = "0.3.32"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ bytes = "1.12.0"
 bytesize = "2.4.0"
 chrono = "0.4.45"
 console = "0.16.3"
-ed25519-dalek = { version = "2.2.0", features = ["pkcs8", "pem"] }
+ed25519-dalek = { version = "3.0.0" }
 elegant-departure = "0.3.2"
 figment = "0.10.19"
 futures = "0.3.32"

--- a/objectstore-types/Cargo.toml
+++ b/objectstore-types/Cargo.toml
@@ -16,7 +16,6 @@ http = { workspace = true }
 humantime = { workspace = true }
 humantime-serde = { workspace = true }
 mediatype = { workspace = true }
-percent-encoding = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 

--- a/objectstore-types/Cargo.toml
+++ b/objectstore-types/Cargo.toml
@@ -10,10 +10,13 @@ edition = "2024"
 publish = true
 
 [dependencies]
+base64 = { workspace = true }
+ed25519-dalek = { workspace = true }
 http = { workspace = true }
 humantime = { workspace = true }
 humantime-serde = { workspace = true }
 mediatype = { workspace = true }
+percent-encoding = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 

--- a/objectstore-types/src/lib.rs
+++ b/objectstore-types/src/lib.rs
@@ -8,5 +8,6 @@
 pub mod auth;
 pub mod metadata;
 pub mod multipart;
+pub mod presign;
 pub mod range;
 pub mod scope;

--- a/objectstore-types/src/presign.rs
+++ b/objectstore-types/src/presign.rs
@@ -89,11 +89,17 @@ pub enum PresignError {
 /// normalized to `GET`, and [`X_OS_SIG`] is excluded from the canonical query
 /// string.
 ///
-/// `path` must be the request path as it appears in the URL (the same value the
-/// signer put on the wire and the verifier reads back, e.g. `uri.path()`); it is
-/// percent-encoded wholesale. `query` is the list of decoded query parameter
-/// key/value pairs; they are re-encoded canonically here, so ordering of the
-/// input does not matter.
+/// `path` is percent-encoded wholesale here (the `/` separators are deliberately
+/// not treated specially). This function is oblivious to the path's contents;
+/// correctness only requires that the signer and verifier pass **byte-identical**
+/// path strings. The natural choice is the raw path exactly as it appears in the
+/// request line — `uri.path()` on the server, and the equivalent from the built URL
+/// on the client. Do **not** percent-decode it first: decoding is lossy (`%2F` and a
+/// literal `/` collapse to the same byte), which would weaken the signature and risk
+/// a signer/verifier mismatch.
+///
+/// `query` is the list of decoded query parameter key/value pairs; they are
+/// re-encoded canonically here, so ordering of the input does not matter.
 ///
 /// `signed_headers` is the list of request headers named by `X-Os-Signed-Headers`
 /// (name/value pairs); names are lowercased, values are whitespace-trimmed, and

--- a/objectstore-types/src/presign.rs
+++ b/objectstore-types/src/presign.rs
@@ -227,9 +227,9 @@ mod tests {
             "/v1/objects/testing/_/key",
             Some(sample_query()),
         );
-        let signature = canonical.sign(&sk.as_bytes());
+        let signature = canonical.sign(sk.as_bytes());
 
-        assert_eq!(canonical.verify(&vk.as_bytes(), &signature), Ok(()));
+        assert_eq!(canonical.verify(vk.as_bytes(), &signature), Ok(()));
     }
 
     #[test]
@@ -242,7 +242,7 @@ mod tests {
             "/v1/objects/testing/_/key",
             Some(sample_query()),
         );
-        let signature = canonical.sign(&sk.as_bytes());
+        let signature = canonical.sign(sk.as_bytes());
 
         let tampered = CanonicalRequest::new(
             &Method::GET,
@@ -250,7 +250,7 @@ mod tests {
             Some(sample_query()),
         );
         assert_eq!(
-            tampered.verify(&vk.as_bytes(), &signature),
+            tampered.verify(vk.as_bytes(), &signature),
             Err(Error::VerificationFailed)
         );
     }
@@ -265,10 +265,10 @@ mod tests {
             "/v1/objects/testing/_/key",
             Some(sample_query()),
         );
-        let signature = canonical.sign(&sk.as_bytes());
+        let signature = canonical.sign(sk.as_bytes());
 
         assert_eq!(
-            canonical.verify(&other_vk.as_bytes(), &signature),
+            canonical.verify(other_vk.as_bytes(), &signature),
             Err(Error::VerificationFailed)
         );
     }
@@ -284,12 +284,12 @@ mod tests {
 
         // Not valid base64url.
         assert_eq!(
-            canonical.verify(&vk.as_bytes(), "not valid base64!!"),
+            canonical.verify(vk.as_bytes(), "not valid base64!!"),
             Err(Error::InvalidSignatureEncoding)
         );
         // Valid base64url but not a 64-byte signature.
         assert_eq!(
-            canonical.verify(&vk.as_bytes(), &URL_SAFE_NO_PAD.encode([0u8; 10])),
+            canonical.verify(vk.as_bytes(), &URL_SAFE_NO_PAD.encode([0u8; 10])),
             Err(Error::InvalidSignatureEncoding)
         );
     }

--- a/objectstore-types/src/presign.rs
+++ b/objectstore-types/src/presign.rs
@@ -102,7 +102,8 @@ impl CanonicalRequest {
                     let key = key.to_ascii_lowercase();
                     (key != "x-os-sig").then(|| format!("{key}={value}"))
                 } else {
-                    Some(pair.to_ascii_lowercase())
+                    let key = pair.to_ascii_lowercase();
+                    (key != "x-os-sig").then_some(key)
                 }
             })
             .collect();
@@ -206,6 +207,16 @@ mod tests {
              x-os-key-id=relay&\
              x-os-timestamp=1985-04-12T23:20:50.52Z"
         );
+    }
+
+    #[test]
+    fn key_only_sig_param_is_excluded() {
+        let canonical = CanonicalRequest::new(
+            &Method::GET,
+            "/v1/objects/testing/_/key",
+            Some("a=1&X-Os-Sig&b=2"),
+        );
+        assert_eq!(canonical.0, "GET\n/v1/objects/testing/_/key\na=1&b=2");
     }
 
     #[test]

--- a/objectstore-types/src/presign.rs
+++ b/objectstore-types/src/presign.rs
@@ -210,16 +210,6 @@ mod tests {
     }
 
     #[test]
-    fn key_only_sig_param_is_excluded() {
-        let canonical = CanonicalRequest::new(
-            &Method::GET,
-            "/v1/objects/testing/_/key",
-            Some("a=1&X-Os-Sig&b=2"),
-        );
-        assert_eq!(canonical.0, "GET\n/v1/objects/testing/_/key\na=1&b=2");
-    }
-
-    #[test]
     fn head_is_normalized_to_get() {
         let path = "/v1/objects/testing/_/key";
         assert_eq!(

--- a/objectstore-types/src/presign.rs
+++ b/objectstore-types/src/presign.rs
@@ -7,10 +7,10 @@
 //!
 //! ```text
 //! GET /v1/objects/<usecase>/<scopes>/<key>
-//!     ?X-Os-Timestamp=2026-04-20T13:37:00.00Z
-//!     &X-Os-Expires=3600
-//!     &X-Os-Key-Id=relay
-//!     &X-Os-Sig=<signature>
+//!     ?os-timestamp=2026-04-20T13:37:00.00Z
+//!     &os-duration=3600
+//!     &os-kid=relay
+//!     &os-sig=<signature>
 //! ```
 //!
 //! The signature covers a **canonical form** (see below) of the request.
@@ -27,7 +27,7 @@
 //!
 //! - normalized method: the uppercase HTTP method, with `HEAD` mapped to `GET`;
 //! - path: the request path, included verbatim as transmitted/received on the wire;
-//! - canonical query string: every query parameter except `X-Os-Sig`, with keys
+//! - canonical query string: every query parameter except `os-sig`, with keys
 //!   lowercased, sorted lexicographically by name and value, joined with `&`.
 
 use base64::Engine as _;
@@ -38,16 +38,16 @@ use http::Method;
 pub use ed25519_dalek::{SigningKey as DalekSigningKey, VerifyingKey as DalekVerifyingKey};
 
 /// Query parameter carrying the time at which the request was signed.
-pub const X_OS_TIMESTAMP: &str = "X-Os-Timestamp";
+pub const PARAM_TIMESTAMP: &str = "os-timestamp";
 
 /// Query parameter carrying the validity duration, in seconds.
-pub const X_OS_EXPIRES: &str = "X-Os-Expires";
+pub const PARAM_DURATION: &str = "os-duration";
 
 /// Query parameter naming the key ID used to sign the request.
-pub const X_OS_KEY_ID: &str = "X-Os-Key-Id";
+pub const PARAM_KID: &str = "os-kid";
 
 /// Query parameter carrying the base64url-encoded signature.
-pub const X_OS_SIG: &str = "X-Os-Sig";
+pub const PARAM_SIG: &str = "os-sig";
 
 /// Errors returned when verifying a pre-signed request signature.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -100,10 +100,10 @@ impl CanonicalRequest {
             .filter_map(|pair| {
                 if let Some((key, value)) = pair.split_once('=') {
                     let key = key.to_ascii_lowercase();
-                    (key != "x-os-sig").then(|| format!("{key}={value}"))
+                    (key != PARAM_SIG).then(|| format!("{key}={value}"))
                 } else {
                     let key = pair.to_ascii_lowercase();
-                    (key != "x-os-sig").then_some(key)
+                    (key != PARAM_SIG).then_some(key)
                 }
             })
             .collect();
@@ -116,7 +116,7 @@ impl CanonicalRequest {
     /// Signs this canonical form with Ed25519.
     ///
     /// Returns the base64url-encoded signature, suitable as the value of the
-    /// [`X_OS_SIG`] query parameter.
+    /// [`PARAM_SIG`] query parameter.
     pub fn sign(&self, key: &SigningKey) -> String {
         let key = DalekSigningKey::from_bytes(key);
         let signature = key.sign(self.0.as_bytes());
@@ -152,17 +152,17 @@ mod tests {
     }
 
     /// Raw query string as it would appear on the wire (unsorted, includes the
-    /// X-Os-Sig that must be excluded).
+    /// os-sig that must be excluded).
     fn sample_query() -> &'static str {
-        "X-Os-Timestamp=1985-04-12T23:20:50.52Z\
-         &X-Os-Key-Id=relay\
-         &X-Os-Expires=3600\
-         &X-Os-Sig=should-be-excluded"
+        "os-timestamp=1985-04-12T23:20:50.52Z\
+         &os-kid=relay\
+         &os-duration=3600\
+         &os-sig=should-be-excluded"
     }
 
     #[test]
     fn canonical_form_is_stable() {
-        // Base case: full query. Pins path encoding (slashes too), X-Os-Sig
+        // Base case: full query. Pins path encoding (slashes too), os-sig
         // exclusion, key lowercasing, and query sort order.
         let canonical = CanonicalRequest::new(
             &Method::GET,
@@ -173,9 +173,9 @@ mod tests {
             canonical.0,
             "GET\n\
              /v1/objects/testing/org=17;project=42/foo/bar\n\
-             x-os-expires=3600&\
-             x-os-key-id=relay&\
-             x-os-timestamp=1985-04-12T23:20:50.52Z"
+             os-duration=3600&\
+             os-kid=relay&\
+             os-timestamp=1985-04-12T23:20:50.52Z"
         );
 
         // Empty query: the canonical query component is empty.
@@ -203,9 +203,9 @@ mod tests {
             canonical.0,
             "GET\n\
              /v1/objects/testing/_/key\n\
-             x-os-expires=3600&\
-             x-os-key-id=relay&\
-             x-os-timestamp=1985-04-12T23:20:50.52Z"
+             os-duration=3600&\
+             os-kid=relay&\
+             os-timestamp=1985-04-12T23:20:50.52Z"
         );
     }
 

--- a/objectstore-types/src/presign.rs
+++ b/objectstore-types/src/presign.rs
@@ -13,7 +13,7 @@
 //!     &os-sig=<signature>
 //! ```
 //!
-//! The signature covers a **canonical form** (see below) of the request.
+//! The signature covers a canonical form of the request.
 //!
 //! # Canonical form
 //!

--- a/objectstore-types/src/presign.rs
+++ b/objectstore-types/src/presign.rs
@@ -7,10 +7,10 @@
 //!
 //! ```text
 //! GET /v1/objects/<usecase>/<scopes>/<key>
-//!     ?os-timestamp=2026-04-20T13:37:00.00Z
-//!     &os-duration=3600
-//!     &os-kid=relay
-//!     &os-sig=<signature>
+//!     ?os_timestamp=2026-04-20T13:37:00.00Z
+//!     &os_duration=3600
+//!     &os_kid=relay
+//!     &os_sig=<signature>
 //! ```
 //!
 //! The signature covers a canonical form of the request.
@@ -27,7 +27,7 @@
 //!
 //! - normalized method: the uppercase HTTP method, with `HEAD` mapped to `GET`;
 //! - path: the request path, included verbatim as transmitted/received on the wire;
-//! - canonical query string: every query parameter except `os-sig`, with keys
+//! - canonical query string: every query parameter except `os_sig`, with keys
 //!   lowercased, sorted lexicographically by name and value, joined with `&`.
 
 use base64::Engine as _;
@@ -38,16 +38,16 @@ use http::Method;
 pub use ed25519_dalek::{SigningKey as DalekSigningKey, VerifyingKey as DalekVerifyingKey};
 
 /// Query parameter carrying the time at which the request was signed.
-pub const PARAM_TIMESTAMP: &str = "os-timestamp";
+pub const PARAM_TIMESTAMP: &str = "os_timestamp";
 
 /// Query parameter carrying the validity duration, in seconds.
-pub const PARAM_DURATION: &str = "os-duration";
+pub const PARAM_DURATION: &str = "os_duration";
 
 /// Query parameter naming the key ID used to sign the request.
-pub const PARAM_KID: &str = "os-kid";
+pub const PARAM_KID: &str = "os_kid";
 
 /// Query parameter carrying the base64url-encoded signature.
-pub const PARAM_SIG: &str = "os-sig";
+pub const PARAM_SIG: &str = "os_sig";
 
 /// Errors returned when verifying a pre-signed request signature.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -152,17 +152,17 @@ mod tests {
     }
 
     /// Raw query string as it would appear on the wire (unsorted, includes the
-    /// os-sig that must be excluded).
+    /// os_sig that must be excluded).
     fn sample_query() -> &'static str {
-        "os-timestamp=1985-04-12T23:20:50.52Z\
-         &os-kid=relay\
-         &os-duration=3600\
-         &os-sig=should-be-excluded"
+        "os_timestamp=1985-04-12T23:20:50.52Z\
+         &os_kid=relay\
+         &os_duration=3600\
+         &os_sig=should-be-excluded"
     }
 
     #[test]
     fn canonical_form_is_stable() {
-        // Base case: full query. Pins path encoding (slashes too), os-sig
+        // Base case: full query. Pins path encoding (slashes too), os_sig
         // exclusion, key lowercasing, and query sort order.
         let canonical = CanonicalRequest::new(
             &Method::GET,
@@ -173,9 +173,9 @@ mod tests {
             canonical.0,
             "GET\n\
              /v1/objects/testing/org=17;project=42/foo/bar\n\
-             os-duration=3600&\
-             os-kid=relay&\
-             os-timestamp=1985-04-12T23:20:50.52Z"
+             os_duration=3600&\
+             os_kid=relay&\
+             os_timestamp=1985-04-12T23:20:50.52Z"
         );
 
         // Empty query: the canonical query component is empty.
@@ -203,9 +203,9 @@ mod tests {
             canonical.0,
             "GET\n\
              /v1/objects/testing/_/key\n\
-             os-duration=3600&\
-             os-kid=relay&\
-             os-timestamp=1985-04-12T23:20:50.52Z"
+             os_duration=3600&\
+             os_kid=relay&\
+             os_timestamp=1985-04-12T23:20:50.52Z"
         );
     }
 

--- a/objectstore-types/src/presign.rs
+++ b/objectstore-types/src/presign.rs
@@ -23,31 +23,26 @@
 //! The canonical form is comprised of four newline-separated components:
 //!
 //! ```text
-//! <canonical method>\n
-//! <canonical path>\n
+//! <normalized method>\n
+//! <path>\n
 //! <canonical query string>\n
 //! <canonical headers>
 //! ```
 //!
-//! - canonical method: the uppercase HTTP method, with `HEAD` mapped to `GET`;
-//! - canonical path: the percent-encoded request path;
-//! - canonical query string: every query parameter except `X-Os-Sig`,
-//!   with keys and values percent-encoded, sorted by encoded key then
-//!   encoded value, joined as `key=value` pairs with `&` separator.
+//! - normalized method: the uppercase HTTP method, with `HEAD` mapped to `GET`;
+//! - path: the request path;
+//! - canonical query string: every query parameter except `X-Os-Sig`, sorted
+//!   lexicographically, joined with `&`.
 //! - canonical headers: the request headers named in `X-Os-Signed-Headers`, each
 //!   rendered as `name:value` with a lowercase name and its value's surrounding
 //!   whitespace stripped, sorted by name, and joined with a `\n` separator.
 //!   When no headers are signed this component is empty, so the canonical form ends
 //!   with a trailing newline.
-//!
-//! Percent encoding of the path and query is always performed using the
-//! [`NON_ALPHANUMERIC`] character set into uppercase hex digits.
 
 use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use ed25519_dalek::{Signature, Signer};
 use http::{HeaderMap, HeaderName, Method};
-use percent_encoding::{NON_ALPHANUMERIC, percent_decode_str, percent_encode};
 
 pub use ed25519_dalek::{SigningKey, VerifyingKey};
 
@@ -110,31 +105,15 @@ impl CanonicalRequest {
             method.as_str()
         };
 
-        let canonical_path = percent_encode(path.as_bytes(), NON_ALPHANUMERIC).to_string();
+        let mut pairs: Vec<&str> = query
+            .unwrap_or_default()
+            .split('&')
+            .filter(|pair| !pair.is_empty())
+            .filter(|pair| pair.split_once('=').map_or(*pair, |(key, _)| key) != X_OS_SIG)
+            .collect();
+        pairs.sort_unstable();
 
-        let mut pairs: Vec<(String, String)> = Vec::new();
-        for pair in query.unwrap_or_default().split('&') {
-            if pair.is_empty() {
-                continue;
-            }
-            let (raw_key, raw_value) = pair.split_once('=').unwrap_or((pair, ""));
-            let key = percent_decode_str(raw_key).decode_utf8_lossy();
-            if key.as_ref() == X_OS_SIG {
-                continue;
-            }
-            let value = percent_decode_str(raw_value).decode_utf8_lossy();
-            pairs.push((
-                percent_encode(key.as_bytes(), NON_ALPHANUMERIC).to_string(),
-                percent_encode(value.as_bytes(), NON_ALPHANUMERIC).to_string(),
-            ));
-        }
-        pairs.sort();
-
-        let canonical_query = pairs
-            .iter()
-            .map(|(key, value)| format!("{key}={value}"))
-            .collect::<Vec<_>>()
-            .join("&");
+        let canonical_query = pairs.join("&");
 
         let mut header_pairs: Vec<(&str, &str)> = Vec::with_capacity(signed_headers.len());
         for name in signed_headers {
@@ -152,7 +131,7 @@ impl CanonicalRequest {
             .join("\n");
 
         Ok(Self(format!(
-            "{canonical_method}\n{canonical_path}\n{canonical_query}\n{canonical_headers}"
+            "{canonical_method}\n{path}\n{canonical_query}\n{canonical_headers}"
         )))
     }
 
@@ -234,10 +213,10 @@ mod tests {
         assert_eq!(
             canonical.as_str(),
             "GET\n\
-             %2Fv1%2Fobjects%2Ftesting%2Forg%3D17%3Bproject%3D42%2Ffoo%2Fbar\n\
-             X%2DOs%2DExpires=3600&\
-             X%2DOs%2DKey%2DId=relay&\
-             X%2DOs%2DTimestamp=1985%2D04%2D12T23%3A20%3A50%2E52Z\n"
+             /v1/objects/testing/org=17;project=42/foo/bar\n\
+             X-Os-Expires=3600&\
+             X-Os-Key-Id=relay&\
+             X-Os-Timestamp=1985-04-12T23:20:50.52Z\n"
         );
 
         // Empty query: both the query and header components are empty, so the form
@@ -250,10 +229,7 @@ mod tests {
             &[],
         )
         .unwrap();
-        assert_eq!(
-            canonical.as_str(),
-            "GET\n%2Fv1%2Fobjects%2Ftesting%2F%5F%2Fkey\n\n"
-        );
+        assert_eq!(canonical.as_str(), "GET\n/v1/objects/testing/_/key\n\n");
 
         // Duplicate query keys are preserved (not deduplicated) and ordered by
         // (key, value).
@@ -267,7 +243,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             canonical.as_str(),
-            "GET\n%2Fv1%2Fobjects%2Ftesting%2F%5F%2Fkey\ndup=a&dup=b&x=1\n"
+            "GET\n/v1/objects/testing/_/key\ndup=a&dup=b&x=1\n"
         );
 
         // Multiple signed headers, passed unsorted with padded values: names are
@@ -292,10 +268,10 @@ mod tests {
         assert_eq!(
             canonical.as_str(),
             "GET\n\
-             %2Fv1%2Fobjects%2Ftesting%2F%5F%2Fkey\n\
-             X%2DOs%2DExpires=3600&\
-             X%2DOs%2DKey%2DId=relay&\
-             X%2DOs%2DTimestamp=1985%2D04%2D12T23%3A20%3A50%2E52Z\n\
+             /v1/objects/testing/_/key\n\
+             X-Os-Expires=3600&\
+             X-Os-Key-Id=relay&\
+             X-Os-Timestamp=1985-04-12T23:20:50.52Z\n\
              content-type:application/json\n\
              host:objectstore.example.com\n\
              x-trace-id:abc"

--- a/objectstore-types/src/presign.rs
+++ b/objectstore-types/src/presign.rs
@@ -9,42 +9,33 @@
 //! GET /v1/objects/<usecase>/<scopes>/<key>
 //!     ?X-Os-Timestamp=2026-04-20T13:37:00.00Z
 //!     &X-Os-Expires=3600
-//!     &X-Os-Signed-Headers=host
 //!     &X-Os-Key-Id=relay
-//!     &X-Os-Alg=Ed25519
 //!     &X-Os-Sig=<signature>
 //! ```
 //!
 //! The signature covers a **canonical form** (see below) of the request.
-//! `X-Os-Alg` is currently ignored, and intended for potential future use.
 //!
 //! # Canonical form
 //!
-//! The canonical form is comprised of four newline-separated components:
+//! The canonical form is comprised of three newline-separated components:
 //!
 //! ```text
 //! <normalized method>\n
 //! <path>\n
-//! <canonical query string>\n
-//! <canonical headers>
+//! <canonical query string>
 //! ```
 //!
 //! - normalized method: the uppercase HTTP method, with `HEAD` mapped to `GET`;
-//! - path: the request path;
-//! - canonical query string: every query parameter except `X-Os-Sig`, sorted
-//!   lexicographically, joined with `&`.
-//! - canonical headers: the request headers named in `X-Os-Signed-Headers`, each
-//!   rendered as `name:value` with a lowercase name and its value's surrounding
-//!   whitespace stripped, sorted by name, and joined with a `\n` separator.
-//!   When no headers are signed this component is empty, so the canonical form ends
-//!   with a trailing newline.
+//! - path: the request path, included verbatim as transmitted/received on the wire;
+//! - canonical query string: every query parameter except `X-Os-Sig`, with keys
+//!   lowercased, sorted lexicographically by name and value, joined with `&`.
 
 use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use ed25519_dalek::{Signature, Signer};
-use http::{HeaderMap, HeaderName, Method};
+use http::Method;
 
-pub use ed25519_dalek::{SigningKey, VerifyingKey};
+pub use ed25519_dalek::{SigningKey as DalekSigningKey, VerifyingKey as DalekVerifyingKey};
 
 /// Query parameter carrying the time at which the request was signed.
 pub const X_OS_TIMESTAMP: &str = "X-Os-Timestamp";
@@ -52,14 +43,8 @@ pub const X_OS_TIMESTAMP: &str = "X-Os-Timestamp";
 /// Query parameter carrying the validity duration, in seconds.
 pub const X_OS_EXPIRES: &str = "X-Os-Expires";
 
-/// Query parameter carrying the list of signed headers.
-pub const X_OS_SIGNED_HEADERS: &str = "X-Os-Signed-Headers";
-
 /// Query parameter naming the key ID used to sign the request.
 pub const X_OS_KEY_ID: &str = "X-Os-Key-Id";
-
-/// Query parameter carrying the signing algorithm specifier.
-pub const X_OS_ALG: &str = "X-Os-Alg";
 
 /// Query parameter carrying the base64url-encoded signature.
 pub const X_OS_SIG: &str = "X-Os-Sig";
@@ -67,16 +52,13 @@ pub const X_OS_SIG: &str = "X-Os-Sig";
 /// Errors returned when verifying a pre-signed request signature.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum Error {
-    /// The signature was not valid base64url or did not decode to a 64-byte
+    /// The user supplied a sequence of bytes that's not a valid Ed25519 key.
+    #[error("invalid key")]
+    InvalidKey,
+    /// The signature is not valid base64url or doesn't decode to a 64-byte
     /// Ed25519 signature.
     #[error("invalid signature encoding")]
     InvalidSignatureEncoding,
-    /// A header listed in `signed_headers` was not present in the request.
-    #[error("signed header `{0}` is missing from the request")]
-    MissingSignedHeader(HeaderName),
-    /// A signed header's value was not valid text (i.e. not printable ASCII).
-    #[error("signed header value is not valid text")]
-    InvalidHeaderValue,
     /// The signature did not match the canonical request for the given key.
     #[error("signature verification failed")]
     VerificationFailed,
@@ -86,71 +68,56 @@ pub enum Error {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CanonicalRequest(String);
 
+/// An Ed25519 signing key.
+pub type SigningKey = [u8; 32];
+
+/// An Ed25519 verifying key.
+pub type VerifyingKey = [u8; 32];
+
 impl CanonicalRequest {
     /// Builds the canonical form of a request.
     ///
-    /// See the [module-level documentation](self) for the exact format.
+    /// `path` and `query` MUST be the raw request path and query string as transmitted/received
+    /// on the wire, which means that servers should pass the raw contents of these components, and
+    /// clients should ensure that the encoding used to compute the signature matches exactly the
+    /// encoding used by their HTTP client.
     ///
-    /// # Errors
-    ///
-    /// Returns [`Error::MissingSignedHeader`] if a header listed in
-    /// `signed_headers` is not present in `headers`, and
-    /// [`Error::InvalidHeaderValue`] if a signed header's value is not
-    /// printable ASCII.
-    pub fn new(
-        method: &Method,
-        path: &str,
-        query: Option<&str>,
-        headers: &HeaderMap,
-        signed_headers: &[&HeaderName],
-    ) -> Result<Self, Error> {
-        let canonical_method = if *method == Method::HEAD {
+    /// This is important to avoid any signature verification failures due to different
+    /// encoding/decoding implementations between the client and server, and is based on the
+    /// assumption that any intermediate proxies will never re-encode the URL, but always pass it
+    /// through with the original encoding.
+    pub fn new(method: &Method, path: &str, query: Option<&str>) -> Self {
+        let normalized_method = if *method == Method::HEAD {
             "GET"
         } else {
             method.as_str()
         };
 
-        let mut pairs: Vec<&str> = query
+        let mut pairs: Vec<String> = query
             .unwrap_or_default()
             .split('&')
             .filter(|pair| !pair.is_empty())
-            .filter(|pair| pair.split_once('=').map_or(*pair, |(key, _)| key) != X_OS_SIG)
+            .filter_map(|pair| {
+                if let Some((key, value)) = pair.split_once('=') {
+                    let key = key.to_ascii_lowercase();
+                    (key != "x-os-sig").then(|| format!("{key}={value}"))
+                } else {
+                    Some(pair.to_ascii_lowercase())
+                }
+            })
             .collect();
         pairs.sort_unstable();
-
         let canonical_query = pairs.join("&");
 
-        let mut header_pairs: Vec<(&str, &str)> = Vec::with_capacity(signed_headers.len());
-        for name in signed_headers {
-            let value = headers
-                .get(*name)
-                .ok_or_else(|| Error::MissingSignedHeader((*name).clone()))?;
-            let value = value.to_str().map_err(|_| Error::InvalidHeaderValue)?;
-            header_pairs.push((name.as_str(), value.trim()));
-        }
-        header_pairs.sort();
-
-        let canonical_headers = header_pairs
-            .iter()
-            .map(|(name, value)| format!("{name}:{value}"))
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        Ok(Self(format!(
-            "{canonical_method}\n{path}\n{canonical_query}\n{canonical_headers}"
-        )))
-    }
-
-    /// Returns the canonical form as a string.
-    pub fn as_str(&self) -> &str {
-        &self.0
+        Self(format!("{normalized_method}\n{path}\n{canonical_query}"))
     }
 
     /// Signs this canonical form with Ed25519.
     ///
-    /// Returns the base64url-encoded  signature, suitable as the value of the
+    /// Returns the base64url-encoded signature, suitable as the value of the
     /// [`X_OS_SIG`] query parameter.
     pub fn sign(&self, key: &SigningKey) -> String {
+        let key = DalekSigningKey::from_bytes(key);
         let signature = key.sign(self.0.as_bytes());
         URL_SAFE_NO_PAD.encode(signature.to_bytes())
     }
@@ -159,10 +126,12 @@ impl CanonicalRequest {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::InvalidSignatureEncoding`] if `signature_b64` is not valid
-    /// base64url or not a 64-byte signature, and [`Error::VerificationFailed`] if
-    /// the signature does not match.
+    /// Returns [`Error::InvalidKey`] if `key` is not a valid Ed25519 verifying key,
+    /// [`Error::InvalidSignatureEncoding`] if `signature_b64` is not valid base64url
+    /// or not a 64-byte signature, and [`Error::VerificationFailed`] if the signature
+    /// does not match.
     pub fn verify(&self, key: &VerifyingKey, signature_b64: &str) -> Result<(), Error> {
+        let key = DalekVerifyingKey::from_bytes(key).map_err(|_| Error::InvalidKey)?;
         let bytes = URL_SAFE_NO_PAD
             .decode(signature_b64)
             .map_err(|_| Error::InvalidSignatureEncoding)?;
@@ -177,10 +146,8 @@ impl CanonicalRequest {
 mod tests {
     use super::*;
 
-    use http::HeaderValue;
-
-    fn test_signing_key() -> SigningKey {
-        SigningKey::from_bytes(&[0x42; 32])
+    fn test_signing_key() -> DalekSigningKey {
+        DalekSigningKey::from_bytes(&[0x42; 32])
     }
 
     /// Raw query string as it would appear on the wire (unsorted, includes the
@@ -192,50 +159,27 @@ mod tests {
          &X-Os-Sig=should-be-excluded"
     }
 
-    fn header_map(pairs: &[(&str, &str)]) -> HeaderMap {
-        let mut map = HeaderMap::new();
-        for (name, value) in pairs {
-            map.insert(
-                HeaderName::from_bytes(name.as_bytes()).unwrap(),
-                HeaderValue::from_str(value).unwrap(),
-            );
-        }
-        map
-    }
-
     #[test]
     fn canonical_form_is_stable() {
-        // Base case: full query, no signed headers. Pins path encoding (slashes
-        // too), X-Os-Sig exclusion, query sort order, and the trailing empty header
-        // line.
+        // Base case: full query. Pins path encoding (slashes too), X-Os-Sig
+        // exclusion, key lowercasing, and query sort order.
         let canonical = CanonicalRequest::new(
             &Method::GET,
             "/v1/objects/testing/org=17;project=42/foo/bar",
             Some(sample_query()),
-            &HeaderMap::new(),
-            &[],
-        )
-        .unwrap();
+        );
         assert_eq!(
-            canonical.as_str(),
+            canonical.0,
             "GET\n\
              /v1/objects/testing/org=17;project=42/foo/bar\n\
-             X-Os-Expires=3600&\
-             X-Os-Key-Id=relay&\
-             X-Os-Timestamp=1985-04-12T23:20:50.52Z\n"
+             x-os-expires=3600&\
+             x-os-key-id=relay&\
+             x-os-timestamp=1985-04-12T23:20:50.52Z"
         );
 
-        // Empty query: both the query and header components are empty, so the form
-        // ends with two consecutive newlines.
-        let canonical = CanonicalRequest::new(
-            &Method::GET,
-            "/v1/objects/testing/_/key",
-            None,
-            &HeaderMap::new(),
-            &[],
-        )
-        .unwrap();
-        assert_eq!(canonical.as_str(), "GET\n/v1/objects/testing/_/key\n\n");
+        // Empty query: the canonical query component is empty.
+        let canonical = CanonicalRequest::new(&Method::GET, "/v1/objects/testing/_/key", None);
+        assert_eq!(canonical.0, "GET\n/v1/objects/testing/_/key\n");
 
         // Duplicate query keys are preserved (not deduplicated) and ordered by
         // (key, value).
@@ -243,44 +187,24 @@ mod tests {
             &Method::GET,
             "/v1/objects/testing/_/key",
             Some("dup=b&dup=a&x=1"),
-            &HeaderMap::new(),
-            &[],
-        )
-        .unwrap();
+        );
         assert_eq!(
-            canonical.as_str(),
-            "GET\n/v1/objects/testing/_/key\ndup=a&dup=b&x=1\n"
+            canonical.0,
+            "GET\n/v1/objects/testing/_/key\ndup=a&dup=b&x=1"
         );
 
-        // Multiple signed headers, passed unsorted with padded values: names are
-        // already lowercase (the `HeaderName` type guarantees it), values trimmed,
-        // sorted by name, joined with `\n`.
-        let headers = header_map(&[
-            ("Host", "objectstore.example.com"),
-            ("Content-Type", "  application/json  "),
-            ("X-Trace-Id", " abc "),
-        ]);
-        let host = HeaderName::from_static("host");
-        let content_type = HeaderName::from_static("content-type");
-        let x_trace_id = HeaderName::from_static("x-trace-id");
         let canonical = CanonicalRequest::new(
             &Method::GET,
             "/v1/objects/testing/_/key",
             Some(sample_query()),
-            &headers,
-            &[&host, &content_type, &x_trace_id],
-        )
-        .unwrap();
+        );
         assert_eq!(
-            canonical.as_str(),
+            canonical.0,
             "GET\n\
              /v1/objects/testing/_/key\n\
-             X-Os-Expires=3600&\
-             X-Os-Key-Id=relay&\
-             X-Os-Timestamp=1985-04-12T23:20:50.52Z\n\
-             content-type:application/json\n\
-             host:objectstore.example.com\n\
-             x-trace-id:abc"
+             x-os-expires=3600&\
+             x-os-key-id=relay&\
+             x-os-timestamp=1985-04-12T23:20:50.52Z"
         );
     }
 
@@ -288,20 +212,8 @@ mod tests {
     fn head_is_normalized_to_get() {
         let path = "/v1/objects/testing/_/key";
         assert_eq!(
-            CanonicalRequest::new(
-                &Method::HEAD,
-                path,
-                Some(sample_query()),
-                &HeaderMap::new(),
-                &[]
-            ),
-            CanonicalRequest::new(
-                &Method::GET,
-                path,
-                Some(sample_query()),
-                &HeaderMap::new(),
-                &[]
-            ),
+            CanonicalRequest::new(&Method::HEAD, path, Some(sample_query()),),
+            CanonicalRequest::new(&Method::GET, path, Some(sample_query()),),
         );
     }
 
@@ -310,19 +222,14 @@ mod tests {
         let sk = test_signing_key();
         let vk = sk.verifying_key();
 
-        let headers = header_map(&[("Content-Type", "application/json")]);
-        let content_type = HeaderName::from_static("content-type");
         let canonical = CanonicalRequest::new(
             &Method::GET,
             "/v1/objects/testing/_/key",
             Some(sample_query()),
-            &headers,
-            &[&content_type],
-        )
-        .unwrap();
-        let signature = canonical.sign(&sk);
+        );
+        let signature = canonical.sign(&sk.as_bytes());
 
-        assert_eq!(canonical.verify(&vk, &signature), Ok(()));
+        assert_eq!(canonical.verify(&vk.as_bytes(), &signature), Ok(()));
     }
 
     #[test]
@@ -334,22 +241,16 @@ mod tests {
             &Method::GET,
             "/v1/objects/testing/_/key",
             Some(sample_query()),
-            &HeaderMap::new(),
-            &[],
-        )
-        .unwrap();
-        let signature = canonical.sign(&sk);
+        );
+        let signature = canonical.sign(&sk.as_bytes());
 
         let tampered = CanonicalRequest::new(
             &Method::GET,
             "/v1/objects/testing/_/other",
             Some(sample_query()),
-            &HeaderMap::new(),
-            &[],
-        )
-        .unwrap();
+        );
         assert_eq!(
-            tampered.verify(&vk, &signature),
+            tampered.verify(&vk.as_bytes(), &signature),
             Err(Error::VerificationFailed)
         );
     }
@@ -357,20 +258,17 @@ mod tests {
     #[test]
     fn verify_rejects_wrong_key() {
         let sk = test_signing_key();
-        let other_vk = SigningKey::from_bytes(&[0x01; 32]).verifying_key();
+        let other_vk = DalekSigningKey::from_bytes(&[0x01; 32]).verifying_key();
 
         let canonical = CanonicalRequest::new(
             &Method::GET,
             "/v1/objects/testing/_/key",
             Some(sample_query()),
-            &HeaderMap::new(),
-            &[],
-        )
-        .unwrap();
-        let signature = canonical.sign(&sk);
+        );
+        let signature = canonical.sign(&sk.as_bytes());
 
         assert_eq!(
-            canonical.verify(&other_vk, &signature),
+            canonical.verify(&other_vk.as_bytes(), &signature),
             Err(Error::VerificationFailed)
         );
     }
@@ -382,55 +280,17 @@ mod tests {
             &Method::GET,
             "/v1/objects/testing/_/key",
             Some(sample_query()),
-            &HeaderMap::new(),
-            &[],
-        )
-        .unwrap();
+        );
 
         // Not valid base64url.
         assert_eq!(
-            canonical.verify(&vk, "not valid base64!!"),
+            canonical.verify(&vk.as_bytes(), "not valid base64!!"),
             Err(Error::InvalidSignatureEncoding)
         );
         // Valid base64url but not a 64-byte signature.
         assert_eq!(
-            canonical.verify(&vk, &URL_SAFE_NO_PAD.encode([0u8; 10])),
+            canonical.verify(&vk.as_bytes(), &URL_SAFE_NO_PAD.encode([0u8; 10])),
             Err(Error::InvalidSignatureEncoding)
-        );
-    }
-
-    #[test]
-    fn canonical_rejects_missing_signed_header() {
-        let host = HeaderName::from_static("host");
-        assert_eq!(
-            CanonicalRequest::new(
-                &Method::GET,
-                "/v1/objects/testing/_/key",
-                None,
-                &HeaderMap::new(),
-                &[&host],
-            ),
-            Err(Error::MissingSignedHeader(host))
-        );
-    }
-
-    #[test]
-    fn canonical_rejects_non_text_header_value() {
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            HeaderName::from_static("x-binary"),
-            HeaderValue::from_bytes(&[0xff, 0xfe]).unwrap(),
-        );
-        let x_binary = HeaderName::from_static("x-binary");
-        assert_eq!(
-            CanonicalRequest::new(
-                &Method::GET,
-                "/v1/objects/testing/_/key",
-                None,
-                &headers,
-                &[&x_binary],
-            ),
-            Err(Error::InvalidHeaderValue)
         );
     }
 }

--- a/objectstore-types/src/presign.rs
+++ b/objectstore-types/src/presign.rs
@@ -2,23 +2,20 @@
 //!
 //! A pre-signed URL lets a client that owns an Ed25519 keypair hand out a
 //! time-limited URL that authorizes a specific request.
+//!
 //! Example:
 //!
 //! ```text
 //! GET /v1/objects/<usecase>/<scopes>/<key>
-//!     ?X-Os-Key-Id=relay
-//!     &X-Os-Timestamp=2026-04-20T13:37:00.00Z
-//!     &X-Os-Expires=<duration in seconds>
+//!     ?X-Os-Timestamp=2026-04-20T13:37:00.00Z
+//!     &X-Os-Expires=3600
+//!     &X-Os-Signed-Headers=host
+//!     &X-Os-Key-Id=relay
+//!     &X-Os-Alg=Ed25519
 //!     &X-Os-Sig=<signature>
 //! ```
 //!
 //! The signature covers a **canonical form** (see below) of the request.
-//!
-//! In addition to the above query parameters, the following query
-//! parameters are intended to be introduced in future if/when needed:
-//! - `X-Os-Alg`: specifies the signing algorithm. When unspecified, defaults to
-//!   Ed25519.
-//! - `X-Os-Signed-Headers`: specifies the request headers that are signed (see below).
 //!
 //! # Canonical form
 //!
@@ -53,31 +50,34 @@ use percent_encoding::{NON_ALPHANUMERIC, percent_encode};
 
 pub use ed25519_dalek::{SigningKey, VerifyingKey};
 
-/// Query parameter naming the key ID used to sign the request.
-///
-/// Its value selects the public key the verifier uses (the same `kid` mechanism
-/// as JWT auth).
-pub const X_OS_KEY_ID: &str = "X-Os-Key-Id";
-
 /// Query parameter carrying the time at which the request was signed.
 pub const X_OS_TIMESTAMP: &str = "X-Os-Timestamp";
 
 /// Query parameter carrying the validity duration, in seconds.
 pub const X_OS_EXPIRES: &str = "X-Os-Expires";
 
+/// Query parameter carrying the list of signed headers.
+pub const X_OS_SIGNED_HEADERS: &str = "X-Os-Signed-Headers";
+
+/// Query parameter naming the key ID used to sign the request.
+pub const X_OS_KEY_ID: &str = "X-Os-Key-Id";
+
+/// Query parameter carrying the signing algorithm specifier.
+pub const X_OS_ALG: &str = "X-Os-Alg";
+
 /// Query parameter carrying the base64url-encoded signature.
-///
-/// This parameter is excluded from the canonical query string, since it is the
-/// output of signing that string.
 pub const X_OS_SIG: &str = "X-Os-Sig";
 
 /// Errors returned when verifying a pre-signed request signature.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-pub enum PresignError {
+pub enum Error {
     /// The signature was not valid base64url or did not decode to a 64-byte
     /// Ed25519 signature.
     #[error("invalid signature encoding")]
     InvalidSignatureEncoding,
+    /// An unknown signature algorithm was specified.
+    #[error("unknown algorithm")]
+    UnknownAlgorithm,
     /// The signature did not match the canonical request for the given key.
     #[error("signature verification failed")]
     VerificationFailed,
@@ -85,35 +85,17 @@ pub enum PresignError {
 
 /// Builds the canonical string that gets signed for a pre-signed request.
 ///
-/// See the [module-level documentation](self) for the exact format. `HEAD` is
-/// normalized to `GET`, and [`X_OS_SIG`] is excluded from the canonical query
-/// string.
+/// See the [module-level documentation](self) for the exact format.
 ///
-/// `path` is percent-encoded wholesale here (the `/` separators are deliberately
-/// not treated specially). This function is oblivious to the path's contents;
-/// correctness only requires that the signer and verifier pass **byte-identical**
-/// path strings. The natural choice is the raw path exactly as it appears in the
-/// request line — `uri.path()` on the server, and the equivalent from the built URL
-/// on the client. Do **not** percent-decode it first: decoding is lossy (`%2F` and a
-/// literal `/` collapse to the same byte), which would weaken the signature and risk
-/// a signer/verifier mismatch.
-///
-/// `query` is the list of decoded query parameter key/value pairs; they are
-/// re-encoded canonically here, so ordering of the input does not matter.
-///
-/// `signed_headers` is the list of request headers named by `X-Os-Signed-Headers`
-/// (name/value pairs); names are lowercased, values are whitespace-trimmed, and
-/// the entries are sorted by name here, so input ordering does not matter. Pass an
-/// empty slice when no headers are signed. Values must come from a validated HTTP
-/// header map (they must not contain CR/LF); see the
-/// [module-level documentation](self).
+/// Note that header values must come from a validated HTTP header map (i.e., they must not contain
+/// CR/LF).
 pub fn canonical_request(
     method: &Method,
     path: &str,
     query: &[(&str, &str)],
     signed_headers: &[(&str, &str)],
 ) -> String {
-    let method = if *method == Method::HEAD {
+    let canonical_method = if *method == Method::HEAD {
         "GET"
     } else {
         method.as_str()
@@ -151,7 +133,7 @@ pub fn canonical_request(
         .collect::<Vec<_>>()
         .join("\n");
 
-    format!("{method}\n{canonical_path}\n{canonical_query}\n{canonical_headers}")
+    format!("{canonical_method}\n{canonical_path}\n{canonical_query}\n{canonical_headers}")
 }
 
 /// Signs a canonical request string with Ed25519.
@@ -173,15 +155,14 @@ pub fn verify(
     verifying_key: &VerifyingKey,
     canonical: &str,
     signature_b64: &str,
-) -> Result<(), PresignError> {
+) -> Result<(), Error> {
     let bytes = URL_SAFE_NO_PAD
         .decode(signature_b64)
-        .map_err(|_| PresignError::InvalidSignatureEncoding)?;
-    let signature =
-        Signature::from_slice(&bytes).map_err(|_| PresignError::InvalidSignatureEncoding)?;
+        .map_err(|_| Error::InvalidSignatureEncoding)?;
+    let signature = Signature::from_slice(&bytes).map_err(|_| Error::InvalidSignatureEncoding)?;
     verifying_key
         .verify_strict(canonical.as_bytes(), &signature)
-        .map_err(|_| PresignError::VerificationFailed)
+        .map_err(|_| Error::VerificationFailed)
 }
 
 #[cfg(test)]
@@ -275,7 +256,7 @@ mod tests {
         );
         assert_eq!(
             verify(&vk, &tampered, &signature),
-            Err(PresignError::VerificationFailed)
+            Err(Error::VerificationFailed)
         );
     }
 
@@ -294,7 +275,7 @@ mod tests {
 
         assert_eq!(
             verify(&other_vk, &canonical, &signature),
-            Err(PresignError::VerificationFailed)
+            Err(Error::VerificationFailed)
         );
     }
 
@@ -311,12 +292,12 @@ mod tests {
         // Not valid base64url.
         assert_eq!(
             verify(&vk, &canonical, "not valid base64!!"),
-            Err(PresignError::InvalidSignatureEncoding)
+            Err(Error::InvalidSignatureEncoding)
         );
         // Valid base64url but not a 64-byte signature.
         assert_eq!(
             verify(&vk, &canonical, &URL_SAFE_NO_PAD.encode([0u8; 10])),
-            Err(PresignError::InvalidSignatureEncoding)
+            Err(Error::InvalidSignatureEncoding)
         );
     }
 

--- a/objectstore-types/src/presign.rs
+++ b/objectstore-types/src/presign.rs
@@ -190,13 +190,15 @@ mod tests {
 
     #[test]
     fn canonical_form_is_stable() {
+        // Base case: full query, no signed headers. Pins path encoding (slashes
+        // too), X-Os-Sig exclusion, query sort order, and the trailing empty header
+        // line.
         let canonical = CanonicalRequest::new(
             &Method::GET,
             "/v1/objects/testing/org=17;project=42/foo/bar",
             &sample_query(),
             &[],
         );
-
         assert_eq!(
             canonical.as_str(),
             "GET\n\
@@ -206,9 +208,34 @@ mod tests {
              X%2DOs%2DTimestamp=1985%2D04%2D12T23%3A20%3A50%2E52Z\n"
         );
 
+        // Empty query: both the query and header components are empty, so the form
+        // ends with two consecutive newlines.
+        let canonical = CanonicalRequest::new(&Method::GET, "/v1/objects/testing/_/key", &[], &[]);
+        assert_eq!(
+            canonical.as_str(),
+            "GET\n%2Fv1%2Fobjects%2Ftesting%2F%5F%2Fkey\n\n"
+        );
+
+        // Duplicate query keys are preserved (not deduplicated) and ordered by
+        // (key, value).
+        let canonical = CanonicalRequest::new(
+            &Method::GET,
+            "/v1/objects/testing/_/key",
+            &[("dup", "b"), ("dup", "a"), ("x", "1")],
+            &[],
+        );
+        assert_eq!(
+            canonical.as_str(),
+            "GET\n%2Fv1%2Fobjects%2Ftesting%2F%5F%2Fkey\ndup=a&dup=b&x=1\n"
+        );
+
+        // Multiple signed headers, unsorted with mixed-case names and padded
+        // values: names lowercased, values trimmed, sorted by name, joined with
+        // `\n`.
         let headers = [
             ("Host", "objectstore.example.com"),
             ("Content-Type", "  application/json  "),
+            ("X-Trace-Id", " abc "),
         ];
         let canonical = CanonicalRequest::new(
             &Method::GET,
@@ -216,7 +243,6 @@ mod tests {
             &sample_query(),
             &headers,
         );
-
         assert_eq!(
             canonical.as_str(),
             "GET\n\
@@ -225,7 +251,8 @@ mod tests {
              X%2DOs%2DKey%2DId=relay&\
              X%2DOs%2DTimestamp=1985%2D04%2D12T23%3A20%3A50%2E52Z\n\
              content-type:application/json\n\
-             host:objectstore.example.com"
+             host:objectstore.example.com\n\
+             x-trace-id:abc"
         );
     }
 

--- a/objectstore-types/src/presign.rs
+++ b/objectstore-types/src/presign.rs
@@ -46,8 +46,8 @@
 use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use ed25519_dalek::{Signature, Signer};
-use http::Method;
-use percent_encoding::{NON_ALPHANUMERIC, percent_encode};
+use http::{HeaderMap, HeaderName, Method};
+use percent_encoding::{NON_ALPHANUMERIC, percent_decode_str, percent_encode};
 
 pub use ed25519_dalek::{SigningKey, VerifyingKey};
 
@@ -76,6 +76,9 @@ pub enum Error {
     /// Ed25519 signature.
     #[error("invalid signature encoding")]
     InvalidSignatureEncoding,
+    /// A signed header's value was not valid text (i.e. not printable ASCII).
+    #[error("signed header value is not valid text")]
+    NonTextHeaderValue,
     /// The signature did not match the canonical request for the given key.
     #[error("signature verification failed")]
     VerificationFailed,
@@ -88,16 +91,25 @@ pub struct CanonicalRequest(String);
 impl CanonicalRequest {
     /// Builds the canonical form of a request.
     ///
+    /// `path` and `query` are the raw request-line components, taken verbatim from
+    /// `uri.path()` / `uri.query()` on the server or the built `url::Url` on the
+    /// client — both signer and verifier must pass the same bytes. `signed_headers`
+    /// names the headers to sign; each is looked up in `headers`, and missing ones
+    /// are skipped (so a signed-but-absent header simply fails verification).
+    ///
     /// See the [module-level documentation](self) for the exact format.
     ///
-    /// Note that header values must come from a validated HTTP header map (i.e.,
-    /// they must not contain CR/LF).
+    /// # Errors
+    ///
+    /// Returns [`Error::NonTextHeaderValue`] if a signed header's value is not
+    /// printable ASCII.
     pub fn new(
         method: &Method,
         path: &str,
-        query: &[(&str, &str)],
-        signed_headers: &[(&str, &str)],
-    ) -> Self {
+        query: Option<&str>,
+        headers: &HeaderMap,
+        signed_headers: &[&HeaderName],
+    ) -> Result<Self, Error> {
         let canonical_method = if *method == Method::HEAD {
             "GET"
         } else {
@@ -106,16 +118,26 @@ impl CanonicalRequest {
 
         let canonical_path = percent_encode(path.as_bytes(), NON_ALPHANUMERIC).to_string();
 
-        let mut pairs: Vec<(String, String)> = query
-            .iter()
-            .filter(|&&(key, _)| key != X_OS_SIG)
-            .map(|&(key, value)| {
-                (
-                    percent_encode(key.as_bytes(), NON_ALPHANUMERIC).to_string(),
-                    percent_encode(value.as_bytes(), NON_ALPHANUMERIC).to_string(),
-                )
-            })
-            .collect();
+        // Re-encode each query parameter canonically (decode the raw pair, then
+        // encode with `NON_ALPHANUMERIC`) and sort, so signer and verifier agree
+        // regardless of how the raw query was encoded on the wire. `X-Os-Sig` is
+        // excluded since it is the output of signing.
+        let mut pairs: Vec<(String, String)> = Vec::new();
+        for pair in query.unwrap_or_default().split('&') {
+            if pair.is_empty() {
+                continue;
+            }
+            let (raw_key, raw_value) = pair.split_once('=').unwrap_or((pair, ""));
+            let key = percent_decode_str(raw_key).decode_utf8_lossy();
+            if key.as_ref() == X_OS_SIG {
+                continue;
+            }
+            let value = percent_decode_str(raw_value).decode_utf8_lossy();
+            pairs.push((
+                percent_encode(key.as_bytes(), NON_ALPHANUMERIC).to_string(),
+                percent_encode(value.as_bytes(), NON_ALPHANUMERIC).to_string(),
+            ));
+        }
         pairs.sort();
 
         let canonical_query = pairs
@@ -124,21 +146,26 @@ impl CanonicalRequest {
             .collect::<Vec<_>>()
             .join("&");
 
-        let mut headers: Vec<(String, &str)> = signed_headers
-            .iter()
-            .map(|&(name, value)| (name.to_ascii_lowercase(), value.trim()))
-            .collect();
-        headers.sort();
+        // Header names are already lowercase (`HeaderName`), and header values
+        // cannot contain CR/LF (`HeaderValue`), so no encoding is needed.
+        let mut header_pairs: Vec<(&str, &str)> = Vec::with_capacity(signed_headers.len());
+        for name in signed_headers {
+            if let Some(value) = headers.get(*name) {
+                let value = value.to_str().map_err(|_| Error::NonTextHeaderValue)?;
+                header_pairs.push((name.as_str(), value.trim()));
+            }
+        }
+        header_pairs.sort();
 
-        let canonical_headers = headers
+        let canonical_headers = header_pairs
             .iter()
             .map(|(name, value)| format!("{name}:{value}"))
             .collect::<Vec<_>>()
             .join("\n");
 
-        Self(format!(
+        Ok(Self(format!(
             "{canonical_method}\n{canonical_path}\n{canonical_query}\n{canonical_headers}"
-        ))
+        )))
     }
 
     /// Returns the canonical form as a string.
@@ -175,17 +202,30 @@ impl CanonicalRequest {
 mod tests {
     use super::*;
 
+    use http::HeaderValue;
+
     fn test_signing_key() -> SigningKey {
         SigningKey::from_bytes(&[0x42; 32])
     }
 
-    fn sample_query() -> Vec<(&'static str, &'static str)> {
-        vec![
-            (X_OS_TIMESTAMP, "1985-04-12T23:20:50.52Z"),
-            (X_OS_KEY_ID, "relay"),
-            (X_OS_EXPIRES, "3600"),
-            (X_OS_SIG, "should-be-excluded"),
-        ]
+    /// Raw query string as it would appear on the wire (unsorted, includes the
+    /// X-Os-Sig that must be excluded).
+    fn sample_query() -> &'static str {
+        "X-Os-Timestamp=1985-04-12T23:20:50.52Z\
+         &X-Os-Key-Id=relay\
+         &X-Os-Expires=3600\
+         &X-Os-Sig=should-be-excluded"
+    }
+
+    fn header_map(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        for (name, value) in pairs {
+            map.insert(
+                HeaderName::from_bytes(name.as_bytes()).unwrap(),
+                HeaderValue::from_str(value).unwrap(),
+            );
+        }
+        map
     }
 
     #[test]
@@ -196,9 +236,11 @@ mod tests {
         let canonical = CanonicalRequest::new(
             &Method::GET,
             "/v1/objects/testing/org=17;project=42/foo/bar",
-            &sample_query(),
+            Some(sample_query()),
+            &HeaderMap::new(),
             &[],
-        );
+        )
+        .unwrap();
         assert_eq!(
             canonical.as_str(),
             "GET\n\
@@ -210,7 +252,14 @@ mod tests {
 
         // Empty query: both the query and header components are empty, so the form
         // ends with two consecutive newlines.
-        let canonical = CanonicalRequest::new(&Method::GET, "/v1/objects/testing/_/key", &[], &[]);
+        let canonical = CanonicalRequest::new(
+            &Method::GET,
+            "/v1/objects/testing/_/key",
+            None,
+            &HeaderMap::new(),
+            &[],
+        )
+        .unwrap();
         assert_eq!(
             canonical.as_str(),
             "GET\n%2Fv1%2Fobjects%2Ftesting%2F%5F%2Fkey\n\n"
@@ -221,28 +270,35 @@ mod tests {
         let canonical = CanonicalRequest::new(
             &Method::GET,
             "/v1/objects/testing/_/key",
-            &[("dup", "b"), ("dup", "a"), ("x", "1")],
+            Some("dup=b&dup=a&x=1"),
+            &HeaderMap::new(),
             &[],
-        );
+        )
+        .unwrap();
         assert_eq!(
             canonical.as_str(),
             "GET\n%2Fv1%2Fobjects%2Ftesting%2F%5F%2Fkey\ndup=a&dup=b&x=1\n"
         );
 
-        // Multiple signed headers, unsorted with mixed-case names and padded
-        // values: names lowercased, values trimmed, sorted by name, joined with
-        // `\n`.
-        let headers = [
+        // Multiple signed headers, passed unsorted with padded values: names are
+        // already lowercase (the `HeaderName` type guarantees it), values trimmed,
+        // sorted by name, joined with `\n`.
+        let headers = header_map(&[
             ("Host", "objectstore.example.com"),
             ("Content-Type", "  application/json  "),
             ("X-Trace-Id", " abc "),
-        ];
+        ]);
+        let host = HeaderName::from_static("host");
+        let content_type = HeaderName::from_static("content-type");
+        let x_trace_id = HeaderName::from_static("x-trace-id");
         let canonical = CanonicalRequest::new(
             &Method::GET,
             "/v1/objects/testing/_/key",
-            &sample_query(),
+            Some(sample_query()),
             &headers,
-        );
+            &[&host, &content_type, &x_trace_id],
+        )
+        .unwrap();
         assert_eq!(
             canonical.as_str(),
             "GET\n\
@@ -259,10 +315,21 @@ mod tests {
     #[test]
     fn head_is_normalized_to_get() {
         let path = "/v1/objects/testing/_/key";
-        let query = sample_query();
         assert_eq!(
-            CanonicalRequest::new(&Method::HEAD, path, &query, &[]),
-            CanonicalRequest::new(&Method::GET, path, &query, &[]),
+            CanonicalRequest::new(
+                &Method::HEAD,
+                path,
+                Some(sample_query()),
+                &HeaderMap::new(),
+                &[]
+            ),
+            CanonicalRequest::new(
+                &Method::GET,
+                path,
+                Some(sample_query()),
+                &HeaderMap::new(),
+                &[]
+            ),
         );
     }
 
@@ -271,12 +338,16 @@ mod tests {
         let sk = test_signing_key();
         let vk = sk.verifying_key();
 
+        let headers = header_map(&[("Content-Type", "application/json")]);
+        let content_type = HeaderName::from_static("content-type");
         let canonical = CanonicalRequest::new(
             &Method::GET,
             "/v1/objects/testing/_/key",
-            &sample_query(),
-            &[("Content-Type", "application/json")],
-        );
+            Some(sample_query()),
+            &headers,
+            &[&content_type],
+        )
+        .unwrap();
         let signature = canonical.sign(&sk);
 
         assert_eq!(canonical.verify(&vk, &signature), Ok(()));
@@ -290,17 +361,21 @@ mod tests {
         let canonical = CanonicalRequest::new(
             &Method::GET,
             "/v1/objects/testing/_/key",
-            &sample_query(),
+            Some(sample_query()),
+            &HeaderMap::new(),
             &[],
-        );
+        )
+        .unwrap();
         let signature = canonical.sign(&sk);
 
         let tampered = CanonicalRequest::new(
             &Method::GET,
             "/v1/objects/testing/_/other",
-            &sample_query(),
+            Some(sample_query()),
+            &HeaderMap::new(),
             &[],
-        );
+        )
+        .unwrap();
         assert_eq!(
             tampered.verify(&vk, &signature),
             Err(Error::VerificationFailed)
@@ -315,9 +390,11 @@ mod tests {
         let canonical = CanonicalRequest::new(
             &Method::GET,
             "/v1/objects/testing/_/key",
-            &sample_query(),
+            Some(sample_query()),
+            &HeaderMap::new(),
             &[],
-        );
+        )
+        .unwrap();
         let signature = canonical.sign(&sk);
 
         assert_eq!(
@@ -332,9 +409,11 @@ mod tests {
         let canonical = CanonicalRequest::new(
             &Method::GET,
             "/v1/objects/testing/_/key",
-            &sample_query(),
+            Some(sample_query()),
+            &HeaderMap::new(),
             &[],
-        );
+        )
+        .unwrap();
 
         // Not valid base64url.
         assert_eq!(
@@ -345,6 +424,26 @@ mod tests {
         assert_eq!(
             canonical.verify(&vk, &URL_SAFE_NO_PAD.encode([0u8; 10])),
             Err(Error::InvalidSignatureEncoding)
+        );
+    }
+
+    #[test]
+    fn non_text_header_value_is_rejected() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("x-binary"),
+            HeaderValue::from_bytes(&[0xff, 0xfe]).unwrap(),
+        );
+        let x_binary = HeaderName::from_static("x-binary");
+        assert_eq!(
+            CanonicalRequest::new(
+                &Method::GET,
+                "/v1/objects/testing/_/key",
+                None,
+                &headers,
+                &[&x_binary],
+            ),
+            Err(Error::NonTextHeaderValue)
         );
     }
 }

--- a/objectstore-types/src/presign.rs
+++ b/objectstore-types/src/presign.rs
@@ -88,9 +88,9 @@ impl CanonicalRequest {
     /// through with the original encoding.
     pub fn new(method: &Method, path: &str, query: Option<&str>) -> Self {
         let normalized_method = if *method == Method::HEAD {
-            "GET"
+            String::from("GET")
         } else {
-            method.as_str()
+            method.as_str().to_uppercase()
         };
 
         let mut pairs: Vec<String> = query

--- a/objectstore-types/src/presign.rs
+++ b/objectstore-types/src/presign.rs
@@ -78,7 +78,7 @@ pub enum Error {
     InvalidSignatureEncoding,
     /// A signed header's value was not valid text (i.e. not printable ASCII).
     #[error("signed header value is not valid text")]
-    NonTextHeaderValue,
+    InvalidHeaderValue,
     /// The signature did not match the canonical request for the given key.
     #[error("signature verification failed")]
     VerificationFailed,
@@ -91,17 +91,11 @@ pub struct CanonicalRequest(String);
 impl CanonicalRequest {
     /// Builds the canonical form of a request.
     ///
-    /// `path` and `query` are the raw request-line components, taken verbatim from
-    /// `uri.path()` / `uri.query()` on the server or the built `url::Url` on the
-    /// client — both signer and verifier must pass the same bytes. `signed_headers`
-    /// names the headers to sign; each is looked up in `headers`, and missing ones
-    /// are skipped (so a signed-but-absent header simply fails verification).
-    ///
     /// See the [module-level documentation](self) for the exact format.
     ///
     /// # Errors
     ///
-    /// Returns [`Error::NonTextHeaderValue`] if a signed header's value is not
+    /// Returns [`Error::InvalidHeaderValue`] if a signed header's value is not
     /// printable ASCII.
     pub fn new(
         method: &Method,
@@ -118,10 +112,6 @@ impl CanonicalRequest {
 
         let canonical_path = percent_encode(path.as_bytes(), NON_ALPHANUMERIC).to_string();
 
-        // Re-encode each query parameter canonically (decode the raw pair, then
-        // encode with `NON_ALPHANUMERIC`) and sort, so signer and verifier agree
-        // regardless of how the raw query was encoded on the wire. `X-Os-Sig` is
-        // excluded since it is the output of signing.
         let mut pairs: Vec<(String, String)> = Vec::new();
         for pair in query.unwrap_or_default().split('&') {
             if pair.is_empty() {
@@ -146,12 +136,10 @@ impl CanonicalRequest {
             .collect::<Vec<_>>()
             .join("&");
 
-        // Header names are already lowercase (`HeaderName`), and header values
-        // cannot contain CR/LF (`HeaderValue`), so no encoding is needed.
         let mut header_pairs: Vec<(&str, &str)> = Vec::with_capacity(signed_headers.len());
         for name in signed_headers {
             if let Some(value) = headers.get(*name) {
-                let value = value.to_str().map_err(|_| Error::NonTextHeaderValue)?;
+                let value = value.to_str().map_err(|_| Error::InvalidHeaderValue)?;
                 header_pairs.push((name.as_str(), value.trim()));
             }
         }
@@ -175,14 +163,16 @@ impl CanonicalRequest {
 
     /// Signs this canonical form with Ed25519.
     ///
-    /// Returns the base64url-encoded (no padding) signature, suitable as the value
-    /// of the [`X_OS_SIG`] query parameter.
+    /// Returns the base64url-encoded  signature, suitable as the value of the
+    /// [`X_OS_SIG`] query parameter.
     pub fn sign(&self, key: &SigningKey) -> String {
         let signature = key.sign(self.0.as_bytes());
         URL_SAFE_NO_PAD.encode(signature.to_bytes())
     }
 
     /// Verifies a base64url-encoded Ed25519 signature against this canonical form.
+    ///
+    /// # Errors
     ///
     /// Returns [`Error::InvalidSignatureEncoding`] if `signature_b64` is not valid
     /// base64url or not a 64-byte signature, and [`Error::VerificationFailed`] if
@@ -428,7 +418,7 @@ mod tests {
     }
 
     #[test]
-    fn non_text_header_value_is_rejected() {
+    fn canonical_rejects_non_text_header_value() {
         let mut headers = HeaderMap::new();
         headers.insert(
             HeaderName::from_static("x-binary"),
@@ -443,7 +433,7 @@ mod tests {
                 &headers,
                 &[&x_binary],
             ),
-            Err(Error::NonTextHeaderValue)
+            Err(Error::InvalidHeaderValue)
         );
     }
 }

--- a/objectstore-types/src/presign.rs
+++ b/objectstore-types/src/presign.rs
@@ -1,0 +1,274 @@
+//! Canonicalization and signing primitives for pre-signed URLs.
+//!
+//! A pre-signed URL lets a client that owns an Ed25519 keypair (e.g. Relay or
+//! Sentry) hand out a time-limited URL that authorizes a single **GET** or
+//! **HEAD** object read, without the recipient needing an auth token. The
+//! authorization lives entirely in query parameters:
+//!
+//! ```text
+//! GET /v1/objects/<usecase>/<scopes>/<key>
+//!     ?X-Os-Key-Id=relay
+//!     &X-Os-Timestamp=1985-04-12T23:20:50.52Z
+//!     &X-Os-Expires=3600            # validity in seconds
+//!     &X-Os-Sig=<base64url signature>
+//! ```
+//!
+//! The signature covers a **canonical form** of the request (see
+//! [`canonical_request`]). The signer builds and signs it with [`sign`]; the
+//! verifier rebuilds the identical canonical form from the received request and
+//! checks the signature with [`verify`] against the public key selected by
+//! `X-Os-Key-Id`.
+//!
+//! # Canonical form
+//!
+//! The canonical form is four newline-separated components:
+//!
+//! ```text
+//! <method>\n
+//! <canonical path>\n
+//! <canonical query string>\n
+//! <canonical headers>
+//! ```
+//!
+//! - **method** — the uppercase HTTP method, with `HEAD` normalized to `GET` so
+//!   that a single signature is valid for either (a `HEAD` is a bodyless `GET`).
+//! - **canonical path** — the request path, percent-encoded as a single string
+//!   using [`NON_ALPHANUMERIC`] (uppercase hex). The `/` separator is not
+//!   treated specially; it is encoded like any other reserved byte.
+//! - **canonical query string** — every query parameter except [`X_OS_SIG`],
+//!   with keys and values percent-encoded (same set), sorted by encoded key then
+//!   encoded value, and joined as `key=value` pairs with `&`.
+//! - **canonical headers** — empty for now. Signing specific request headers is
+//!   a future extension (`X-Os-Signed-Headers`), so the canonical form currently
+//!   always ends with a trailing newline (an empty final line).
+//!
+//! The signature algorithm is fixed to Ed25519 today; `X-Os-Alg` is reserved for
+//! a future extension.
+
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use ed25519_dalek::{Signature, Signer};
+use http::Method;
+use percent_encoding::{NON_ALPHANUMERIC, percent_encode};
+
+pub use ed25519_dalek::{SigningKey, VerifyingKey};
+
+/// Query parameter naming the key ID used to sign the request.
+///
+/// Its value selects the public key the verifier uses (the same `kid` mechanism
+/// as JWT auth).
+pub const X_OS_KEY_ID: &str = "X-Os-Key-Id";
+
+/// Query parameter carrying the time at which the request was signed.
+pub const X_OS_TIMESTAMP: &str = "X-Os-Timestamp";
+
+/// Query parameter carrying the validity duration, in seconds.
+pub const X_OS_EXPIRES: &str = "X-Os-Expires";
+
+/// Query parameter carrying the base64url-encoded signature.
+///
+/// This parameter is excluded from the canonical query string, since it is the
+/// output of signing that string.
+pub const X_OS_SIG: &str = "X-Os-Sig";
+
+/// Errors returned when verifying a pre-signed request signature.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum PresignError {
+    /// The signature was not valid base64url or did not decode to a 64-byte
+    /// Ed25519 signature.
+    #[error("invalid signature encoding")]
+    InvalidSignatureEncoding,
+    /// The signature did not match the canonical request for the given key.
+    #[error("signature verification failed")]
+    VerificationFailed,
+}
+
+/// Builds the canonical string that gets signed for a pre-signed request.
+///
+/// See the [module-level documentation](self) for the exact format. `HEAD` is
+/// normalized to `GET`, and [`X_OS_SIG`] is excluded from the canonical query
+/// string.
+///
+/// `path` must be the request path as it appears in the URL (the same value the
+/// signer put on the wire and the verifier reads back, e.g. `uri.path()`); it is
+/// percent-encoded wholesale. `query` is the list of decoded query parameter
+/// key/value pairs; they are re-encoded canonically here, so ordering of the
+/// input does not matter.
+pub fn canonical_request(method: &Method, path: &str, query: &[(String, String)]) -> String {
+    let method = if *method == Method::HEAD {
+        "GET"
+    } else {
+        method.as_str()
+    };
+
+    let canonical_path = percent_encode(path.as_bytes(), NON_ALPHANUMERIC).to_string();
+
+    let mut pairs: Vec<(String, String)> = query
+        .iter()
+        .filter(|(key, _)| key.as_str() != X_OS_SIG)
+        .map(|(key, value)| {
+            (
+                percent_encode(key.as_bytes(), NON_ALPHANUMERIC).to_string(),
+                percent_encode(value.as_bytes(), NON_ALPHANUMERIC).to_string(),
+            )
+        })
+        .collect();
+    pairs.sort();
+
+    let canonical_query = pairs
+        .iter()
+        .map(|(key, value)| format!("{key}={value}"))
+        .collect::<Vec<_>>()
+        .join("&");
+
+    format!("{method}\n{canonical_path}\n{canonical_query}\n")
+}
+
+/// Signs a canonical request string with Ed25519.
+///
+/// Returns the base64url-encoded (no padding) signature, suitable as the value
+/// of the [`X_OS_SIG`] query parameter.
+pub fn sign(signing_key: &SigningKey, canonical: &str) -> String {
+    let signature = signing_key.sign(canonical.as_bytes());
+    URL_SAFE_NO_PAD.encode(signature.to_bytes())
+}
+
+/// Verifies a base64url-encoded Ed25519 signature over a canonical request
+/// string.
+///
+/// Returns [`PresignError::InvalidSignatureEncoding`] if `signature_b64` is not
+/// valid base64url or not a 64-byte signature, and
+/// [`PresignError::VerificationFailed`] if the signature does not match.
+pub fn verify(
+    verifying_key: &VerifyingKey,
+    canonical: &str,
+    signature_b64: &str,
+) -> Result<(), PresignError> {
+    let bytes = URL_SAFE_NO_PAD
+        .decode(signature_b64)
+        .map_err(|_| PresignError::InvalidSignatureEncoding)?;
+    let signature =
+        Signature::from_slice(&bytes).map_err(|_| PresignError::InvalidSignatureEncoding)?;
+    verifying_key
+        .verify_strict(canonical.as_bytes(), &signature)
+        .map_err(|_| PresignError::VerificationFailed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Deterministic signing key for tests (a fixed 32-byte Ed25519 seed).
+    ///
+    /// Avoids depending on `objectstore-test` (which would be a dependency cycle)
+    /// or on a random source.
+    fn test_signing_key() -> SigningKey {
+        SigningKey::from_bytes(&[0x42; 32])
+    }
+
+    fn sample_query() -> Vec<(String, String)> {
+        // Intentionally unsorted, and includes X-Os-Sig which must be excluded.
+        vec![
+            (
+                X_OS_TIMESTAMP.to_owned(),
+                "1985-04-12T23:20:50.52Z".to_owned(),
+            ),
+            (X_OS_KEY_ID.to_owned(), "relay".to_owned()),
+            (X_OS_EXPIRES.to_owned(), "3600".to_owned()),
+            (X_OS_SIG.to_owned(), "should-be-excluded".to_owned()),
+        ]
+    }
+
+    #[test]
+    fn canonical_form_is_stable() {
+        let canonical = canonical_request(
+            &Method::GET,
+            "/v1/objects/testing/org=17;project=42/foo/bar",
+            &sample_query(),
+        );
+
+        // Known-answer test that pins the exact bytes: path fully percent-encoded
+        // (slashes too), X-Os-Sig excluded, params sorted by encoded key, and a
+        // trailing empty header line.
+        assert_eq!(
+            canonical,
+            "GET\n\
+             %2Fv1%2Fobjects%2Ftesting%2Forg%3D17%3Bproject%3D42%2Ffoo%2Fbar\n\
+             X%2DOs%2DExpires=3600&\
+             X%2DOs%2DKey%2DId=relay&\
+             X%2DOs%2DTimestamp=1985%2D04%2D12T23%3A20%3A50%2E52Z\n"
+        );
+    }
+
+    #[test]
+    fn head_is_normalized_to_get() {
+        let path = "/v1/objects/testing/_/key";
+        let query = sample_query();
+        assert_eq!(
+            canonical_request(&Method::HEAD, path, &query),
+            canonical_request(&Method::GET, path, &query),
+        );
+    }
+
+    #[test]
+    fn sign_and_verify_roundtrip() {
+        let sk = test_signing_key();
+        let vk = sk.verifying_key();
+
+        let canonical =
+            canonical_request(&Method::GET, "/v1/objects/testing/_/key", &sample_query());
+        let signature = sign(&sk, &canonical);
+
+        assert_eq!(verify(&vk, &canonical, &signature), Ok(()));
+    }
+
+    #[test]
+    fn verify_rejects_tampered_canonical() {
+        let sk = test_signing_key();
+        let vk = sk.verifying_key();
+
+        let canonical =
+            canonical_request(&Method::GET, "/v1/objects/testing/_/key", &sample_query());
+        let signature = sign(&sk, &canonical);
+
+        let tampered =
+            canonical_request(&Method::GET, "/v1/objects/testing/_/other", &sample_query());
+        assert_eq!(
+            verify(&vk, &tampered, &signature),
+            Err(PresignError::VerificationFailed)
+        );
+    }
+
+    #[test]
+    fn verify_rejects_wrong_key() {
+        let sk = test_signing_key();
+        let other_vk = SigningKey::from_bytes(&[0x01; 32]).verifying_key();
+
+        let canonical =
+            canonical_request(&Method::GET, "/v1/objects/testing/_/key", &sample_query());
+        let signature = sign(&sk, &canonical);
+
+        assert_eq!(
+            verify(&other_vk, &canonical, &signature),
+            Err(PresignError::VerificationFailed)
+        );
+    }
+
+    #[test]
+    fn verify_rejects_bad_signature_encoding() {
+        let vk = test_signing_key().verifying_key();
+        let canonical =
+            canonical_request(&Method::GET, "/v1/objects/testing/_/key", &sample_query());
+
+        // Not valid base64url.
+        assert_eq!(
+            verify(&vk, &canonical, "not valid base64!!"),
+            Err(PresignError::InvalidSignatureEncoding)
+        );
+        // Valid base64url but not a 64-byte signature.
+        assert_eq!(
+            verify(&vk, &canonical, &URL_SAFE_NO_PAD.encode([0u8; 10])),
+            Err(PresignError::InvalidSignatureEncoding)
+        );
+    }
+}

--- a/objectstore-types/src/presign.rs
+++ b/objectstore-types/src/presign.rs
@@ -1,49 +1,49 @@
-//! Canonicalization and signing primitives for pre-signed URLs.
+//! Utilities for signing and verifying pre-signed URLs.
 //!
-//! A pre-signed URL lets a client that owns an Ed25519 keypair (e.g. Relay or
-//! Sentry) hand out a time-limited URL that authorizes a single **GET** or
-//! **HEAD** object read, without the recipient needing an auth token. The
-//! authorization lives entirely in query parameters:
+//! A pre-signed URL lets a client that owns an Ed25519 keypair hand out a
+//! time-limited URL that authorizes a specific request.
+//! Example:
 //!
 //! ```text
 //! GET /v1/objects/<usecase>/<scopes>/<key>
 //!     ?X-Os-Key-Id=relay
-//!     &X-Os-Timestamp=1985-04-12T23:20:50.52Z
-//!     &X-Os-Expires=3600            # validity in seconds
-//!     &X-Os-Sig=<base64url signature>
+//!     &X-Os-Timestamp=2026-04-20T13:37:00.00Z
+//!     &X-Os-Expires=<duration in seconds>
+//!     &X-Os-Sig=<signature>
 //! ```
 //!
-//! The signature covers a **canonical form** of the request (see
-//! [`canonical_request`]). The signer builds and signs it with [`sign`]; the
-//! verifier rebuilds the identical canonical form from the received request and
-//! checks the signature with [`verify`] against the public key selected by
-//! `X-Os-Key-Id`.
+//! The signature covers a **canonical form** (see below) of the request.
+//!
+//! In addition to the above query parameters, the following query
+//! parameters are intended to be introduced in future if/when needed:
+//! - `X-Os-Alg`: specifies the signing algorithm. When unspecified, defaults to
+//!   Ed25519.
+//! - `X-Os-Signed-Headers`: specifies the request headers that are signed (see below).
 //!
 //! # Canonical form
 //!
-//! The canonical form is four newline-separated components:
+//! The canonical form is comprised of four newline-separated components:
 //!
 //! ```text
-//! <method>\n
+//! <canonical method>\n
 //! <canonical path>\n
 //! <canonical query string>\n
 //! <canonical headers>
 //! ```
 //!
-//! - **method** — the uppercase HTTP method, with `HEAD` normalized to `GET` so
-//!   that a single signature is valid for either (a `HEAD` is a bodyless `GET`).
-//! - **canonical path** — the request path, percent-encoded as a single string
-//!   using [`NON_ALPHANUMERIC`] (uppercase hex). The `/` separator is not
-//!   treated specially; it is encoded like any other reserved byte.
-//! - **canonical query string** — every query parameter except [`X_OS_SIG`],
-//!   with keys and values percent-encoded (same set), sorted by encoded key then
-//!   encoded value, and joined as `key=value` pairs with `&`.
-//! - **canonical headers** — empty for now. Signing specific request headers is
-//!   a future extension (`X-Os-Signed-Headers`), so the canonical form currently
-//!   always ends with a trailing newline (an empty final line).
+//! - canonical method: the uppercase HTTP method, with `HEAD` mapped to `GET`;
+//! - canonical path: the percent-encoded request path;
+//! - canonical query string: every query parameter except `X-Os-Sig`,
+//!   with keys and values percent-encoded, sorted by encoded key then
+//!   encoded value, joined as `key=value` pairs with `&` separator.
+//! - canonical headers: the request headers named in `X-Os-Signed-Headers`, each
+//!   rendered as `name:value` with a lowercase name and its value's surrounding
+//!   whitespace stripped, sorted by name, and joined with a `\n` separator.
+//!   When no headers are signed this component is empty, so the canonical form ends
+//!   with a trailing newline.
 //!
-//! The signature algorithm is fixed to Ed25519 today; `X-Os-Alg` is reserved for
-//! a future extension.
+//! Percent encoding of the path and query is always performed using the
+//! [`NON_ALPHANUMERIC`] character set into uppercase hex digits.
 
 use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -94,7 +94,19 @@ pub enum PresignError {
 /// percent-encoded wholesale. `query` is the list of decoded query parameter
 /// key/value pairs; they are re-encoded canonically here, so ordering of the
 /// input does not matter.
-pub fn canonical_request(method: &Method, path: &str, query: &[(String, String)]) -> String {
+///
+/// `signed_headers` is the list of request headers named by `X-Os-Signed-Headers`
+/// (name/value pairs); names are lowercased, values are whitespace-trimmed, and
+/// the entries are sorted by name here, so input ordering does not matter. Pass an
+/// empty slice when no headers are signed. Values must come from a validated HTTP
+/// header map (they must not contain CR/LF); see the
+/// [module-level documentation](self).
+pub fn canonical_request(
+    method: &Method,
+    path: &str,
+    query: &[(&str, &str)],
+    signed_headers: &[(&str, &str)],
+) -> String {
     let method = if *method == Method::HEAD {
         "GET"
     } else {
@@ -105,8 +117,8 @@ pub fn canonical_request(method: &Method, path: &str, query: &[(String, String)]
 
     let mut pairs: Vec<(String, String)> = query
         .iter()
-        .filter(|(key, _)| key.as_str() != X_OS_SIG)
-        .map(|(key, value)| {
+        .filter(|&&(key, _)| key != X_OS_SIG)
+        .map(|&(key, value)| {
             (
                 percent_encode(key.as_bytes(), NON_ALPHANUMERIC).to_string(),
                 percent_encode(value.as_bytes(), NON_ALPHANUMERIC).to_string(),
@@ -121,7 +133,19 @@ pub fn canonical_request(method: &Method, path: &str, query: &[(String, String)]
         .collect::<Vec<_>>()
         .join("&");
 
-    format!("{method}\n{canonical_path}\n{canonical_query}\n")
+    let mut headers: Vec<(String, &str)> = signed_headers
+        .iter()
+        .map(|&(name, value)| (name.to_ascii_lowercase(), value.trim()))
+        .collect();
+    headers.sort();
+
+    let canonical_headers = headers
+        .iter()
+        .map(|(name, value)| format!("{name}:{value}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!("{method}\n{canonical_path}\n{canonical_query}\n{canonical_headers}")
 }
 
 /// Signs a canonical request string with Ed25519.
@@ -166,16 +190,13 @@ mod tests {
         SigningKey::from_bytes(&[0x42; 32])
     }
 
-    fn sample_query() -> Vec<(String, String)> {
+    fn sample_query() -> Vec<(&'static str, &'static str)> {
         // Intentionally unsorted, and includes X-Os-Sig which must be excluded.
         vec![
-            (
-                X_OS_TIMESTAMP.to_owned(),
-                "1985-04-12T23:20:50.52Z".to_owned(),
-            ),
-            (X_OS_KEY_ID.to_owned(), "relay".to_owned()),
-            (X_OS_EXPIRES.to_owned(), "3600".to_owned()),
-            (X_OS_SIG.to_owned(), "should-be-excluded".to_owned()),
+            (X_OS_TIMESTAMP, "1985-04-12T23:20:50.52Z"),
+            (X_OS_KEY_ID, "relay"),
+            (X_OS_EXPIRES, "3600"),
+            (X_OS_SIG, "should-be-excluded"),
         ]
     }
 
@@ -185,11 +206,12 @@ mod tests {
             &Method::GET,
             "/v1/objects/testing/org=17;project=42/foo/bar",
             &sample_query(),
+            &[],
         );
 
         // Known-answer test that pins the exact bytes: path fully percent-encoded
         // (slashes too), X-Os-Sig excluded, params sorted by encoded key, and a
-        // trailing empty header line.
+        // trailing empty header line (no signed headers).
         assert_eq!(
             canonical,
             "GET\n\
@@ -205,8 +227,8 @@ mod tests {
         let path = "/v1/objects/testing/_/key";
         let query = sample_query();
         assert_eq!(
-            canonical_request(&Method::HEAD, path, &query),
-            canonical_request(&Method::GET, path, &query),
+            canonical_request(&Method::HEAD, path, &query, &[]),
+            canonical_request(&Method::GET, path, &query, &[]),
         );
     }
 
@@ -215,8 +237,12 @@ mod tests {
         let sk = test_signing_key();
         let vk = sk.verifying_key();
 
-        let canonical =
-            canonical_request(&Method::GET, "/v1/objects/testing/_/key", &sample_query());
+        let canonical = canonical_request(
+            &Method::GET,
+            "/v1/objects/testing/_/key",
+            &sample_query(),
+            &[("Content-Type", "application/json")],
+        );
         let signature = sign(&sk, &canonical);
 
         assert_eq!(verify(&vk, &canonical, &signature), Ok(()));
@@ -227,12 +253,20 @@ mod tests {
         let sk = test_signing_key();
         let vk = sk.verifying_key();
 
-        let canonical =
-            canonical_request(&Method::GET, "/v1/objects/testing/_/key", &sample_query());
+        let canonical = canonical_request(
+            &Method::GET,
+            "/v1/objects/testing/_/key",
+            &sample_query(),
+            &[],
+        );
         let signature = sign(&sk, &canonical);
 
-        let tampered =
-            canonical_request(&Method::GET, "/v1/objects/testing/_/other", &sample_query());
+        let tampered = canonical_request(
+            &Method::GET,
+            "/v1/objects/testing/_/other",
+            &sample_query(),
+            &[],
+        );
         assert_eq!(
             verify(&vk, &tampered, &signature),
             Err(PresignError::VerificationFailed)
@@ -244,8 +278,12 @@ mod tests {
         let sk = test_signing_key();
         let other_vk = SigningKey::from_bytes(&[0x01; 32]).verifying_key();
 
-        let canonical =
-            canonical_request(&Method::GET, "/v1/objects/testing/_/key", &sample_query());
+        let canonical = canonical_request(
+            &Method::GET,
+            "/v1/objects/testing/_/key",
+            &sample_query(),
+            &[],
+        );
         let signature = sign(&sk, &canonical);
 
         assert_eq!(
@@ -257,8 +295,12 @@ mod tests {
     #[test]
     fn verify_rejects_bad_signature_encoding() {
         let vk = test_signing_key().verifying_key();
-        let canonical =
-            canonical_request(&Method::GET, "/v1/objects/testing/_/key", &sample_query());
+        let canonical = canonical_request(
+            &Method::GET,
+            "/v1/objects/testing/_/key",
+            &sample_query(),
+            &[],
+        );
 
         // Not valid base64url.
         assert_eq!(
@@ -270,5 +312,44 @@ mod tests {
             verify(&vk, &canonical, &URL_SAFE_NO_PAD.encode([0u8; 10])),
             Err(PresignError::InvalidSignatureEncoding)
         );
+    }
+
+    #[test]
+    fn canonical_headers_are_lowercased_trimmed_and_sorted() {
+        // Intentionally unsorted, mixed-case names, padded values.
+        let headers = [
+            ("Host", "objectstore.example.com"),
+            ("Content-Type", "  application/json  "),
+        ];
+        let canonical = canonical_request(
+            &Method::GET,
+            "/v1/objects/testing/_/key",
+            &sample_query(),
+            &headers,
+        );
+
+        // The canonical headers replace the previously-empty final component:
+        // names lowercased, values trimmed, sorted by name, joined with `\n`.
+        assert_eq!(
+            canonical,
+            "GET\n\
+             %2Fv1%2Fobjects%2Ftesting%2F%5F%2Fkey\n\
+             X%2DOs%2DExpires=3600&\
+             X%2DOs%2DKey%2DId=relay&\
+             X%2DOs%2DTimestamp=1985%2D04%2D12T23%3A20%3A50%2E52Z\n\
+             content-type:application/json\n\
+             host:objectstore.example.com"
+        );
+    }
+
+    #[test]
+    fn empty_signed_headers_matches_trailing_newline_form() {
+        // Passing no signed headers must be byte-identical to the historical
+        // three-component form, so existing GET/HEAD signatures keep verifying.
+        let path = "/v1/objects/testing/_/key";
+        let query = sample_query();
+        let canonical = canonical_request(&Method::GET, path, &query, &[]);
+        assert!(canonical.ends_with("\n"));
+        assert!(!canonical.contains(':'));
     }
 }

--- a/objectstore-types/src/presign.rs
+++ b/objectstore-types/src/presign.rs
@@ -71,6 +71,9 @@ pub enum Error {
     /// Ed25519 signature.
     #[error("invalid signature encoding")]
     InvalidSignatureEncoding,
+    /// A header listed in `signed_headers` was not present in the request.
+    #[error("signed header `{0}` is missing from the request")]
+    MissingSignedHeader(HeaderName),
     /// A signed header's value was not valid text (i.e. not printable ASCII).
     #[error("signed header value is not valid text")]
     InvalidHeaderValue,
@@ -90,7 +93,9 @@ impl CanonicalRequest {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::InvalidHeaderValue`] if a signed header's value is not
+    /// Returns [`Error::MissingSignedHeader`] if a header listed in
+    /// `signed_headers` is not present in `headers`, and
+    /// [`Error::InvalidHeaderValue`] if a signed header's value is not
     /// printable ASCII.
     pub fn new(
         method: &Method,
@@ -117,10 +122,11 @@ impl CanonicalRequest {
 
         let mut header_pairs: Vec<(&str, &str)> = Vec::with_capacity(signed_headers.len());
         for name in signed_headers {
-            if let Some(value) = headers.get(*name) {
-                let value = value.to_str().map_err(|_| Error::InvalidHeaderValue)?;
-                header_pairs.push((name.as_str(), value.trim()));
-            }
+            let value = headers
+                .get(*name)
+                .ok_or_else(|| Error::MissingSignedHeader((*name).clone()))?;
+            let value = value.to_str().map_err(|_| Error::InvalidHeaderValue)?;
+            header_pairs.push((name.as_str(), value.trim()));
         }
         header_pairs.sort();
 
@@ -390,6 +396,21 @@ mod tests {
         assert_eq!(
             canonical.verify(&vk, &URL_SAFE_NO_PAD.encode([0u8; 10])),
             Err(Error::InvalidSignatureEncoding)
+        );
+    }
+
+    #[test]
+    fn canonical_rejects_missing_signed_header() {
+        let host = HeaderName::from_static("host");
+        assert_eq!(
+            CanonicalRequest::new(
+                &Method::GET,
+                "/v1/objects/testing/_/key",
+                None,
+                &HeaderMap::new(),
+                &[&host],
+            ),
+            Err(Error::MissingSignedHeader(host))
         );
     }
 

--- a/objectstore-types/src/presign.rs
+++ b/objectstore-types/src/presign.rs
@@ -16,6 +16,7 @@
 //! ```
 //!
 //! The signature covers a **canonical form** (see below) of the request.
+//! The X-Os-Alg is currently ignored, and intended for potential future use.
 //!
 //! # Canonical form
 //!
@@ -75,110 +76,110 @@ pub enum Error {
     /// Ed25519 signature.
     #[error("invalid signature encoding")]
     InvalidSignatureEncoding,
-    /// An unknown signature algorithm was specified.
-    #[error("unknown algorithm")]
-    UnknownAlgorithm,
     /// The signature did not match the canonical request for the given key.
     #[error("signature verification failed")]
     VerificationFailed,
 }
 
-/// Builds the canonical string that gets signed for a pre-signed request.
-///
-/// See the [module-level documentation](self) for the exact format.
-///
-/// Note that header values must come from a validated HTTP header map (i.e., they must not contain
-/// CR/LF).
-pub fn canonical_request(
-    method: &Method,
-    path: &str,
-    query: &[(&str, &str)],
-    signed_headers: &[(&str, &str)],
-) -> String {
-    let canonical_method = if *method == Method::HEAD {
-        "GET"
-    } else {
-        method.as_str()
-    };
+/// The canonical form of a request to be signed or verified.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CanonicalRequest(String);
 
-    let canonical_path = percent_encode(path.as_bytes(), NON_ALPHANUMERIC).to_string();
+impl CanonicalRequest {
+    /// Builds the canonical form of a request.
+    ///
+    /// See the [module-level documentation](self) for the exact format.
+    ///
+    /// Note that header values must come from a validated HTTP header map (i.e.,
+    /// they must not contain CR/LF).
+    pub fn new(
+        method: &Method,
+        path: &str,
+        query: &[(&str, &str)],
+        signed_headers: &[(&str, &str)],
+    ) -> Self {
+        let canonical_method = if *method == Method::HEAD {
+            "GET"
+        } else {
+            method.as_str()
+        };
 
-    let mut pairs: Vec<(String, String)> = query
-        .iter()
-        .filter(|&&(key, _)| key != X_OS_SIG)
-        .map(|&(key, value)| {
-            (
-                percent_encode(key.as_bytes(), NON_ALPHANUMERIC).to_string(),
-                percent_encode(value.as_bytes(), NON_ALPHANUMERIC).to_string(),
-            )
-        })
-        .collect();
-    pairs.sort();
+        let canonical_path = percent_encode(path.as_bytes(), NON_ALPHANUMERIC).to_string();
 
-    let canonical_query = pairs
-        .iter()
-        .map(|(key, value)| format!("{key}={value}"))
-        .collect::<Vec<_>>()
-        .join("&");
+        let mut pairs: Vec<(String, String)> = query
+            .iter()
+            .filter(|&&(key, _)| key != X_OS_SIG)
+            .map(|&(key, value)| {
+                (
+                    percent_encode(key.as_bytes(), NON_ALPHANUMERIC).to_string(),
+                    percent_encode(value.as_bytes(), NON_ALPHANUMERIC).to_string(),
+                )
+            })
+            .collect();
+        pairs.sort();
 
-    let mut headers: Vec<(String, &str)> = signed_headers
-        .iter()
-        .map(|&(name, value)| (name.to_ascii_lowercase(), value.trim()))
-        .collect();
-    headers.sort();
+        let canonical_query = pairs
+            .iter()
+            .map(|(key, value)| format!("{key}={value}"))
+            .collect::<Vec<_>>()
+            .join("&");
 
-    let canonical_headers = headers
-        .iter()
-        .map(|(name, value)| format!("{name}:{value}"))
-        .collect::<Vec<_>>()
-        .join("\n");
+        let mut headers: Vec<(String, &str)> = signed_headers
+            .iter()
+            .map(|&(name, value)| (name.to_ascii_lowercase(), value.trim()))
+            .collect();
+        headers.sort();
 
-    format!("{canonical_method}\n{canonical_path}\n{canonical_query}\n{canonical_headers}")
-}
+        let canonical_headers = headers
+            .iter()
+            .map(|(name, value)| format!("{name}:{value}"))
+            .collect::<Vec<_>>()
+            .join("\n");
 
-/// Signs a canonical request string with Ed25519.
-///
-/// Returns the base64url-encoded (no padding) signature, suitable as the value
-/// of the [`X_OS_SIG`] query parameter.
-pub fn sign(signing_key: &SigningKey, canonical: &str) -> String {
-    let signature = signing_key.sign(canonical.as_bytes());
-    URL_SAFE_NO_PAD.encode(signature.to_bytes())
-}
+        Self(format!(
+            "{canonical_method}\n{canonical_path}\n{canonical_query}\n{canonical_headers}"
+        ))
+    }
 
-/// Verifies a base64url-encoded Ed25519 signature over a canonical request
-/// string.
-///
-/// Returns [`PresignError::InvalidSignatureEncoding`] if `signature_b64` is not
-/// valid base64url or not a 64-byte signature, and
-/// [`PresignError::VerificationFailed`] if the signature does not match.
-pub fn verify(
-    verifying_key: &VerifyingKey,
-    canonical: &str,
-    signature_b64: &str,
-) -> Result<(), Error> {
-    let bytes = URL_SAFE_NO_PAD
-        .decode(signature_b64)
-        .map_err(|_| Error::InvalidSignatureEncoding)?;
-    let signature = Signature::from_slice(&bytes).map_err(|_| Error::InvalidSignatureEncoding)?;
-    verifying_key
-        .verify_strict(canonical.as_bytes(), &signature)
-        .map_err(|_| Error::VerificationFailed)
+    /// Returns the canonical form as a string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Signs this canonical form with Ed25519.
+    ///
+    /// Returns the base64url-encoded (no padding) signature, suitable as the value
+    /// of the [`X_OS_SIG`] query parameter.
+    pub fn sign(&self, key: &SigningKey) -> String {
+        let signature = key.sign(self.0.as_bytes());
+        URL_SAFE_NO_PAD.encode(signature.to_bytes())
+    }
+
+    /// Verifies a base64url-encoded Ed25519 signature against this canonical form.
+    ///
+    /// Returns [`Error::InvalidSignatureEncoding`] if `signature_b64` is not valid
+    /// base64url or not a 64-byte signature, and [`Error::VerificationFailed`] if
+    /// the signature does not match.
+    pub fn verify(&self, key: &VerifyingKey, signature_b64: &str) -> Result<(), Error> {
+        let bytes = URL_SAFE_NO_PAD
+            .decode(signature_b64)
+            .map_err(|_| Error::InvalidSignatureEncoding)?;
+        let signature =
+            Signature::from_slice(&bytes).map_err(|_| Error::InvalidSignatureEncoding)?;
+        key.verify_strict(self.0.as_bytes(), &signature)
+            .map_err(|_| Error::VerificationFailed)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// Deterministic signing key for tests (a fixed 32-byte Ed25519 seed).
-    ///
-    /// Avoids depending on `objectstore-test` (which would be a dependency cycle)
-    /// or on a random source.
     fn test_signing_key() -> SigningKey {
         SigningKey::from_bytes(&[0x42; 32])
     }
 
     fn sample_query() -> Vec<(&'static str, &'static str)> {
-        // Intentionally unsorted, and includes X-Os-Sig which must be excluded.
         vec![
             (X_OS_TIMESTAMP, "1985-04-12T23:20:50.52Z"),
             (X_OS_KEY_ID, "relay"),
@@ -189,136 +190,35 @@ mod tests {
 
     #[test]
     fn canonical_form_is_stable() {
-        let canonical = canonical_request(
+        let canonical = CanonicalRequest::new(
             &Method::GET,
             "/v1/objects/testing/org=17;project=42/foo/bar",
             &sample_query(),
             &[],
         );
 
-        // Known-answer test that pins the exact bytes: path fully percent-encoded
-        // (slashes too), X-Os-Sig excluded, params sorted by encoded key, and a
-        // trailing empty header line (no signed headers).
         assert_eq!(
-            canonical,
+            canonical.as_str(),
             "GET\n\
              %2Fv1%2Fobjects%2Ftesting%2Forg%3D17%3Bproject%3D42%2Ffoo%2Fbar\n\
              X%2DOs%2DExpires=3600&\
              X%2DOs%2DKey%2DId=relay&\
              X%2DOs%2DTimestamp=1985%2D04%2D12T23%3A20%3A50%2E52Z\n"
         );
-    }
 
-    #[test]
-    fn head_is_normalized_to_get() {
-        let path = "/v1/objects/testing/_/key";
-        let query = sample_query();
-        assert_eq!(
-            canonical_request(&Method::HEAD, path, &query, &[]),
-            canonical_request(&Method::GET, path, &query, &[]),
-        );
-    }
-
-    #[test]
-    fn sign_and_verify_roundtrip() {
-        let sk = test_signing_key();
-        let vk = sk.verifying_key();
-
-        let canonical = canonical_request(
-            &Method::GET,
-            "/v1/objects/testing/_/key",
-            &sample_query(),
-            &[("Content-Type", "application/json")],
-        );
-        let signature = sign(&sk, &canonical);
-
-        assert_eq!(verify(&vk, &canonical, &signature), Ok(()));
-    }
-
-    #[test]
-    fn verify_rejects_tampered_canonical() {
-        let sk = test_signing_key();
-        let vk = sk.verifying_key();
-
-        let canonical = canonical_request(
-            &Method::GET,
-            "/v1/objects/testing/_/key",
-            &sample_query(),
-            &[],
-        );
-        let signature = sign(&sk, &canonical);
-
-        let tampered = canonical_request(
-            &Method::GET,
-            "/v1/objects/testing/_/other",
-            &sample_query(),
-            &[],
-        );
-        assert_eq!(
-            verify(&vk, &tampered, &signature),
-            Err(Error::VerificationFailed)
-        );
-    }
-
-    #[test]
-    fn verify_rejects_wrong_key() {
-        let sk = test_signing_key();
-        let other_vk = SigningKey::from_bytes(&[0x01; 32]).verifying_key();
-
-        let canonical = canonical_request(
-            &Method::GET,
-            "/v1/objects/testing/_/key",
-            &sample_query(),
-            &[],
-        );
-        let signature = sign(&sk, &canonical);
-
-        assert_eq!(
-            verify(&other_vk, &canonical, &signature),
-            Err(Error::VerificationFailed)
-        );
-    }
-
-    #[test]
-    fn verify_rejects_bad_signature_encoding() {
-        let vk = test_signing_key().verifying_key();
-        let canonical = canonical_request(
-            &Method::GET,
-            "/v1/objects/testing/_/key",
-            &sample_query(),
-            &[],
-        );
-
-        // Not valid base64url.
-        assert_eq!(
-            verify(&vk, &canonical, "not valid base64!!"),
-            Err(Error::InvalidSignatureEncoding)
-        );
-        // Valid base64url but not a 64-byte signature.
-        assert_eq!(
-            verify(&vk, &canonical, &URL_SAFE_NO_PAD.encode([0u8; 10])),
-            Err(Error::InvalidSignatureEncoding)
-        );
-    }
-
-    #[test]
-    fn canonical_headers_are_lowercased_trimmed_and_sorted() {
-        // Intentionally unsorted, mixed-case names, padded values.
         let headers = [
             ("Host", "objectstore.example.com"),
             ("Content-Type", "  application/json  "),
         ];
-        let canonical = canonical_request(
+        let canonical = CanonicalRequest::new(
             &Method::GET,
             "/v1/objects/testing/_/key",
             &sample_query(),
             &headers,
         );
 
-        // The canonical headers replace the previously-empty final component:
-        // names lowercased, values trimmed, sorted by name, joined with `\n`.
         assert_eq!(
-            canonical,
+            canonical.as_str(),
             "GET\n\
              %2Fv1%2Fobjects%2Ftesting%2F%5F%2Fkey\n\
              X%2DOs%2DExpires=3600&\
@@ -330,13 +230,94 @@ mod tests {
     }
 
     #[test]
-    fn empty_signed_headers_matches_trailing_newline_form() {
-        // Passing no signed headers must be byte-identical to the historical
-        // three-component form, so existing GET/HEAD signatures keep verifying.
+    fn head_is_normalized_to_get() {
         let path = "/v1/objects/testing/_/key";
         let query = sample_query();
-        let canonical = canonical_request(&Method::GET, path, &query, &[]);
-        assert!(canonical.ends_with("\n"));
-        assert!(!canonical.contains(':'));
+        assert_eq!(
+            CanonicalRequest::new(&Method::HEAD, path, &query, &[]),
+            CanonicalRequest::new(&Method::GET, path, &query, &[]),
+        );
+    }
+
+    #[test]
+    fn sign_and_verify_roundtrip() {
+        let sk = test_signing_key();
+        let vk = sk.verifying_key();
+
+        let canonical = CanonicalRequest::new(
+            &Method::GET,
+            "/v1/objects/testing/_/key",
+            &sample_query(),
+            &[("Content-Type", "application/json")],
+        );
+        let signature = canonical.sign(&sk);
+
+        assert_eq!(canonical.verify(&vk, &signature), Ok(()));
+    }
+
+    #[test]
+    fn verify_rejects_tampered_canonical() {
+        let sk = test_signing_key();
+        let vk = sk.verifying_key();
+
+        let canonical = CanonicalRequest::new(
+            &Method::GET,
+            "/v1/objects/testing/_/key",
+            &sample_query(),
+            &[],
+        );
+        let signature = canonical.sign(&sk);
+
+        let tampered = CanonicalRequest::new(
+            &Method::GET,
+            "/v1/objects/testing/_/other",
+            &sample_query(),
+            &[],
+        );
+        assert_eq!(
+            tampered.verify(&vk, &signature),
+            Err(Error::VerificationFailed)
+        );
+    }
+
+    #[test]
+    fn verify_rejects_wrong_key() {
+        let sk = test_signing_key();
+        let other_vk = SigningKey::from_bytes(&[0x01; 32]).verifying_key();
+
+        let canonical = CanonicalRequest::new(
+            &Method::GET,
+            "/v1/objects/testing/_/key",
+            &sample_query(),
+            &[],
+        );
+        let signature = canonical.sign(&sk);
+
+        assert_eq!(
+            canonical.verify(&other_vk, &signature),
+            Err(Error::VerificationFailed)
+        );
+    }
+
+    #[test]
+    fn verify_rejects_bad_signature_encoding() {
+        let vk = test_signing_key().verifying_key();
+        let canonical = CanonicalRequest::new(
+            &Method::GET,
+            "/v1/objects/testing/_/key",
+            &sample_query(),
+            &[],
+        );
+
+        // Not valid base64url.
+        assert_eq!(
+            canonical.verify(&vk, "not valid base64!!"),
+            Err(Error::InvalidSignatureEncoding)
+        );
+        // Valid base64url but not a 64-byte signature.
+        assert_eq!(
+            canonical.verify(&vk, &URL_SAFE_NO_PAD.encode([0u8; 10])),
+            Err(Error::InvalidSignatureEncoding)
+        );
     }
 }

--- a/objectstore-types/src/presign.rs
+++ b/objectstore-types/src/presign.rs
@@ -16,7 +16,7 @@
 //! ```
 //!
 //! The signature covers a **canonical form** (see below) of the request.
-//! The X-Os-Alg is currently ignored, and intended for potential future use.
+//! `X-Os-Alg` is currently ignored, and intended for potential future use.
 //!
 //! # Canonical form
 //!


### PR DESCRIPTION
Adds `objectstore-types::presign` — low-level utilities for signing and verifying Ed25519-signed pre-signed URLs, as specified in the [design doc](https://app.notion.com/p/sentry/Capability-Pre-signed-URLs-3418b10e4b5d8076ba65c4382f077b82?v=21e8b10e4b5d80e8a4e5000cf4b021f2&source=copy_link).

## What this does

Pre-signed URLs let a client that holds an Ed25519 keypair produce a time-limited, request-bound URL without requiring the server to share a secret. The server only needs the corresponding public key to verify.

A signed request looks like:

```
GET /v1/objects/<usecase>/<scopes>/<key>
    ?os_timestamp=2026-04-20T13:37:00.00Z
    &os_duration=3600
    &os_kid=relay
    &os_sig=<signature>
```

The signature covers a **canonical form** of the request built from three newline-separated components:

```
<normalized method>\n
<path>\n
<canonical query string>
```

- **Normalized method**: uppercase HTTP method, with `HEAD` mapped to `GET`
- **Path**: the request path, included verbatim as transmitted/received on the wire
- **Canonical query string**: every query parameter except `os-sig`, with keys lowercased, sorted lexicographically by name and value, joined with `&`

This PR provides:
- `CanonicalRequest` — builds and holds the canonical string
- `CanonicalRequest::sign` — signs with a raw 32-byte Ed25519 signing key, returns a base64url-encoded signature
- `CanonicalRequest::verify` — verifies a base64url signature against a raw 32-byte verifying key
- Public query-parameter name constants (`PARAM_TIMESTAMP`, `PARAM_SIG`, `PARAM_KID`, `PARAM_DURATION`)
- `Error` type covering invalid keys, encoding failures, and verification failures

## Design decisions

**Ed25519 (asymmetric) over HMAC (symmetric).** The signer (e.g. Relay) only needs the private key; objectstore verifies with the public key and never has to share a secret. This fits the multi-tenant trust model where different callers hold different keypairs.

**Raw `[u8; 32]` key types instead of re-exporting `ed25519-dalek` types.** Keeps the public API decoupled from the specific Ed25519 crate. Callers pass plain byte arrays; conversion to library-specific key types happens internally.

**`HEAD` normalized to `GET` in the canonical form.** A single signed URL works for both `GET` and `HEAD` requests without re-signing.

**Path included verbatim (no re-encoding).** Avoids signature verification failures from differing URL encoding implementations between client and server. Based on the assumption that intermediate proxies pass the URL through with the original encoding.

**Query parameter keys lowercased before sorting.** Ensures the canonical form is case-insensitive for query parameter names, preventing verification failures from casing differences between client and server.

**No signed headers.** The canonical form does not include request headers — only the method, path, and query string are signed. This keeps the scheme simple and avoids issues with intermediaries modifying headers.

**Duplicate query parameters preserved, not deduplicated.** The canonical query sort is purely lexicographic over `key=value` strings, so duplicate keys survive and are ordered by value deterministically.

**`verify_strict` over `verify`.** Uses `ed25519-dalek`'s strict verification, which rejects edge-case malleability vectors that are technically within spec but undesirable in a security-sensitive path.

**Base64url without padding (`URL_SAFE_NO_PAD`).** Avoids `=` characters that would need percent-encoding in query strings.

## What's not in this PR

Expiry checking (`os_duration` / `os_timestamp`), key-ID resolution (`os_kid`), and server-side middleware wiring are follow-up work. This PR is the signing/verification primitive that those will build on.

Refs FS-386