### PR TITLE
feat(service): Add span instrumentation to backends

### DIFF
--- a/objectstore-log/src/subscriber.rs
+++ b/objectstore-log/src/subscriber.rs
@@ -15,7 +15,8 @@ include!(concat!(env!("OUT_DIR"), "/constants.gen.rs"));
 ///
 /// When built with the `sentry` feature, also attaches a Sentry tracing layer if the Sentry client
 /// has been initialized. `ERROR` and `WARN` events become Sentry events; `INFO`/`DEBUG` become
-/// Sentry logs; `TRACE` is ignored.
+/// Sentry logs; `TRACE` events are ignored. `ERROR`..`DEBUG` spans become Sentry spans; `TRACE`
+/// spans are ignored.
 pub fn init(config: &LoggingConfig) {
     #[cfg(feature = "sentry")]
     let sentry_layer = sentry::Hub::current()
@@ -23,13 +24,15 @@ pub fn init(config: &LoggingConfig) {
         .filter(|c| c.is_enabled())
         .map(|_| {
             use sentry::integrations::tracing as sentry_tracing;
-            sentry_tracing::layer().event_filter(|metadata| match *metadata.level() {
-                Level::ERROR | Level::WARN => {
-                    sentry_tracing::EventFilter::Event | sentry_tracing::EventFilter::Log
-                }
-                Level::INFO | Level::DEBUG => sentry_tracing::EventFilter::Log,
-                Level::TRACE => sentry_tracing::EventFilter::Ignore,
-            })
+            sentry_tracing::layer()
+                .event_filter(|metadata| match *metadata.level() {
+                    Level::ERROR | Level::WARN => {
+                        sentry_tracing::EventFilter::Event | sentry_tracing::EventFilter::Log
+                    }
+                    Level::INFO | Level::DEBUG => sentry_tracing::EventFilter::Log,
+                    Level::TRACE => sentry_tracing::EventFilter::Ignore,
+                })
+                .span_filter(|metadata| !matches!(*metadata.level(), Level::TRACE))
         });
 
     let format = tracing_subscriber::fmt::layer()

--- a/objectstore-service/src/backend/bigtable.rs
+++ b/objectstore-service/src/backend/bigtable.rs
@@ -41,6 +41,7 @@ use objectstore_types::metadata::{ExpirationPolicy, Metadata};
 use objectstore_types::range::{ByteRange, ContentRange};
 use serde::{Deserialize, Serialize};
 use tonic::Code;
+use tracing::Instrument;
 
 use crate::backend::common::{
     Backend, DeleteResponse, GetResponse, HighVolumeBackend, MetadataResponse, PutResponse,
@@ -740,6 +741,7 @@ impl BigTableBackend {
     /// Reads a single row by key, returning parsed row data.
     ///
     /// Returns `None` if the row is absent or has expired.
+    #[tracing::instrument(level = "debug", fields(action), skip_all)]
     async fn read_row(
         &self,
         path: &[u8],
@@ -776,6 +778,7 @@ impl BigTableBackend {
         })
     }
 
+    #[tracing::instrument(level = "debug", fields(action), skip_all)]
     async fn mutate(
         &self,
         path: Vec<u8>,
@@ -821,6 +824,7 @@ impl BigTableBackend {
     /// Best-effort TTI bump for a row.
     ///
     /// If the payload isn't loaded, it will be fetched. Failures are ignored silently.
+    #[tracing::instrument(level = "debug", fields(?hv_id, loaded), skip_all)]
     async fn bump_tti(&self, path: Vec<u8>, row: &RowData, loaded: bool, hv_id: &ObjectId) {
         let expiration_policy = row.expiration_policy();
 
@@ -860,6 +864,7 @@ impl BigTableBackend {
     }
 
     /// Executes a `CheckAndMutateRow` request.
+    #[tracing::instrument(level = "debug", fields(action = context), skip_all)]
     async fn check_and_mutate(
         &self,
         row_key: Vec<u8>,
@@ -898,7 +903,7 @@ impl Backend for BigTableBackend {
         "bigtable"
     }
 
-    #[tracing::instrument(level = "trace", fields(?id), skip_all)]
+    #[tracing::instrument(level = "debug", fields(?id), skip_all)]
     async fn put_object(
         &self,
         id: &ObjectId,
@@ -919,7 +924,7 @@ impl Backend for BigTableBackend {
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", fields(?id), skip_all)]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn get_object(&self, id: &ObjectId, range: Option<ByteRange>) -> Result<GetResponse> {
         match self.get_tiered_object(id, range).await? {
             TieredGet::Object(metadata, content_range, payload) => {
@@ -930,7 +935,7 @@ impl Backend for BigTableBackend {
         }
     }
 
-    #[tracing::instrument(level = "trace", fields(?id), skip_all)]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn get_metadata(&self, id: &ObjectId) -> Result<MetadataResponse> {
         match self.get_tiered_metadata(id).await? {
             TieredMetadata::Object(metadata) => Ok(Some(metadata)),
@@ -939,7 +944,7 @@ impl Backend for BigTableBackend {
         }
     }
 
-    #[tracing::instrument(level = "trace", fields(?id), skip_all)]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn delete_object(&self, id: &ObjectId) -> Result<DeleteResponse> {
         objectstore_log::debug!("Deleting from Bigtable backend");
 
@@ -952,7 +957,7 @@ impl Backend for BigTableBackend {
 
 #[async_trait::async_trait]
 impl HighVolumeBackend for BigTableBackend {
-    #[tracing::instrument(level = "trace", fields(?id), skip_all)]
+    #[tracing::instrument(level = "debug", fields(?id), skip_all)]
     async fn put_non_tombstone(
         &self,
         id: &ObjectId,
@@ -1000,7 +1005,7 @@ impl HighVolumeBackend for BigTableBackend {
         Err(Error::generic("BigTable: race loop in put_non_tombstone"))
     }
 
-    #[tracing::instrument(level = "trace", fields(?id), skip_all)]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn get_tiered_object(
         &self,
         id: &ObjectId,
@@ -1037,7 +1042,7 @@ impl HighVolumeBackend for BigTableBackend {
         })
     }
 
-    #[tracing::instrument(level = "trace", fields(?id), skip_all)]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn get_tiered_metadata(&self, id: &ObjectId) -> Result<TieredMetadata> {
         objectstore_log::debug!("Reading metadata from Bigtable backend");
         let path = id.as_storage_path().to_string().into_bytes();
@@ -1066,7 +1071,7 @@ impl HighVolumeBackend for BigTableBackend {
         })
     }
 
-    #[tracing::instrument(level = "trace", fields(?id), skip_all)]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn delete_non_tombstone(&self, id: &ObjectId) -> Result<Option<Tombstone>> {
         objectstore_log::debug!("Conditional delete from Bigtable backend");
 
@@ -1110,7 +1115,7 @@ impl HighVolumeBackend for BigTableBackend {
         ))
     }
 
-    #[tracing::instrument(level = "trace", fields(?id), skip_all)]
+    #[tracing::instrument(level = "debug", skip(self, write))]
     async fn compare_and_write(
         &self,
         id: &ObjectId,
@@ -1205,7 +1210,26 @@ where
     let mut retry_count = 0usize;
 
     loop {
-        match f().await {
+        let attempt_span = tracing::debug_span!(
+            "bigtable.request",
+            action = context,
+            grpc.status = tracing::field::Empty,
+        );
+        let attempt = async {
+            let result = f().await;
+            let span = tracing::Span::current();
+            match &result {
+                Ok(_) => span.record("grpc.status", "ok"),
+                Err(BigTableError::RpcError(status)) => {
+                    span.record("grpc.status", tracing::field::debug(status.code()))
+                }
+                // Non-RPC error; the error event carries the details.
+                Err(_) => &span,
+            };
+            result
+        };
+
+        match attempt.instrument(attempt_span).await {
             Ok(res) => return Ok(res),
             Err(e) if retry_count >= REQUEST_RETRY_COUNT || !is_retryable(&e) => {
                 objectstore_metrics::count!("bigtable.failures", action = context);

--- a/objectstore-service/src/backend/changelog.rs
+++ b/objectstore-service/src/backend/changelog.rs
@@ -121,6 +121,7 @@ impl ChangeManager {
     ///
     /// When the [`ChangeGuard`] is dropped, a background process is spawned to
     /// clean up any unreferenced objects in LT storage.
+    #[tracing::instrument(level = "debug", fields(id = ?change.id, new = ?change.new, old = ?change.old), skip_all)]
     pub async fn record(self: Arc<Self>, change: Change) -> Result<ChangeGuard> {
         let token = self.tracker.token();
 
@@ -143,6 +144,7 @@ impl ChangeManager {
     /// Behaves like [`Self::record`], except that the guard is created in the `Assembling` state.
     /// Unlike other states, this guard does nothing on drop, leaving the burden of cleaning up to
     /// the [`ChangeLog`].
+    #[tracing::instrument(level = "debug", fields(id = ?change.id, new = ?change.new, old = ?change.old), skip_all)]
     pub async fn record_assembling(self: Arc<Self>, change: Change) -> Result<ChangeGuard> {
         let token = self.tracker.token();
 

--- a/objectstore-service/src/backend/common.rs
+++ b/objectstore-service/src/backend/common.rs
@@ -6,7 +6,6 @@ use objectstore_types::metadata::{ExpirationPolicy, Metadata};
 use objectstore_types::range::{ByteRange, ContentRange};
 
 use bytes::Bytes;
-use tracing::Instrument;
 
 use crate::error::{Error, Result};
 use crate::id::ObjectId;
@@ -279,32 +278,4 @@ pub(super) fn reqwest_client() -> reqwest::Client {
         .no_deflate()
         .build()
         .expect("Client::new()")
-}
-
-/// Extension trait that sends a request inside a tracing span.
-pub(super) trait SendTraced {
-    /// Sends the request, wrapping it in a span that covers the full request
-    /// duration and records the response status code.
-    async fn send_traced(self) -> reqwest::Result<reqwest::Response>;
-}
-
-impl SendTraced for reqwest::RequestBuilder {
-    async fn send_traced(self) -> reqwest::Result<reqwest::Response> {
-        let (client, request) = self.build_split();
-        let request = request?;
-        let span = tracing::debug_span!(
-            "http.request",
-            method = %request.method(),
-            url = %request.url(),
-            http.status_code = tracing::field::Empty,
-        );
-        let send_future = async {
-            let response = client.execute(request).await;
-            if let Ok(response) = &response {
-                tracing::Span::current().record("http.status_code", response.status().as_u16());
-            }
-            response
-        };
-        send_future.instrument(span).await
-    }
 }

--- a/objectstore-service/src/backend/common.rs
+++ b/objectstore-service/src/backend/common.rs
@@ -6,6 +6,7 @@ use objectstore_types::metadata::{ExpirationPolicy, Metadata};
 use objectstore_types::range::{ByteRange, ContentRange};
 
 use bytes::Bytes;
+use tracing::Instrument;
 
 use crate::error::{Error, Result};
 use crate::id::ObjectId;
@@ -278,4 +279,32 @@ pub(super) fn reqwest_client() -> reqwest::Client {
         .no_deflate()
         .build()
         .expect("Client::new()")
+}
+
+/// Extension trait that sends a request inside a tracing span.
+pub(super) trait SendTraced {
+    /// Sends the request, wrapping it in a span that covers the full request
+    /// duration and records the response status code.
+    async fn send_traced(self) -> reqwest::Result<reqwest::Response>;
+}
+
+impl SendTraced for reqwest::RequestBuilder {
+    async fn send_traced(self) -> reqwest::Result<reqwest::Response> {
+        let (client, request) = self.build_split();
+        let request = request?;
+        let span = tracing::debug_span!(
+            "http.request",
+            method = %request.method(),
+            url = %request.url(),
+            http.status_code = tracing::field::Empty,
+        );
+        let send_future = async {
+            let response = client.execute(request).await;
+            if let Ok(response) = &response {
+                tracing::Span::current().record("http.status_code", response.status().as_u16());
+            }
+            response
+        };
+        send_future.instrument(span).await
+    }
 }

--- a/objectstore-service/src/backend/extensions.rs
+++ b/objectstore-service/src/backend/extensions.rs
@@ -1,15 +1,45 @@
-//! HTTP response status checking with error body parsing.
+//! Extension traits for `reqwest` requests and responses.
 //!
-//! Provides [`ResponseExt`], an extension trait that replaces
-//! [`reqwest::Response::error_for_status`] with a version that reads the
-//! response body on 4xx/5xx errors and parses the structured error code and
-//! message from it (JSON for GCS JSON API, XML for GCS XML API and S3).
+//! Provides [`SendTraced`], which sends a request inside a tracing span, and
+//! [`ResponseExt`], which replaces [`reqwest::Response::error_for_status`] with a
+//! version that reads the response body on 4xx/5xx errors and parses the
+//! structured error code and message from it (JSON for GCS JSON API, XML for GCS
+//! XML API and S3).
 
 use reqwest::{Response, header};
 use serde::Deserialize;
+use tracing::Instrument;
 
 use crate::error::{BackendDetail, Error, Result};
 use crate::stream;
+
+/// Extension trait that sends a request inside a tracing span.
+pub trait SendTraced {
+    /// Sends the request, wrapping it in a span that covers the full request
+    /// duration and records the response status code.
+    async fn send_traced(self) -> reqwest::Result<reqwest::Response>;
+}
+
+impl SendTraced for reqwest::RequestBuilder {
+    async fn send_traced(self) -> reqwest::Result<reqwest::Response> {
+        let (client, request) = self.build_split();
+        let request = request?;
+        let span = tracing::debug_span!(
+            "http.request",
+            method = %request.method(),
+            url = %request.url(),
+            http.status_code = tracing::field::Empty,
+        );
+        let send_future = async {
+            let response = client.execute(request).await;
+            if let Ok(response) = &response {
+                tracing::Span::current().record("http.status_code", response.status().as_u16());
+            }
+            response
+        };
+        send_future.instrument(span).await
+    }
+}
 
 /// GCS JSON API error envelope (`{"error": {"message": "...", ...}}`).
 #[derive(Deserialize)]

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -15,10 +15,10 @@ use reqwest::header::HeaderName;
 use reqwest::{Body, IntoUrl, Method, RequestBuilder, StatusCode, Url, header, multipart};
 use serde::{Deserialize, Serialize};
 
-use super::response::ResponseExt;
+use super::extensions::{ResponseExt, SendTraced};
 use crate::backend::common::{
     self, Backend, DeleteResponse, GetResponse, MetadataResponse, MultipartUploadBackend,
-    PutResponse, SendTraced,
+    PutResponse,
 };
 use crate::error::{Error, Result};
 use crate::gcp_auth::PrefetchingTokenProvider;

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use super::response::ResponseExt;
 use crate::backend::common::{
     self, Backend, DeleteResponse, GetResponse, MetadataResponse, MultipartUploadBackend,
-    PutResponse,
+    PutResponse, SendTraced,
 };
 use crate::error::{Error, Result};
 use crate::gcp_auth::PrefetchingTokenProvider;
@@ -526,13 +526,14 @@ impl GcsBackend {
 
     /// Fetches the GCS object metadata (without the payload), bumps TTI if
     /// needed, and returns the parsed [`Metadata`].
+    #[tracing::instrument(level = "debug", fields(%object_url), skip(self))]
     async fn fetch_gcs_metadata(&self, object_url: &Url) -> Result<Option<Metadata>> {
         let metadata_opt = self
             .with_retry("get_metadata", || async {
                 let resp = self
                     .request(Method::GET, object_url.clone())
                     .await?
-                    .send()
+                    .send_traced()
                     .await
                     .map_err(|e| Error::reqwest("GCS: get metadata request", e))?;
 
@@ -581,6 +582,7 @@ impl GcsBackend {
         Ok(Some(metadata))
     }
 
+    #[tracing::instrument(level = "debug", fields(%object_url), skip(self))]
     async fn update_custom_time(&self, object_url: Url, custom_time: SystemTime) -> Result<()> {
         #[derive(Debug, Serialize)]
         #[serde(rename_all = "camelCase")]
@@ -593,7 +595,7 @@ impl GcsBackend {
             self.request(Method::PATCH, object_url.clone())
                 .await?
                 .json(&CustomTimeRequest { custom_time })
-                .send()
+                .send_traced()
                 .await
                 .check_error("GCS: update custom time")
                 .await?
@@ -624,7 +626,7 @@ impl Backend for GcsBackend {
         Ok(self)
     }
 
-    #[tracing::instrument(level = "trace", fields(?id), skip_all)]
+    #[tracing::instrument(level = "debug", fields(?id), skip_all)]
     async fn put_object(
         &self,
         id: &ObjectId,
@@ -667,7 +669,7 @@ impl Backend for GcsBackend {
             .await?
             .multipart(multipart)
             .header(header::CONTENT_TYPE, content_type)
-            .send()
+            .send_traced()
             .await
             .check_error("GCS: upload object")
             .await?
@@ -677,7 +679,7 @@ impl Backend for GcsBackend {
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", fields(?id), skip_all)]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn get_object(&self, id: &ObjectId, range: Option<ByteRange>) -> Result<GetResponse> {
         objectstore_log::debug!("Reading from GCS backend");
         let object_url = self.object_url(id)?;
@@ -696,7 +698,7 @@ impl Backend for GcsBackend {
                     req = req.header(header::RANGE, r.to_header_value());
                 }
                 let resp = req
-                    .send()
+                    .send_traced()
                     .await
                     .map_err(|e| Error::reqwest("GCS: get payload", e))?;
 
@@ -744,14 +746,14 @@ impl Backend for GcsBackend {
         Ok(Some((metadata, content_range, stream)))
     }
 
-    #[tracing::instrument(level = "trace", fields(?id), skip_all)]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn get_metadata(&self, id: &ObjectId) -> Result<MetadataResponse> {
         objectstore_log::debug!("Reading metadata from GCS backend");
         let object_url = self.object_url(id)?;
         self.fetch_gcs_metadata(&object_url).await
     }
 
-    #[tracing::instrument(level = "trace", fields(?id), skip_all)]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn delete_object(&self, id: &ObjectId) -> Result<DeleteResponse> {
         objectstore_log::debug!("Deleting from GCS backend");
         let object_url = self.object_url(id)?;
@@ -760,7 +762,7 @@ impl Backend for GcsBackend {
             let resp = self
                 .request(Method::DELETE, object_url.clone())
                 .await?
-                .send()
+                .send_traced()
                 .await
                 .map_err(|e| Error::reqwest("GCS: delete object", e))?;
 
@@ -890,7 +892,7 @@ impl From<XmlError> for crate::multipart::CompleteMultipartError {
 /// that we test against has an incomplete implementation of the XML multipart API that likely doesn't match GCS's behavior in many cases.
 #[async_trait::async_trait]
 impl MultipartUploadBackend for GcsBackend {
-    #[tracing::instrument(level = "trace", fields(?id), skip_all)]
+    #[tracing::instrument(level = "debug", fields(?id), skip_all)]
     async fn initiate_multipart(
         &self,
         id: &ObjectId,
@@ -912,7 +914,7 @@ impl MultipartUploadBackend for GcsBackend {
         }
 
         let resp = builder
-            .send()
+            .send_traced()
             .await
             .check_error("GCS: initiate multipart upload")
             .await?;
@@ -931,7 +933,7 @@ impl MultipartUploadBackend for GcsBackend {
         Ok(xml.try_into()?)
     }
 
-    #[tracing::instrument(level = "trace", fields(?id, upload_id, part_number), skip_all)]
+    #[tracing::instrument(level = "debug", skip(self, content_md5, body))]
     async fn upload_part(
         &self,
         id: &ObjectId,
@@ -957,7 +959,11 @@ impl MultipartUploadBackend for GcsBackend {
             builder = builder.header("content-md5", md5);
         }
 
-        let resp = builder.send().await.check_error("GCS: upload part").await?;
+        let resp = builder
+            .send_traced()
+            .await
+            .check_error("GCS: upload part")
+            .await?;
 
         let etag = resp
             .headers()
@@ -971,7 +977,7 @@ impl MultipartUploadBackend for GcsBackend {
         Ok(etag)
     }
 
-    #[tracing::instrument(level = "trace", fields(?id, upload_id), skip_all)]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn list_parts(
         &self,
         id: &ObjectId,
@@ -995,7 +1001,7 @@ impl MultipartUploadBackend for GcsBackend {
         let resp = self
             .request(Method::GET, url)
             .await?
-            .send()
+            .send_traced()
             .await
             .check_error("GCS: list parts")
             .await?;
@@ -1014,7 +1020,7 @@ impl MultipartUploadBackend for GcsBackend {
         Ok(xml.into())
     }
 
-    #[tracing::instrument(level = "trace", fields(?id, upload_id), skip_all)]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn abort_multipart(
         &self,
         id: &ObjectId,
@@ -1026,7 +1032,7 @@ impl MultipartUploadBackend for GcsBackend {
 
         self.request(Method::DELETE, url)
             .await?
-            .send()
+            .send_traced()
             .await
             .check_error("GCS: abort multipart upload")
             .await?
@@ -1036,7 +1042,7 @@ impl MultipartUploadBackend for GcsBackend {
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", fields(?id, upload_id), skip_all)]
+    #[tracing::instrument(level = "debug", skip(self, parts))]
     async fn complete_multipart(
         &self,
         id: &ObjectId,
@@ -1058,7 +1064,7 @@ impl MultipartUploadBackend for GcsBackend {
             .await?
             .header(header::CONTENT_TYPE, "application/xml")
             .body(xml)
-            .send()
+            .send_traced()
             .await
             .check_error("GCS: complete multipart upload")
             .await?;

--- a/objectstore-service/src/backend/local_fs.rs
+++ b/objectstore-service/src/backend/local_fs.rs
@@ -76,7 +76,7 @@ impl Backend for LocalFsBackend {
         Ok(self)
     }
 
-    #[tracing::instrument(level = "trace", fields(?id), skip_all)]
+    #[tracing::instrument(level = "debug", fields(?id), skip_all)]
     async fn put_object(
         &self,
         id: &ObjectId,
@@ -119,7 +119,7 @@ impl Backend for LocalFsBackend {
     }
 
     // TODO: Return `Ok(None)` if object is found but past expiry
-    #[tracing::instrument(level = "trace", fields(?id), skip_all)]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn get_object(&self, id: &ObjectId, range: Option<ByteRange>) -> Result<GetResponse> {
         objectstore_log::debug!("Reading from local_fs backend");
         let path = self.path.join(id.as_storage_path().to_string());
@@ -164,7 +164,7 @@ impl Backend for LocalFsBackend {
         Ok(Some((metadata, content_range, stream)))
     }
 
-    #[tracing::instrument(level = "trace", fields(?id), skip_all)]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn delete_object(&self, id: &ObjectId) -> Result<DeleteResponse> {
         objectstore_log::debug!("Deleting from local_fs backend");
         let path = self.path.join(id.as_storage_path().to_string());

--- a/objectstore-service/src/backend/mod.rs
+++ b/objectstore-service/src/backend/mod.rs
@@ -15,10 +15,10 @@ pub mod bigtable;
 pub mod changelog;
 pub mod common;
 pub mod counting;
+mod extensions;
 pub mod gcs;
 pub mod in_memory;
 pub mod local_fs;
-mod response;
 pub mod s3_compatible;
 pub mod tiered;
 

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -9,9 +9,9 @@ use objectstore_types::range::{ByteRange, ContentRange};
 use reqwest::header::HeaderMap;
 use reqwest::{Body, IntoUrl, Method, RequestBuilder, Response, StatusCode};
 
-use super::response::ResponseExt;
+use super::extensions::{ResponseExt, SendTraced};
 use crate::backend::common::{
-    self, Backend, DeleteResponse, GetResponse, MetadataResponse, PutResponse, SendTraced,
+    self, Backend, DeleteResponse, GetResponse, MetadataResponse, PutResponse,
 };
 use crate::error::{Error, Result};
 use crate::id::ObjectId;

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -11,7 +11,7 @@ use reqwest::{Body, IntoUrl, Method, RequestBuilder, Response, StatusCode};
 
 use super::response::ResponseExt;
 use crate::backend::common::{
-    self, Backend, DeleteResponse, GetResponse, MetadataResponse, PutResponse,
+    self, Backend, DeleteResponse, GetResponse, MetadataResponse, PutResponse, SendTraced,
 };
 use crate::error::{Error, Result};
 use crate::id::ObjectId;
@@ -172,10 +172,13 @@ where
         if let Some(r) = range {
             builder = builder.header(reqwest::header::RANGE, r.to_header_value());
         }
-        let response = builder.send().await.map_err(|cause| Error::Reqwest {
-            context: "S3: failed to send request".to_string(),
-            cause,
-        })?;
+        let response = builder
+            .send_traced()
+            .await
+            .map_err(|cause| Error::Reqwest {
+                context: "S3: failed to send request".to_string(),
+                cause,
+            })?;
 
         if response.status() == StatusCode::NOT_FOUND {
             objectstore_log::debug!("Object not found");
@@ -260,7 +263,7 @@ where
             )
             .header("x-goog-metadata-directive", "REPLACE")
             .headers(metadata_to_gcs_headers(metadata, GCS_CUSTOM_PREFIX)?)
-            .send()
+            .send_traced()
             .await
             .check_error("S3: update expiration time")
             .await?
@@ -299,7 +302,7 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
         "s3-compatible"
     }
 
-    #[tracing::instrument(level = "trace", fields(?id), skip_all)]
+    #[tracing::instrument(level = "debug", fields(?id), skip_all)]
     async fn put_object(
         &self,
         id: &ObjectId,
@@ -311,7 +314,7 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
             .await?
             .headers(metadata_to_gcs_headers(metadata, GCS_CUSTOM_PREFIX)?)
             .body(Body::wrap_stream(stream))
-            .send()
+            .send_traced()
             .await
             .check_error("S3: failed to put object")
             .await?
@@ -321,7 +324,7 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
         Ok(())
     }
 
-    #[tracing::instrument(level = "trace", fields(?id), skip_all)]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn get_object(&self, id: &ObjectId, range: Option<ByteRange>) -> Result<GetResponse> {
         objectstore_log::debug!("Reading from s3_compatible backend");
 
@@ -335,20 +338,20 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
         Ok(Some((metadata, content_range, stream.boxed())))
     }
 
-    #[tracing::instrument(level = "trace", fields(?id), skip_all)]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn get_metadata(&self, id: &ObjectId) -> Result<MetadataResponse> {
         objectstore_log::debug!("Reading metadata from s3_compatible backend");
         let response = self.request_object(Method::HEAD, id, None).await?;
         Ok(response.map(|(metadata, _, _)| metadata))
     }
 
-    #[tracing::instrument(level = "trace", fields(?id), skip_all)]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn delete_object(&self, id: &ObjectId) -> Result<DeleteResponse> {
         objectstore_log::debug!("Deleting from s3_compatible backend");
         let response = self
             .request(Method::DELETE, self.object_url(id))
             .await?
-            .send()
+            .send_traced()
             .await
             .map_err(|cause| Error::Reqwest {
                 context: "S3: failed to send delete request".to_string(),

--- a/objectstore-service/src/backend/tiered.rs
+++ b/objectstore-service/src/backend/tiered.rs
@@ -267,6 +267,7 @@ impl TieredStorage {
     ///
     /// If a tombstone already exists, attempts to swap it for the new object and delete the old
     /// long-term object.
+    #[tracing::instrument(level = "debug", fields(?id), skip_all)]
     async fn put_high_volume(
         &self,
         id: &ObjectId,
@@ -313,6 +314,7 @@ impl TieredStorage {
     ///
     /// Deletes the previous long-term object if overwriting an existing tombstone. If the tombstone
     /// write fails, the new long-term object is cleaned up.
+    #[tracing::instrument(level = "debug", fields(?id), skip_all)]
     async fn put_long_term(
         &self,
         id: &ObjectId,
@@ -370,6 +372,7 @@ impl Backend for TieredStorage {
         Ok(self)
     }
 
+    #[tracing::instrument(level = "debug", fields(?id), skip_all)]
     async fn put_object(
         &self,
         id: &ObjectId,
@@ -415,6 +418,7 @@ impl Backend for TieredStorage {
         Ok(())
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn get_object(&self, id: &ObjectId, range: Option<ByteRange>) -> Result<GetResponse> {
         let timer = objectstore_metrics::timer!(
             "get.latency.pre-response",
@@ -458,6 +462,7 @@ impl Backend for TieredStorage {
         Ok(result)
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn get_metadata(&self, id: &ObjectId) -> Result<MetadataResponse> {
         let timer = objectstore_metrics::timer!("head.latency", usecase = id.usecase().to_owned());
 
@@ -479,6 +484,7 @@ impl Backend for TieredStorage {
         Ok(result)
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn delete_object(&self, id: &ObjectId) -> Result<DeleteResponse> {
         let timer =
             objectstore_metrics::timer!("delete.latency", usecase = id.usecase().to_owned());
@@ -600,6 +606,7 @@ impl TryFrom<&UploadId> for TieredUploadId {
 
 #[async_trait::async_trait]
 impl MultipartUploadBackend for TieredStorage {
+    #[tracing::instrument(level = "debug", fields(?id), skip_all)]
     async fn initiate_multipart(
         &self,
         id: &ObjectId,
@@ -627,6 +634,7 @@ impl MultipartUploadBackend for TieredStorage {
         Ok(id)
     }
 
+    #[tracing::instrument(level = "debug", fields(?id, part_number, content_length), skip_all)]
     async fn upload_part(
         &self,
         id: &ObjectId,
@@ -669,6 +677,7 @@ impl MultipartUploadBackend for TieredStorage {
         Ok(etag)
     }
 
+    #[tracing::instrument(level = "debug", skip(self, upload_id))]
     async fn list_parts(
         &self,
         id: &ObjectId,
@@ -697,6 +706,7 @@ impl MultipartUploadBackend for TieredStorage {
         Ok(response)
     }
 
+    #[tracing::instrument(level = "debug", fields(?id), skip_all)]
     async fn abort_multipart(
         &self,
         id: &ObjectId,
@@ -723,6 +733,7 @@ impl MultipartUploadBackend for TieredStorage {
         Ok(())
     }
 
+    #[tracing::instrument(level = "debug", fields(?id), skip_all)]
     async fn complete_multipart(
         &self,
         id: &ObjectId,


### PR DESCRIPTION
Backend operations now appear as real child spans in Sentry, turning the existing per-request and per-task transactions into full trace waterfalls. They were empty before because the sentry-tracing layer only converts `INFO`+ spans by default; the logging layer now forwards `DEBUG`+ spans (`TRACE` still ignored) and the backend spans moved to `debug`.

GCS/S3 HTTP calls and BigTable RPCs each get a per-attempt span covering the real request duration (method/URL/status, or action/gRPC status), and the tiered, changelog, and per-backend operations are annotated so the waterfall reads top-down. Spans carry small primitive fields (object id, range, part numbers, URLs); payloads, streams, and metadata are excluded.

Observability-only — no behavior changes and console logging is untouched.

Closes FS-412