### PR TITLE
fix(py-client): Treat object keys as literal strings

### DIFF
--- a/clients/python/src/objectstore_client/client.py
+++ b/clients/python/src/objectstore_client/client.py
@@ -274,10 +274,10 @@ class Session:
         # Percent-encode the path ourselves so the key is treated as a literal
         # string (a literal "%" becomes "%25"). This keeps every request path
         # consistent with pre-signed URLs, which encode the same way; see
-        # `presign.encode_path`. urllib3 leaves our already-encoded output on the
+        # `utils.encode_path`. urllib3 leaves our already-encoded output on the
         # wire verbatim, so this only changes bytes for keys containing a literal
         # "%XX" (which urllib3 would otherwise mistake for an existing escape).
-        path = presign.encode_path(self._base_path.rstrip("/") + relative_path)
+        path = utils.encode_path(self._base_path.rstrip("/") + relative_path)
         if full:
             return f"http://{self._pool.host}:{self._pool.port}{path}"
         return path
@@ -298,7 +298,7 @@ class Session:
         relative_path = f"/v1/{resource}/{self._usecase.name}/{self._scope}/{key or ''}"
         # Encode the path (with the literal key); see `_make_url`. `query` is
         # already percent-encoded by the caller via `urlencode`, so leave it.
-        path = presign.encode_path(self._base_path.rstrip("/") + relative_path)
+        path = utils.encode_path(self._base_path.rstrip("/") + relative_path)
         if query:
             return f"{path}?{query}"
         return path
@@ -496,7 +496,7 @@ class Session:
         # `_make_url` already percent-encodes the path identically to the wire.
         encoded_path = self._make_url(key)
         timestamp = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-        encoded_query = presign.encode_query(
+        encoded_query = utils.encode_query(
             f"{presign.PARAM_KID}={self._token.kid}"
             f"&{presign.PARAM_TIMESTAMP}={timestamp}"
             f"&{presign.PARAM_DURATION}={duration_secs}"

--- a/clients/python/src/objectstore_client/client.py
+++ b/clients/python/src/objectstore_client/client.py
@@ -271,7 +271,7 @@ class Session:
 
     def _make_url(self, key: str | None, full: bool = False) -> str:
         relative_path = f"/v1/objects/{self._usecase.name}/{self._scope}/{key or ''}"
-        path = utils._encode_path(self._base_path.rstrip("/") + relative_path)
+        path = utils.encode_path(self._base_path.rstrip("/") + relative_path)
         if full:
             return f"http://{self._pool.host}:{self._pool.port}{path}"
         return path
@@ -290,7 +290,7 @@ class Session:
             resource = "objects:multipart"
 
         relative_path = f"/v1/{resource}/{self._usecase.name}/{self._scope}/{key or ''}"
-        path = utils._encode_path(self._base_path.rstrip("/") + relative_path)
+        path = utils.encode_path(self._base_path.rstrip("/") + relative_path)
         if query:
             return f"{path}?{query}"
         return path
@@ -488,7 +488,7 @@ class Session:
         # `_make_url` already percent-encodes the path identically to the wire.
         encoded_path = self._make_url(key)
         timestamp = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-        encoded_query = utils._encode_query(
+        encoded_query = utils.encode_query(
             f"{presign.PARAM_KID}={self._token.kid}"
             f"&{presign.PARAM_TIMESTAMP}={timestamp}"
             f"&{presign.PARAM_DURATION}={duration_secs}"

--- a/clients/python/src/objectstore_client/client.py
+++ b/clients/python/src/objectstore_client/client.py
@@ -271,7 +271,7 @@ class Session:
 
     def _make_url(self, key: str | None, full: bool = False) -> str:
         relative_path = f"/v1/objects/{self._usecase.name}/{self._scope}/{key or ''}"
-        path = utils.encode_path(self._base_path.rstrip("/") + relative_path)
+        path = utils._encode_path(self._base_path.rstrip("/") + relative_path)
         if full:
             return f"http://{self._pool.host}:{self._pool.port}{path}"
         return path
@@ -290,7 +290,7 @@ class Session:
             resource = "objects:multipart"
 
         relative_path = f"/v1/{resource}/{self._usecase.name}/{self._scope}/{key or ''}"
-        path = utils.encode_path(self._base_path.rstrip("/") + relative_path)
+        path = utils._encode_path(self._base_path.rstrip("/") + relative_path)
         if query:
             return f"{path}?{query}"
         return path
@@ -488,7 +488,7 @@ class Session:
         # `_make_url` already percent-encodes the path identically to the wire.
         encoded_path = self._make_url(key)
         timestamp = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-        encoded_query = utils.encode_query(
+        encoded_query = utils._encode_query(
             f"{presign.PARAM_KID}={self._token.kid}"
             f"&{presign.PARAM_TIMESTAMP}={timestamp}"
             f"&{presign.PARAM_DURATION}={duration_secs}"

--- a/clients/python/src/objectstore_client/client.py
+++ b/clients/python/src/objectstore_client/client.py
@@ -271,7 +271,13 @@ class Session:
 
     def _make_url(self, key: str | None, full: bool = False) -> str:
         relative_path = f"/v1/objects/{self._usecase.name}/{self._scope}/{key or ''}"
-        path = self._base_path.rstrip("/") + relative_path
+        # Percent-encode the path ourselves so the key is treated as a literal
+        # string (a literal "%" becomes "%25"). This keeps every request path
+        # consistent with pre-signed URLs, which encode the same way; see
+        # `presign.encode_path`. urllib3 leaves our already-encoded output on the
+        # wire verbatim, so this only changes bytes for keys containing a literal
+        # "%XX" (which urllib3 would otherwise mistake for an existing escape).
+        path = presign.encode_path(self._base_path.rstrip("/") + relative_path)
         if full:
             return f"http://{self._pool.host}:{self._pool.port}{path}"
         return path
@@ -290,7 +296,9 @@ class Session:
             resource = "objects:multipart"
 
         relative_path = f"/v1/{resource}/{self._usecase.name}/{self._scope}/{key or ''}"
-        path = self._base_path.rstrip("/") + relative_path
+        # Encode the path (with the literal key); see `_make_url`. `query` is
+        # already percent-encoded by the caller via `urlencode`, so leave it.
+        path = presign.encode_path(self._base_path.rstrip("/") + relative_path)
         if query:
             return f"{path}?{query}"
         return path
@@ -485,7 +493,8 @@ class Session:
             )
         duration_secs = math.ceil(duration.total_seconds())
 
-        encoded_path = presign.encode_path(self._make_url(key))
+        # `_make_url` already percent-encodes the path identically to the wire.
+        encoded_path = self._make_url(key)
         timestamp = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         encoded_query = presign.encode_query(
             f"{presign.PARAM_KID}={self._token.kid}"

--- a/clients/python/src/objectstore_client/client.py
+++ b/clients/python/src/objectstore_client/client.py
@@ -271,12 +271,6 @@ class Session:
 
     def _make_url(self, key: str | None, full: bool = False) -> str:
         relative_path = f"/v1/objects/{self._usecase.name}/{self._scope}/{key or ''}"
-        # Percent-encode the path ourselves so the key is treated as a literal
-        # string (a literal "%" becomes "%25"). This keeps every request path
-        # consistent with pre-signed URLs, which encode the same way; see
-        # `utils.encode_path`. urllib3 leaves our already-encoded output on the
-        # wire verbatim, so this only changes bytes for keys containing a literal
-        # "%XX" (which urllib3 would otherwise mistake for an existing escape).
         path = utils.encode_path(self._base_path.rstrip("/") + relative_path)
         if full:
             return f"http://{self._pool.host}:{self._pool.port}{path}"
@@ -296,8 +290,6 @@ class Session:
             resource = "objects:multipart"
 
         relative_path = f"/v1/{resource}/{self._usecase.name}/{self._scope}/{key or ''}"
-        # Encode the path (with the literal key); see `_make_url`. `query` is
-        # already percent-encoded by the caller via `urlencode`, so leave it.
         path = utils.encode_path(self._base_path.rstrip("/") + relative_path)
         if query:
             return f"{path}?{query}"

--- a/clients/python/src/objectstore_client/presign.py
+++ b/clients/python/src/objectstore_client/presign.py
@@ -8,22 +8,6 @@ See ``objectstore-types/src/presign.rs`` for details on the scheme.
 """
 
 from datetime import timedelta
-from urllib.parse import quote
-
-# Characters left unescaped when percent-encoding, expressed in RFC 3986 terms.
-# `urllib.parse.quote` already leaves the *unreserved* set (ALPHA / DIGIT /
-# "-._~") untouched, so `safe` only lists the extra characters permitted in a
-# path or query without escaping:
-#   - sub-delims: "!$&'()*+,;="
-#   - path extras: ":" "@" "/"  (the pchar set plus the "/" segment separator)
-#   - query also allows "?"
-# This is the same set urllib3 leaves unescaped, so the encoding is a fixed
-# point of the HTTP client that ultimately sends the URL and survives on the
-# wire verbatim. It is also byte-for-byte identical to the Rust client's
-# `percent_encoding` set (see `objectstore-types/src/presign.rs`), so the two
-# clients produce the same signed bytes for any key.
-_PATH_SAFE = "/:@!$&'()*+,;="
-_QUERY_SAFE = _PATH_SAFE + "?"
 
 # Query parameter carrying the RFC 3339 time at which the request was signed.
 PARAM_TIMESTAMP = "os_timestamp"
@@ -44,29 +28,12 @@ MAX_PRESIGN_DURATION = timedelta(days=7)
 SUPPORTED_METHODS = ("GET", "HEAD")
 
 
-def encode_path(path: str) -> str:
-    """Percent-encodes a request path as it will appear on the wire.
-
-    Leaves the RFC 3986 unreserved set, sub-delims, and ``:`` ``@`` ``/``
-    unescaped (see :data:`_PATH_SAFE`); everything else is percent-encoded.
-    """
-    return quote(path, safe=_PATH_SAFE)
-
-
-def encode_query(query: str) -> str:
-    """Percent-encodes a query string as it will appear on the wire.
-
-    Same set as :func:`encode_path`, additionally leaving ``?`` unescaped
-    (see :data:`_QUERY_SAFE`).
-    """
-    return quote(query, safe=_QUERY_SAFE)
-
-
 def build_canonical_form(method: str, encoded_path: str, encoded_query: str) -> str:
     """Builds the canonical form of a request to be signed.
 
     ``encoded_path`` and ``encoded_query`` must already be percent-encoded as
-    they will appear on the wire (see :func:`encode_path` / :func:`encode_query`).
+    they will appear on the wire (see :func:`objectstore_client.utils.encode_path`
+    and :func:`objectstore_client.utils.encode_query`).
     """
     normalized_method = "GET" if method.upper() == "HEAD" else method.upper()
 

--- a/clients/python/src/objectstore_client/utils.py
+++ b/clients/python/src/objectstore_client/utils.py
@@ -23,7 +23,7 @@ _PATH_SAFE = "/:@!$&'()*+,;="
 _QUERY_SAFE = _PATH_SAFE + "?"
 
 
-def encode_path(path: str) -> str:
+def _encode_path(path: str) -> str:
     """Percent-encodes a request path as it will appear on the wire.
 
     Leaves the RFC 3986 unreserved set, sub-delims, and ``:`` ``@`` ``/``
@@ -33,7 +33,7 @@ def encode_path(path: str) -> str:
     return quote(path, safe=_PATH_SAFE)
 
 
-def encode_query(query: str) -> str:
+def _encode_query(query: str) -> str:
     """Percent-encodes a query string as it will appear on the wire.
 
     Same set as :func:`encode_path`, additionally leaving ``?`` unescaped

--- a/clients/python/src/objectstore_client/utils.py
+++ b/clients/python/src/objectstore_client/utils.py
@@ -23,7 +23,7 @@ _PATH_SAFE = "/:@!$&'()*+,;="
 _QUERY_SAFE = _PATH_SAFE + "?"
 
 
-def _encode_path(path: str) -> str:
+def encode_path(path: str) -> str:
     """Percent-encodes a request path as it will appear on the wire.
 
     Leaves the RFC 3986 unreserved set, sub-delims, and ``:`` ``@`` ``/``
@@ -33,7 +33,7 @@ def _encode_path(path: str) -> str:
     return quote(path, safe=_PATH_SAFE)
 
 
-def _encode_query(query: str) -> str:
+def encode_query(query: str) -> str:
     """Percent-encodes a query string as it will appear on the wire.
 
     Same set as :func:`encode_path`, additionally leaving ``?`` unescaped

--- a/clients/python/src/objectstore_client/utils.py
+++ b/clients/python/src/objectstore_client/utils.py
@@ -2,9 +2,44 @@ from __future__ import annotations
 
 import io
 from typing import IO, Any
+from urllib.parse import quote
 
 import filetype  # type: ignore[import-untyped]
 from zstandard import ZstdCompressionReader
+
+# Characters left unescaped when percent-encoding a URL path or query, expressed
+# in RFC 3986 terms. `urllib.parse.quote` already leaves the *unreserved* set
+# (ALPHA / DIGIT / "-._~") untouched, so `safe` only lists the extra characters
+# permitted without escaping:
+#   - sub-delims: "!$&'()*+,;="
+#   - path extras: ":" "@" "/"  (the pchar set plus the "/" segment separator)
+#   - query also allows "?"
+# This is the same set urllib3 leaves unescaped, so the encoding is a fixed point
+# of the HTTP client that ultimately sends the URL and survives on the wire
+# verbatim. It is also byte-for-byte identical to the Rust client's
+# `percent_encoding` set (see `objectstore-types/src/presign.rs`), so the two
+# clients produce the same bytes for any key.
+_PATH_SAFE = "/:@!$&'()*+,;="
+_QUERY_SAFE = _PATH_SAFE + "?"
+
+
+def encode_path(path: str) -> str:
+    """Percent-encodes a request path as it will appear on the wire.
+
+    Leaves the RFC 3986 unreserved set, sub-delims, and ``:`` ``@`` ``/``
+    unescaped (see :data:`_PATH_SAFE`); everything else is percent-encoded. This
+    treats the input as a literal string: a literal ``%`` becomes ``%25``.
+    """
+    return quote(path, safe=_PATH_SAFE)
+
+
+def encode_query(query: str) -> str:
+    """Percent-encodes a query string as it will appear on the wire.
+
+    Same set as :func:`encode_path`, additionally leaving ``?`` unescaped
+    (see :data:`_QUERY_SAFE`).
+    """
+    return quote(query, safe=_QUERY_SAFE)
 
 
 def parse_accept_encoding(header: str) -> list[str]:

--- a/clients/python/tests/test_e2e.py
+++ b/clients/python/tests/test_e2e.py
@@ -788,15 +788,11 @@ def test_presigned_tampered_signature_unauthorized(server_url: str) -> None:
 
 
 # Object keys exercising URL-encoding corner cases. Each must round-trip: the
-# normal urllib3 `put` and the pre-signed `urllib` GET encode the path
-# identically, so they resolve to the same stored object. `?`/`#` are excluded
-# because urllib3's `put` path treats them as query/fragment delimiters.
-#
-# Keys containing a literal `%XX` (percent followed by two hex digits) currently
-# diverge and are excluded: presigning uses `urllib.parse.quote`, which escapes
-# the `%` to `%25` (targeting the literal key), whereas urllib3's `put` path
-# treats `%20` as an existing escape and leaves it intact, so the two resolve to
-# different stored objects. See `looks%20encoded` below.
+# normal `put` and the pre-signed `urllib` GET percent-encode the path
+# identically (both treat the key as a literal string, see
+# `presign.encode_path`), so they resolve to the same stored object. This
+# includes keys containing a literal `%XX`: the `%` is escaped to `%25` rather
+# than mistaken for an existing escape (see `test_put_stores_under_literal_key`).
 ENCODING_CORNER_CASE_KEYS = [
     "plain-key",
     "with space",
@@ -805,8 +801,8 @@ ENCODING_CORNER_CASE_KEYS = [
     "plus+sign",
     "sub!$'()*+,=delims",
     "tilde~dot.key",
-    "100%literal-percent",  # `%li` isn't a valid escape, so both escape the `%`
-    # "looks%20encoded",  # diverges: quote -> %2520, urllib3 put -> %20
+    "100%literal-percent",
+    "looks%20encoded",
     "nested/path/segments",
     "quote'apostrophe",
     "at@sign",
@@ -827,4 +823,25 @@ def test_presigned_get_encoding_corner_cases(server_url: str, key: str) -> None:
     status, body = _fetch(url)
 
     assert status == 200, f"key {key!r} failed with status {status}"
+    assert body == payload
+
+
+def test_put_stores_under_literal_key(server_url: str) -> None:
+    # A literal "%XX" in a key must be stored verbatim, not decoded: `put` sends
+    # `looks%2520encoded` on the wire, which the server decodes back to the
+    # literal key `looks%20encoded` rather than `looks encoded`. The server
+    # echoes the stored key in the `put` response body, so we can assert directly
+    # which key the object landed under.
+    session = _presign_session(server_url)
+    key = "looks%20encoded"
+    payload = b"literal percent key"
+
+    stored_key = session.put(payload, key=key)
+    assert stored_key == key
+
+    # Retrievable by that same literal key, both normally and pre-signed.
+    assert session.get(key).payload.read() == payload
+    url = session.presigned_object_url("GET", key, duration=timedelta(hours=1))
+    status, body = _fetch(url)
+    assert status == 200
     assert body == payload

--- a/clients/python/tests/test_e2e.py
+++ b/clients/python/tests/test_e2e.py
@@ -790,7 +790,7 @@ def test_presigned_tampered_signature_unauthorized(server_url: str) -> None:
 # Object keys exercising URL-encoding corner cases. Each must round-trip: the
 # normal `put` and the pre-signed `urllib` GET percent-encode the path
 # identically (both treat the key as a literal string, see
-# `presign.encode_path`), so they resolve to the same stored object. This
+# `utils.encode_path`), so they resolve to the same stored object. This
 # includes keys containing a literal `%XX`: the `%` is escaped to `%25` rather
 # than mistaken for an existing escape (see `test_put_stores_under_literal_key`).
 ENCODING_CORNER_CASE_KEYS = [

--- a/clients/python/tests/test_presign.py
+++ b/clients/python/tests/test_presign.py
@@ -26,7 +26,7 @@ def test_canonical_form_full_query() -> None:
     # key lowercasing, and query sort order.
     path = "/v1/objects/testing/org=17;project=42/foo/bar"
     canonical = presign.build_canonical_form(
-        "GET", utils.encode_path(path), utils.encode_query(SAMPLE_QUERY)
+        "GET", utils._encode_path(path), utils._encode_query(SAMPLE_QUERY)
     )
     assert canonical == (
         "GET\n"
@@ -38,15 +38,15 @@ def test_canonical_form_full_query() -> None:
 def test_canonical_form_duplicate_keys_preserved_and_sorted() -> None:
     canonical = presign.build_canonical_form(
         "GET",
-        utils.encode_path("/v1/objects/testing/_/key"),
-        utils.encode_query("dup=b&dup=a&x=1"),
+        utils._encode_path("/v1/objects/testing/_/key"),
+        utils._encode_query("dup=b&dup=a&x=1"),
     )
     assert canonical == "GET\n/v1/objects/testing/_/key\ndup=a&dup=b&x=1"
 
 
 def test_head_is_normalized_to_get() -> None:
-    path = utils.encode_path("/v1/objects/testing/_/key")
-    query = utils.encode_query(SAMPLE_QUERY)
+    path = utils._encode_path("/v1/objects/testing/_/key")
+    query = utils._encode_query(SAMPLE_QUERY)
     assert presign.build_canonical_form(
         "HEAD", path, query
     ) == presign.build_canonical_form("GET", path, query)
@@ -63,8 +63,8 @@ def test_sign_canonical_form_roundtrips_with_public_key() -> None:
 
     canonical = presign.build_canonical_form(
         "GET",
-        utils.encode_path("/v1/objects/testing/_/key"),
-        utils.encode_query(SAMPLE_QUERY),
+        utils._encode_path("/v1/objects/testing/_/key"),
+        utils._encode_query(SAMPLE_QUERY),
     )
     signature_b64 = key.signature_for_canonical_form(canonical)
 

--- a/clients/python/tests/test_presign.py
+++ b/clients/python/tests/test_presign.py
@@ -26,7 +26,7 @@ def test_canonical_form_full_query() -> None:
     # key lowercasing, and query sort order.
     path = "/v1/objects/testing/org=17;project=42/foo/bar"
     canonical = presign.build_canonical_form(
-        "GET", utils._encode_path(path), utils._encode_query(SAMPLE_QUERY)
+        "GET", utils.encode_path(path), utils.encode_query(SAMPLE_QUERY)
     )
     assert canonical == (
         "GET\n"
@@ -38,15 +38,15 @@ def test_canonical_form_full_query() -> None:
 def test_canonical_form_duplicate_keys_preserved_and_sorted() -> None:
     canonical = presign.build_canonical_form(
         "GET",
-        utils._encode_path("/v1/objects/testing/_/key"),
-        utils._encode_query("dup=b&dup=a&x=1"),
+        utils.encode_path("/v1/objects/testing/_/key"),
+        utils.encode_query("dup=b&dup=a&x=1"),
     )
     assert canonical == "GET\n/v1/objects/testing/_/key\ndup=a&dup=b&x=1"
 
 
 def test_head_is_normalized_to_get() -> None:
-    path = utils._encode_path("/v1/objects/testing/_/key")
-    query = utils._encode_query(SAMPLE_QUERY)
+    path = utils.encode_path("/v1/objects/testing/_/key")
+    query = utils.encode_query(SAMPLE_QUERY)
     assert presign.build_canonical_form(
         "HEAD", path, query
     ) == presign.build_canonical_form("GET", path, query)
@@ -63,8 +63,8 @@ def test_sign_canonical_form_roundtrips_with_public_key() -> None:
 
     canonical = presign.build_canonical_form(
         "GET",
-        utils._encode_path("/v1/objects/testing/_/key"),
-        utils._encode_query(SAMPLE_QUERY),
+        utils.encode_path("/v1/objects/testing/_/key"),
+        utils.encode_query(SAMPLE_QUERY),
     )
     signature_b64 = key.signature_for_canonical_form(canonical)
 

--- a/clients/python/tests/test_presign.py
+++ b/clients/python/tests/test_presign.py
@@ -5,7 +5,7 @@ import os
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from cryptography.hazmat.primitives.serialization import load_pem_public_key
-from objectstore_client import presign
+from objectstore_client import presign, utils
 from objectstore_client.auth import SecretKey
 
 TEST_EDDSA_PRIVKEY_PATH = os.path.join(os.path.dirname(__file__), "ed25519.private.pem")
@@ -26,7 +26,7 @@ def test_canonical_form_full_query() -> None:
     # key lowercasing, and query sort order.
     path = "/v1/objects/testing/org=17;project=42/foo/bar"
     canonical = presign.build_canonical_form(
-        "GET", presign.encode_path(path), presign.encode_query(SAMPLE_QUERY)
+        "GET", utils.encode_path(path), utils.encode_query(SAMPLE_QUERY)
     )
     assert canonical == (
         "GET\n"
@@ -38,15 +38,15 @@ def test_canonical_form_full_query() -> None:
 def test_canonical_form_duplicate_keys_preserved_and_sorted() -> None:
     canonical = presign.build_canonical_form(
         "GET",
-        presign.encode_path("/v1/objects/testing/_/key"),
-        presign.encode_query("dup=b&dup=a&x=1"),
+        utils.encode_path("/v1/objects/testing/_/key"),
+        utils.encode_query("dup=b&dup=a&x=1"),
     )
     assert canonical == "GET\n/v1/objects/testing/_/key\ndup=a&dup=b&x=1"
 
 
 def test_head_is_normalized_to_get() -> None:
-    path = presign.encode_path("/v1/objects/testing/_/key")
-    query = presign.encode_query(SAMPLE_QUERY)
+    path = utils.encode_path("/v1/objects/testing/_/key")
+    query = utils.encode_query(SAMPLE_QUERY)
     assert presign.build_canonical_form(
         "HEAD", path, query
     ) == presign.build_canonical_form("GET", path, query)
@@ -63,8 +63,8 @@ def test_sign_canonical_form_roundtrips_with_public_key() -> None:
 
     canonical = presign.build_canonical_form(
         "GET",
-        presign.encode_path("/v1/objects/testing/_/key"),
-        presign.encode_query(SAMPLE_QUERY),
+        utils.encode_path("/v1/objects/testing/_/key"),
+        utils.encode_query(SAMPLE_QUERY),
     )
     signature_b64 = key.signature_for_canonical_form(canonical)
 


### PR DESCRIPTION
## Summary

Stacked on #544. Makes the Python client encode request paths itself (via `presign.encode_path`) instead of relying on urllib3's implicit encoding, so a key is always treated as a **literal string**.

### The bug

urllib3's encoder treats a literal `%XX` (percent + two hex digits) in a key as an *existing* escape and leaves it on the wire unchanged. Pre-signed URLs (which use `urllib.parse.quote`) instead escape the `%` to `%25`. So for a key like `looks%20encoded`, `put`/`get` and the pre-signed GET disagreed on which object was addressed:

| path | `put`/`get` (old urllib3) | pre-signed GET (`quote`) |
|---|---|---|
| wire | `…/looks%20encoded` | `…/looks%2520encoded` |
| server resolves key | `looks encoded` (space!) | `looks%20encoded` (literal) |

### The fix

`_make_url` / `_make_multipart_url` now percent-encode the assembled path with `presign.encode_path`. Our output is a subset of urllib3's safe set and contains only valid `%XX`, so urllib3 transmits it verbatim — meaning **wire bytes only change for keys containing a literal `%XX`**; every other key is byte-identical to before. The whole client now treats keys as opaque literal strings, consistent with pre-signed URLs.

### Rust client

Verified **not affected**: the Rust client builds URLs via the `url` crate's `path_segments_mut().push()`, which already escapes a literal `%` to `%25` (`looks%20encoded` → `looks%2520encoded`). It already treats keys as literals, so no change is needed.

## Tests

- Re-enabled the `looks%20encoded` case in `test_presigned_get_encoding_corner_cases` (previously commented out because it diverged).
- Added `test_put_stores_under_literal_key`, which asserts the object lands under the literal key by checking the key the server echoes in the `put` response body (would be `looks encoded` under the old behavior).

## Verification

- `ruff format` / `ruff check` / `mypy`: clean
- Python unit + e2e + multipart suites: **68 passed** (e2e runs against a filesystem-backed server)
- `cargo build`, `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features`: clean
- `cargo test -p objectstore-client --all-features`: passed

## Note for reviewers

This is a wire-visible behavior change for the (pathological) case of keys containing a literal `%XX`: such objects are now stored/fetched under the literal key rather than urllib3's percent-decoded interpretation. Objects previously written under the old interpretation would live at a different path.

Close FS-416