### PR TITLE
docs(py-client): Fix scope character set in Client.session docstring

### DIFF
--- a/clients/python/src/objectstore_client/client.py
+++ b/clients/python/src/objectstore_client/client.py
@@ -171,7 +171,7 @@ class Client:
         of key-value pairs passed as kwargs.
         IMPORTANT: the order of the kwargs matters!
 
-        The admitted characters for keys and values are: `A-Za-z0-9_-()$!+*'`.
+        The admitted characters for keys and values are: `A-Za-z0-9_-()$!+'`.
 
         Users are free to choose the scope structure that best suits their Usecase.
         The combination of Usecase and Scope will determine the physical key/path of the


### PR DESCRIPTION
The `Client.session` docstring listed `*` as an admitted scope character, but the validator in `scope.py` (and the Rust client's shared charset in `objectstore-types`) does not accept it. Remove it so the documented set matches the actual character set.

Refs FS-361