### PR TITLE
ref(server): Add report_only flag to bandwidth limits

### DIFF
--- a/objectstore-server/docs/architecture.md
+++ b/objectstore-server/docs/architecture.md
@@ -194,7 +194,9 @@ every chunk polled. For non-streamed payloads (e.g., batch INSERT where the
 size is known upfront), bytes are recorded directly via
 [`record_bandwidth`](state::Services::record_bandwidth).
 
-Rate-limited requests receive HTTP 429.
+Rate-limited requests receive HTTP 429. When `report_only` is enabled, all
+accounting and metrics (EWMA and limit gauges, KEDA metrics) remain active, but
+requests exceeding the limit are admitted instead of rejected.
 
 ### Web Concurrency Limit
 

--- a/objectstore-server/src/config.rs
+++ b/objectstore-server/src/config.rs
@@ -1042,6 +1042,7 @@ mod tests {
                     global_bps: 1048576
                     usecase_pct: 50
                     scope_pct: 25
+                    report_only: true
                 "#,
             )
             .unwrap();
@@ -1075,6 +1076,7 @@ mod tests {
                     global_bps: Some(1_048_576),
                     usecase_pct: Some(50),
                     scope_pct: Some(25),
+                    report_only: true,
                 },
             };
 

--- a/objectstore-server/src/rate_limits.rs
+++ b/objectstore-server/src/rate_limits.rs
@@ -176,6 +176,13 @@ pub struct BandwidthLimits {
     ///
     /// Value from `0` to `100`. Defaults to `None`, meaning no per-scope bandwidth limit is enforced.
     pub scope_pct: Option<u8>,
+
+    /// When `true`, bandwidth limits are evaluated and reported but never enforced.
+    ///
+    /// All accounting and metrics (EWMA and limit gauges, KEDA metrics) remain active,
+    /// but requests exceeding the limit are not rejected. Defaults to `false`.
+    #[serde(default)]
+    pub report_only: bool,
 }
 
 /// Combined rate limiter that enforces both bandwidth and throughput limits.
@@ -452,7 +459,15 @@ impl BandwidthRateLimiter {
         }
     }
 
+    /// Checks whether the current bandwidth exceeds configured limits.
+    ///
+    /// When [`BandwidthLimits::report_only`] is `true`, returns `None` unconditionally.
+    /// Accounting and metrics remain active regardless.
     fn check(&self, context: &ObjectContext) -> Option<RateLimitRejection> {
+        if self.config.report_only {
+            return None;
+        }
+
         let global_bps = self.config.global_bps?;
 
         // Global check

--- a/objectstore-server/tests/limits.rs
+++ b/objectstore-server/tests/limits.rs
@@ -402,6 +402,64 @@ async fn test_bandwidth_global_bps_limit() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_bandwidth_report_only() -> Result<()> {
+    let server = TestServer::with_config(Config {
+        auth: AuthZ {
+            enforce: false,
+            ..Default::default()
+        },
+        rate_limits: RateLimits {
+            bandwidth: BandwidthLimits {
+                global_bps: Some(500),
+                report_only: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+    .await;
+
+    let client = reqwest::Client::new();
+    let payload = vec![0xABu8; 4096];
+
+    // Upload a 4KB payload to push the EWMA above the 500 bps limit.
+    let response = client
+        .post(server.url("/v1/objects/test/org=1/"))
+        .body(payload.clone())
+        .send()
+        .await?;
+    assert_eq!(response.status(), reqwest::StatusCode::CREATED);
+
+    // Wait for the EWMA to incorporate the bandwidth.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    // With report_only, the request should succeed even though EWMA exceeds the limit.
+    let response = client
+        .post(server.url("/v1/objects/test/org=1/"))
+        .body(payload.clone())
+        .send()
+        .await?;
+    assert_eq!(response.status(), reqwest::StatusCode::CREATED);
+
+    // KEDA metrics should still report the EWMA and limit.
+    let response = client.get(server.url("/keda")).send().await?;
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    let body = response.text().await?;
+    assert!(
+        body.contains("objectstore_bandwidth_ewma "),
+        "missing bandwidth_ewma"
+    );
+    assert!(
+        body.contains("objectstore_bandwidth_limit 500"),
+        "missing bandwidth_limit"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_bandwidth_usecase_pct_limit() -> Result<()> {
     let server = TestServer::with_config(Config {
         auth: AuthZ {


### PR DESCRIPTION
Adds a `report_only` flag to `BandwidthLimits`. When enabled, all byte accounting, EWMA estimation, gauge metrics, and KEDA metrics remain active, but requests that exceed the limit are admitted rather than rejected with 429. This allows disabling enforcement while keeping the metrics available for the autoscaler and general observability. Throughput limits are unaffected.

The flag defaults to `false`.

Ref FS-436