### PR TITLE
ref(server): Emit bandwidth counter to Datadog

### DIFF
--- a/objectstore-server/src/rate_limits.rs
+++ b/objectstore-server/src/rate_limits.rs
@@ -267,6 +267,7 @@ impl RateLimiter {
         for acc in self.bandwidth.accumulators(context) {
             acc.fetch_add(bytes, std::sync::atomic::Ordering::Relaxed);
         }
+        objectstore_metrics::count!("server.bandwidth.bytes" += bytes);
     }
 
     /// Returns the current global bandwidth EWMA in bytes per second.
@@ -802,6 +803,7 @@ where
             for acc in &this.accumulators {
                 acc.fetch_add(len, std::sync::atomic::Ordering::Relaxed);
             }
+            objectstore_metrics::count!("server.bandwidth.bytes" += len);
         }
         res
     }


### PR DESCRIPTION
Bandwidth bytes were captured as a gauge derived from the internal EWMA estimator. They are now additionally emitted as a statsd counter (`server.bandwidth.bytes`), so the rate can be computed by the consumer via `as_rate()`. This removes the dependency on the in-process EWMA for bandwidth observability — once rate limiting no longer needs the estimator, it can be removed entirely.