### PR TITLE
ref(server): Replace bandwidth EWMA with lock-free GCRA buckets

### DIFF
--- a/objectstore-server/docs/architecture.md
+++ b/objectstore-server/docs/architecture.md
@@ -177,10 +177,13 @@ Limits can be set at multiple granularities:
 
 ### Bandwidth
 
-Bandwidth limiting uses an **exponentially weighted moving average** (EWMA) to
-estimate current throughput. Payload streams are wrapped in a
-`MeteredPayloadStream` that reports bytes consumed. When the estimated bandwidth
-exceeds the configured limit, new requests are rejected.
+Bandwidth limiting uses **debt-based GCRA** (Generic Cell Rate Algorithm)
+buckets that track a theoretical arrival time. Payload streams are wrapped in a
+`MeteredPayloadStream` that track consumed bytes. When accumulated debt exceeds
+the configured threshold, new requests are rejected.
+
+The `burst_ms` parameter controls how much transient overshoot is tolerated
+before rejection (in milliseconds). Defaults to `1000` (1 second).
 
 Like throughput, bandwidth limits can be set at multiple granularities:
 
@@ -188,15 +191,13 @@ Like throughput, bandwidth limits can be set at multiple granularities:
 - **Per-usecase**: a percentage of the global limit for each usecase
 - **Per-scope**: a percentage of the global limit for each scope value
 
-Each granularity maintains its own EWMA estimator. The `MeteredPayloadStream`
-increments all applicable accumulators (global + per-usecase + per-scope) for
-every chunk polled. For non-streamed payloads (e.g., batch INSERT where the
-size is known upfront), bytes are recorded directly via
-[`record_bandwidth`](state::Services::record_bandwidth).
+Each granularity maintains its own bucket. The `MeteredPayloadStream` charges
+all applicable buckets (global + per-usecase + per-scope) for every chunk
+polled. For non-streamed payloads, bytes are recorded directly.
 
 Rate-limited requests receive HTTP 429. When `report_only` is enabled, all
-accounting and metrics (EWMA and limit gauges, KEDA metrics) remain active, but
-requests exceeding the limit are admitted instead of rejected.
+accounting and metrics remain active, but requests exceeding the limit are
+admitted instead of rejected.
 
 ### Web Concurrency Limit
 
@@ -239,20 +240,14 @@ metrics so that it remains available when the server is at capacity.
 
 ### Exposed Metrics
 
-#### EWMA Gauges
-
-Pre-smoothed rates, self-contained per scrape (no `irate()` arithmetic needed):
+#### Gauges
 
 | Resource | Utilization | Limit |
 |---|---|---|
-| Bandwidth | `objectstore_bandwidth_ewma` | `objectstore_bandwidth_limit` (only when `global_bps` is set) |
-| Throughput | `objectstore_throughput_ewma` | `objectstore_throughput_limit` (only when `global_rps` is set) |
 | HTTP concurrency | `objectstore_requests_in_flight` | `objectstore_requests_limit` |
 | Task concurrency | `objectstore_tasks_running` | `objectstore_tasks_limit` |
 
-Throughput uses an EWMA with a 50 ms tick and α = 0.2, matching the existing
-bandwidth estimator. The accumulator counts fully admitted requests (requests
-that pass all throughput checks).
+Limit gauges are emitted only when the corresponding limit is configured.
 
 #### Counters
 
@@ -264,30 +259,10 @@ KEDA queries for an unsmoothed, immediately responsive rate:
 | `objectstore_bytes_total` | Total bytes transferred since startup |
 | `objectstore_requests_total` | Total admitted requests since startup |
 
-### Example KEDA ScaledObject Triggers
+### Example KEDA ScaledObject Trigger
 
-#### Using EWMA gauges (backward-compatible)
-
-Scale on the highest utilization across all four resources:
-
-```yaml
-triggers:
-  - type: prometheus
-    metadata:
-      serverAddress: http://prometheus:9090
-      query: |
-        max(
-          objectstore_bandwidth_ewma / objectstore_bandwidth_limit
-          or objectstore_throughput_ewma / objectstore_throughput_limit
-          or objectstore_requests_in_flight / objectstore_requests_limit
-          or objectstore_tasks_running / objectstore_tasks_limit
-        )
-      threshold: "0.7"
-```
-
-#### Using counters with `irate()` (more responsive)
-
-Uses the last two scraped values for an instantaneous rate with no smoothing lag:
+Scale on the highest utilization across all resources using `irate()` for
+bandwidth/throughput rates:
 
 ```yaml
 triggers:

--- a/objectstore-server/src/config.rs
+++ b/objectstore-server/src/config.rs
@@ -1040,6 +1040,7 @@ mod tests {
                         pct: 10
                   bandwidth:
                     global_bps: 1048576
+                    burst_ms: 2000
                     usecase_pct: 50
                     scope_pct: 25
                     report_only: true
@@ -1074,6 +1075,7 @@ mod tests {
                 },
                 bandwidth: BandwidthLimits {
                     global_bps: Some(1_048_576),
+                    burst_ms: 2000,
                     usecase_pct: Some(50),
                     scope_pct: Some(25),
                     report_only: true,

--- a/objectstore-server/src/endpoints/keda.rs
+++ b/objectstore-server/src/endpoints/keda.rs
@@ -2,8 +2,6 @@
 //!
 //! Exposes a `/keda` endpoint in Prometheus text format (version 0.0.4) with:
 //!
-//! - **EWMA gauges** (`objectstore_bandwidth_ewma`, `objectstore_throughput_ewma`): pre-computed
-//!   rates, self-contained per scrape with no `irate()` arithmetic needed (kept for backward compat).
 //! - **Monotonic counters** (`objectstore_bytes_total`, `objectstore_requests_total`):
 //!   cumulative totals since startup; use `irate(counter[window])` in KEDA queries for an
 //!   unsmoothed, immediately responsive rate.
@@ -21,10 +19,8 @@ pub fn router() -> Router<ServiceState> {
 }
 
 async fn keda(State(state): State<ServiceState>) -> impl IntoResponse {
-    let bw_ewma = state.rate_limiter.bandwidth_ewma();
     let bw_limit = state.rate_limiter.bandwidth_limit();
     let bw_total = state.rate_limiter.bandwidth_total_bytes();
-    let tp_rps = state.rate_limiter.throughput_rps();
     let tp_limit = state.rate_limiter.throughput_limit();
     let tp_total = state.rate_limiter.throughput_total_admitted();
     let req_in_flight = state.request_counter.count();
@@ -36,15 +32,9 @@ async fn keda(State(state): State<ServiceState>) -> impl IntoResponse {
         "# HELP objectstore_bytes_total Total bytes transferred since startup\n\
          # TYPE objectstore_bytes_total counter\n\
          objectstore_bytes_total {bw_total}\n\
-         # HELP objectstore_bandwidth_ewma Current bandwidth in bytes/s (EWMA)\n\
-         # TYPE objectstore_bandwidth_ewma gauge\n\
-         objectstore_bandwidth_ewma {bw_ewma}\n\
          # HELP objectstore_requests_total Total admitted requests since startup\n\
          # TYPE objectstore_requests_total counter\n\
          objectstore_requests_total {tp_total}\n\
-         # HELP objectstore_throughput_ewma Current admitted request rate in requests/s (EWMA)\n\
-         # TYPE objectstore_throughput_ewma gauge\n\
-         objectstore_throughput_ewma {tp_rps}\n\
          # HELP objectstore_requests_in_flight Current in-flight HTTP requests\n\
          # TYPE objectstore_requests_in_flight gauge\n\
          objectstore_requests_in_flight {req_in_flight}\n\

--- a/objectstore-server/src/rate_limits.rs
+++ b/objectstore-server/src/rate_limits.rs
@@ -320,6 +320,8 @@ impl RateLimiter {
 #[derive(Debug)]
 struct BandwidthBucket {
     /// Nanoseconds since `epoch` at which all recorded traffic is paid off.
+    ///
+    /// Saturates at `u64::MAX` after ~584 years of uptime.
     tat: AtomicU64,
     /// Nanoseconds of TAT advance per byte: `1e9 / bps`.
     nanos_per_byte: f64,
@@ -346,13 +348,13 @@ impl BandwidthBucket {
         // (no credit accumulation), then advance by the byte cost.
         self.tat
             .update(Ordering::Relaxed, Ordering::Relaxed, |old| {
-                old.max(now_nanos) + weight
+                old.max(now_nanos).saturating_add(weight)
             });
     }
 
     /// Returns `true` if the bucket admits new traffic at `now_nanos`.
     fn check(&self, now_nanos: u64) -> bool {
-        self.tat.load(Ordering::Relaxed) <= now_nanos + self.burst_ns
+        self.tat.load(Ordering::Relaxed) <= now_nanos.saturating_add(self.burst_ns)
     }
 }
 

--- a/objectstore-server/src/rate_limits.rs
+++ b/objectstore-server/src/rate_limits.rs
@@ -472,6 +472,13 @@ impl BandwidthRateLimiter {
             buckets.push(Arc::clone(bucket));
         }
 
+        objectstore_metrics::gauge!(
+            "server.rate_limiter.bandwidth.usecase_map_size" = self.usecases.len()
+        );
+        objectstore_metrics::gauge!(
+            "server.rate_limiter.bandwidth.scope_map_size" = self.scopes.len()
+        );
+
         BandwidthHandle {
             buckets,
             total_bytes: Arc::clone(&self.total_bytes),

--- a/objectstore-server/src/rate_limits.rs
+++ b/objectstore-server/src/rate_limits.rs
@@ -4,14 +4,15 @@
 //! levels of granularity — global, per-usecase, and per-scope — for both request
 //! throughput (requests/s) and upload/download bandwidth (bytes/s).
 //!
-//! Throughput is enforced using token buckets; bandwidth is estimated with an
-//! exponentially weighted moving average (EWMA) updated by a background task every
-//! 50 ms. All rate-limit checks are synchronous and non-blocking.
+//! Throughput is enforced using token buckets. Bandwidth uses debt-based GCRA
+//! (Generic Cell Rate Algorithm) buckets that track a theoretical arrival time
+//! (TAT). All rate-limit checks are synchronous, non-blocking, and lock-free.
 
 use std::fmt;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::{Mutex, atomic::AtomicU64};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
@@ -159,13 +160,20 @@ impl ThroughputRule {
 /// Bandwidth limits applied at global, per-usecase, and per-scope granularity.
 ///
 /// Bandwidth is measured as bytes transferred per second (upload + download combined)
-/// and estimated using an EWMA updated every 50 ms. All limits are optional.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+/// and tracked using debt-based GCRA buckets. All limits are optional.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct BandwidthLimits {
     /// The overall maximum bandwidth (in bytes per second) per service instance.
     ///
     /// Defaults to `None`, meaning no global bandwidth limit is enforced.
     pub global_bps: Option<u64>,
+
+    /// Burst tolerance in milliseconds.
+    ///
+    /// Allows short traffic spikes up to `burst_ms * bps / 1000` bytes before
+    /// rejection. Defaults to `1000` (1 second).
+    #[serde(default = "default_burst_ms")]
+    pub burst_ms: u64,
 
     /// The maximum percentage of the global bandwidth limit that can be used by any usecase.
     ///
@@ -179,21 +187,36 @@ pub struct BandwidthLimits {
 
     /// When `true`, bandwidth limits are evaluated and reported but never enforced.
     ///
-    /// All accounting and metrics (EWMA and limit gauges, KEDA metrics) remain active,
-    /// but requests exceeding the limit are not rejected. Defaults to `false`.
+    /// All accounting and metrics remain active, but requests exceeding the limit
+    /// are not rejected. Defaults to `false`.
     #[serde(default)]
     pub report_only: bool,
+}
+
+fn default_burst_ms() -> u64 {
+    1000
+}
+
+impl Default for BandwidthLimits {
+    fn default() -> Self {
+        Self {
+            global_bps: None,
+            burst_ms: default_burst_ms(),
+            usecase_pct: None,
+            scope_pct: None,
+            report_only: false,
+        }
+    }
 }
 
 /// Combined rate limiter that enforces both bandwidth and throughput limits.
 ///
 /// Checks are synchronous and non-blocking. Bandwidth is checked before
 /// throughput so that rejected requests are never counted toward the admitted
-/// throughput EWMA. See [`check`](RateLimiter::check) for details.
+/// throughput counter. See [`check`](RateLimiter::check) for details.
 ///
 /// Call [`start`](RateLimiter::start) after construction to launch the background
-/// estimation tasks. Without it, bandwidth EWMAs remain at zero and bandwidth
-/// limits are never triggered.
+/// observability tasks.
 #[derive(Debug)]
 pub struct RateLimiter {
     bandwidth: BandwidthRateLimiter,
@@ -203,7 +226,7 @@ pub struct RateLimiter {
 impl RateLimiter {
     /// Creates a new rate limiter from the given configuration.
     ///
-    /// Background estimation tasks are not started until [`start`](RateLimiter::start) is called.
+    /// Background observability tasks are not started until [`start`](RateLimiter::start) is called.
     pub fn new(config: RateLimits) -> Self {
         Self {
             bandwidth: BandwidthRateLimiter::new(config.bandwidth),
@@ -211,11 +234,10 @@ impl RateLimiter {
         }
     }
 
-    /// Starts background tasks for rate limit estimation and monitoring.
+    /// Starts background tasks for rate limit monitoring.
     ///
     /// Must be called from within a Tokio runtime.
     pub fn start(&self) {
-        self.bandwidth.start();
         self.throughput.start();
     }
 
@@ -226,8 +248,8 @@ impl RateLimiter {
     /// throughput so that rejected requests are never counted toward admitted traffic.
     pub fn check(&self, context: &ObjectContext, key: Option<&str>) -> bool {
         // Bandwidth is checked first because it is a pure read (no token consumption).
-        // Throughput increments the EWMA accumulator only on success, so checking it
-        // second ensures rejected requests are never counted toward admitted traffic.
+        // Throughput counts admitted requests, so checking it second ensures rejected
+        // requests are never counted toward admitted traffic.
         let rejection = self
             .bandwidth
             .check(context)
@@ -252,43 +274,25 @@ impl RateLimiter {
         false
     }
 
-    /// Returns all bandwidth accumulators (global + per-usecase + per-scope) for the given context.
+    /// Returns bandwidth buckets and the total-bytes counter for the given context.
     ///
     /// Creates entries in the per-usecase/per-scope maps if they don't exist yet.
-    pub fn bytes_accumulators(&self, context: &ObjectContext) -> Vec<Arc<AtomicU64>> {
-        self.bandwidth.accumulators(context)
+    pub fn bandwidth_handle(&self, context: &ObjectContext) -> BandwidthHandle {
+        self.bandwidth.handle(context)
     }
 
-    /// Records bandwidth usage across all accumulators for the given context.
+    /// Records bandwidth usage across all buckets for the given context.
     ///
     /// This is used for cases where bytes are known upfront (e.g. batch INSERT) rather than
     /// streamed through a `MeteredPayloadStream`.
     pub fn record_bandwidth(&self, context: &ObjectContext, bytes: u64) {
-        for acc in self.bandwidth.accumulators(context) {
-            acc.fetch_add(bytes, std::sync::atomic::Ordering::Relaxed);
-        }
+        self.bandwidth.handle(context).record(bytes);
         objectstore_metrics::count!("server.bandwidth.bytes" += bytes);
-    }
-
-    /// Returns the current global bandwidth EWMA in bytes per second.
-    pub fn bandwidth_ewma(&self) -> u64 {
-        self.bandwidth
-            .global
-            .estimate
-            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Returns the configured global bandwidth limit in bytes/s, if set.
     pub fn bandwidth_limit(&self) -> Option<u64> {
         self.bandwidth.config.global_bps
-    }
-
-    /// Returns the current estimated throughput in requests per second.
-    pub fn throughput_rps(&self) -> u64 {
-        self.throughput
-            .global_estimator
-            .estimate
-            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Returns the configured global throughput limit in requests/s, if set.
@@ -298,51 +302,57 @@ impl RateLimiter {
 
     /// Returns total bytes transferred since startup.
     pub fn bandwidth_total_bytes(&self) -> u64 {
-        self.bandwidth
-            .total_bytes
-            .load(std::sync::atomic::Ordering::Relaxed)
+        self.bandwidth.total_bytes.load(Ordering::Relaxed)
     }
 
     /// Returns total admitted requests since startup.
     pub fn throughput_total_admitted(&self) -> u64 {
-        self.throughput
-            .total_admitted
-            .load(std::sync::atomic::Ordering::Relaxed)
+        self.throughput.total_admitted.load(Ordering::Relaxed)
     }
 }
 
-/// Shared EWMA estimator state.
+/// Debt-based GCRA bandwidth bucket.
 ///
-/// The accumulator is incremented as events occur, and the estimate is updated
-/// periodically by a background task using an exponentially weighted moving average.
+/// Tracks a theoretical arrival time (TAT) that advances by `nanos_per_byte`
+/// for every byte consumed. Admission is granted while TAT stays within
+/// `burst_ns` nanoseconds ahead of the wall clock (burst tolerance). Recovery is
+/// continuous — no background tick required.
 #[derive(Debug)]
-struct EwmaEstimator {
-    accumulator: Arc<AtomicU64>,
-    estimate: Arc<AtomicU64>,
+struct BandwidthBucket {
+    /// Nanoseconds since `epoch` at which all recorded traffic is paid off.
+    tat: AtomicU64,
+    /// Nanoseconds of TAT advance per byte: `1e9 / bps`.
+    nanos_per_byte: f64,
+    /// Burst tolerance in nanoseconds: `burst_ms * 1_000_000`.
+    burst_ns: u64,
 }
 
-impl EwmaEstimator {
-    fn new() -> Self {
+impl BandwidthBucket {
+    /// Creates a new bucket for the given rate and burst tolerance.
+    fn new(bps: u64, burst_ms: u64) -> Self {
+        let nanos_per_byte = 1_000_000_000.0 / bps as f64;
+        let burst_ns = burst_ms * 1_000_000;
         Self {
-            accumulator: Arc::new(AtomicU64::new(0)),
-            estimate: Arc::new(AtomicU64::new(0)),
+            tat: AtomicU64::new(0),
+            nanos_per_byte,
+            burst_ns,
         }
     }
 
-    /// Updates the EWMA from the accumulator.
-    ///
-    /// Swaps the accumulator to zero, converts the count to a per-second rate using
-    /// `to_rate` (i.e., `1.0 / tick_duration.as_secs_f64()`), then applies the
-    /// EWMA smoothing and stores the floored result in `estimate`.
-    fn update_ewma(&self, ewma: &mut f64, to_rate: f64) {
-        const ALPHA: f64 = 0.2;
-        let current = self
-            .accumulator
-            .swap(0, std::sync::atomic::Ordering::Relaxed);
-        let rate = (current as f64) * to_rate;
-        *ewma = ALPHA * rate + (1.0 - ALPHA) * *ewma;
-        self.estimate
-            .store(ewma.floor() as u64, std::sync::atomic::Ordering::Relaxed);
+    /// Records `bytes` of consumption unconditionally (debt is allowed).
+    fn spend(&self, now_nanos: u64, bytes: u64) {
+        let weight = (bytes as f64 * self.nanos_per_byte) as u64;
+        // Clamp + advance in one atomic step: never let TAT fall behind `now`
+        // (no credit accumulation), then advance by the byte cost.
+        self.tat
+            .update(Ordering::Relaxed, Ordering::Relaxed, |old| {
+                old.max(now_nanos) + weight
+            });
+    }
+
+    /// Returns `true` if the bucket admits new traffic at `now_nanos`.
+    fn check(&self, now_nanos: u64) -> bool {
+        self.tat.load(Ordering::Relaxed) <= now_nanos + self.burst_ns
     }
 }
 
@@ -361,147 +371,75 @@ fn pct_of_u64(value: u64, pct: u8) -> u64 {
 #[derive(Debug)]
 struct BandwidthRateLimiter {
     config: BandwidthLimits,
-    /// Global accumulator/estimator pair.
-    global: Arc<EwmaEstimator>,
+    /// Global GCRA bucket.
+    global: Option<Arc<BandwidthBucket>>,
+    /// Shared epoch for converting `Instant` to nanos.
+    epoch: Instant,
     /// Cumulative bytes transferred since startup. Never reset.
     total_bytes: Arc<AtomicU64>,
     // NB: These maps grow unbounded but we accept this as we expect an overall limited
     // number of usecases and scopes. We emit gauge metrics to monitor their size.
-    usecases: Arc<papaya::HashMap<String, Arc<EwmaEstimator>>>,
-    scopes: Arc<papaya::HashMap<Scopes, Arc<EwmaEstimator>>>,
+    usecases: Arc<papaya::HashMap<String, Arc<BandwidthBucket>>>,
+    scopes: Arc<papaya::HashMap<Scopes, Arc<BandwidthBucket>>>,
 }
 
 impl BandwidthRateLimiter {
     fn new(config: BandwidthLimits) -> Self {
+        let global = config
+            .global_bps
+            .map(|bps| Arc::new(BandwidthBucket::new(bps, config.burst_ms)));
+
+        if let Some(limit) = config.global_bps {
+            objectstore_metrics::gauge!("server.bandwidth.limit" = limit);
+        }
+
         Self {
-            config,
-            global: Arc::new(EwmaEstimator::new()),
+            global,
+            epoch: Instant::now(),
             total_bytes: Arc::new(AtomicU64::new(0)),
             usecases: Arc::new(papaya::HashMap::new()),
             scopes: Arc::new(papaya::HashMap::new()),
+            config,
         }
     }
 
-    fn start(&self) {
-        let global = Arc::clone(&self.global);
-        let usecases = Arc::clone(&self.usecases);
-        let scopes = Arc::clone(&self.scopes);
-        let global_limit = self.config.global_bps;
-        // NB: This task has no shutdown mechanism — the rate limiter is only created once.
-        // The task is aborted when the Tokio runtime is dropped on process exit.
-        tokio::task::spawn(async move {
-            Self::estimator(global, usecases, scopes, global_limit).await;
-        });
+    /// Returns nanoseconds elapsed since the shared epoch.
+    fn now_nanos(&self) -> u64 {
+        self.epoch.elapsed().as_nanos() as u64
     }
 
-    /// Estimates the current bandwidth utilization using an exponentially weighted moving average.
-    ///
-    /// Iterates over the global estimator as well as all per-usecase and per-scope estimators
-    /// on each tick, updating their EWMAs.
-    async fn estimator(
-        global: Arc<EwmaEstimator>,
-        usecases: Arc<papaya::HashMap<String, Arc<EwmaEstimator>>>,
-        scopes: Arc<papaya::HashMap<Scopes, Arc<EwmaEstimator>>>,
-        global_limit: Option<u64>,
-    ) {
-        const TICK: Duration = Duration::from_millis(50); // Recompute EWMA on every TICK
-
-        let mut interval = tokio::time::interval(TICK);
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        // The first tick of a tokio interval fires immediately. Consume it so the
-        // first real iteration has a full ~50ms of elapsed time.
-        interval.tick().await;
-        let mut last = Instant::now();
-        let mut global_ewma: f64 = 0.0;
-        // Shadow EWMAs for per-usecase/per-scope entries, keyed the same way as the maps.
-        let mut usecase_ewmas: std::collections::HashMap<String, f64> =
-            std::collections::HashMap::new();
-        let mut scope_ewmas: std::collections::HashMap<Scopes, f64> =
-            std::collections::HashMap::new();
-
-        loop {
-            interval.tick().await;
-
-            let now = Instant::now();
-            let to_bps = 1.0 / now.duration_since(last).as_secs_f64();
-            last = now;
-
-            // Global
-            global.update_ewma(&mut global_ewma, to_bps);
-            objectstore_metrics::gauge!("server.bandwidth.ewma" = global_ewma.floor() as u64);
-            if let Some(limit) = global_limit {
-                objectstore_metrics::gauge!("server.bandwidth.limit" = limit);
-            }
-
-            // Per-usecase
-            {
-                let guard = usecases.pin();
-                for (key, estimator) in guard.iter() {
-                    let ewma = usecase_ewmas.entry(key.clone()).or_insert(0.0);
-                    estimator.update_ewma(ewma, to_bps);
-                }
-            }
-
-            // Per-scope
-            {
-                let guard = scopes.pin();
-                for (key, estimator) in guard.iter() {
-                    let ewma = scope_ewmas.entry(key.clone()).or_insert(0.0);
-                    estimator.update_ewma(ewma, to_bps);
-                }
-            }
-
-            objectstore_metrics::gauge!(
-                "server.rate_limiter.bandwidth.scope_map_size" = scopes.len()
-            );
-            objectstore_metrics::gauge!(
-                "server.rate_limiter.bandwidth.usecase_map_size" = usecases.len()
-            );
-        }
-    }
-
-    /// Checks whether the current bandwidth exceeds configured limits.
+    /// Checks whether the current bandwidth debt exceeds configured limits.
     ///
     /// When [`BandwidthLimits::report_only`] is `true`, returns `None` unconditionally.
-    /// Accounting and metrics remain active regardless.
     fn check(&self, context: &ObjectContext) -> Option<RateLimitRejection> {
         if self.config.report_only {
             return None;
         }
 
-        let global_bps = self.config.global_bps?;
+        let now_nanos = self.now_nanos();
 
         // Global check
-        if self
-            .global
-            .estimate
-            .load(std::sync::atomic::Ordering::Relaxed)
-            > global_bps
+        if let Some(ref global) = self.global
+            && !global.check(now_nanos)
         {
             return Some(RateLimitRejection::BandwidthGlobal);
         }
 
         // Per-usecase check
-        if let Some(usecase_bps) = self.usecase_bps() {
+        if self.usecase_bps().is_some() {
             let guard = self.usecases.pin();
-            if let Some(estimator) = guard.get(&context.usecase)
-                && estimator
-                    .estimate
-                    .load(std::sync::atomic::Ordering::Relaxed)
-                    > usecase_bps
+            if let Some(bucket) = guard.get(&context.usecase)
+                && !bucket.check(now_nanos)
             {
                 return Some(RateLimitRejection::BandwidthUsecase);
             }
         }
 
         // Per-scope check
-        if let Some(scope_bps) = self.scope_bps() {
+        if self.scope_bps().is_some() {
             let guard = self.scopes.pin();
-            if let Some(estimator) = guard.get(&context.scopes)
-                && estimator
-                    .estimate
-                    .load(std::sync::atomic::Ordering::Relaxed)
-                    > scope_bps
+            if let Some(bucket) = guard.get(&context.scopes)
+                && !bucket.check(now_nanos)
             {
                 return Some(RateLimitRejection::BandwidthScope);
             }
@@ -510,31 +448,35 @@ impl BandwidthRateLimiter {
         None
     }
 
-    /// Returns all accumulators (global + per-usecase + per-scope) for the given context.
-    ///
-    /// Creates entries in the per-usecase/per-scope maps if they don't exist yet.
-    /// Always includes `total_bytes` (cumulative, never reset) as the first entry.
-    fn accumulators(&self, context: &ObjectContext) -> Vec<Arc<AtomicU64>> {
-        let mut accs = vec![
-            Arc::clone(&self.total_bytes),
-            Arc::clone(&self.global.accumulator),
-        ];
+    /// Returns a handle containing the bandwidth buckets and total-bytes counter.
+    fn handle(&self, context: &ObjectContext) -> BandwidthHandle {
+        let mut buckets = Vec::new();
 
-        if self.usecase_bps().is_some() {
+        if let Some(ref global) = self.global {
+            buckets.push(Arc::clone(global));
+        }
+
+        if let Some(usecase_bps) = self.usecase_bps() {
             let guard = self.usecases.pin();
-            let estimator = guard
-                .get_or_insert_with(context.usecase.clone(), || Arc::new(EwmaEstimator::new()));
-            accs.push(Arc::clone(&estimator.accumulator));
+            let bucket = guard.get_or_insert_with(context.usecase.clone(), || {
+                Arc::new(BandwidthBucket::new(usecase_bps, self.config.burst_ms))
+            });
+            buckets.push(Arc::clone(bucket));
         }
 
-        if self.scope_bps().is_some() {
+        if let Some(scope_bps) = self.scope_bps() {
             let guard = self.scopes.pin();
-            let estimator =
-                guard.get_or_insert_with(context.scopes.clone(), || Arc::new(EwmaEstimator::new()));
-            accs.push(Arc::clone(&estimator.accumulator));
+            let bucket = guard.get_or_insert_with(context.scopes.clone(), || {
+                Arc::new(BandwidthBucket::new(scope_bps, self.config.burst_ms))
+            });
+            buckets.push(Arc::clone(bucket));
         }
 
-        accs
+        BandwidthHandle {
+            buckets,
+            total_bytes: Arc::clone(&self.total_bytes),
+            epoch: self.epoch,
+        }
     }
 
     /// Returns the effective BPS for per-usecase limiting, if configured.
@@ -552,12 +494,29 @@ impl BandwidthRateLimiter {
     }
 }
 
+/// Handle for recording bandwidth consumption against GCRA buckets.
+#[derive(Debug, Clone)]
+pub struct BandwidthHandle {
+    buckets: Vec<Arc<BandwidthBucket>>,
+    total_bytes: Arc<AtomicU64>,
+    epoch: Instant,
+}
+
+impl BandwidthHandle {
+    /// Records `bytes` of consumption across all buckets and the total counter.
+    pub fn record(&self, bytes: u64) {
+        let now_nanos = self.epoch.elapsed().as_nanos() as u64;
+        self.total_bytes.fetch_add(bytes, Ordering::Relaxed);
+        for bucket in &self.buckets {
+            bucket.spend(now_nanos, bytes);
+        }
+    }
+}
+
 #[derive(Debug)]
 struct ThroughputRateLimiter {
     config: ThroughputLimits,
     global: Option<Mutex<TokenBucket>>,
-    /// Global EWMA estimator for admitted request rate.
-    global_estimator: Arc<EwmaEstimator>,
     /// Cumulative admitted requests since startup. Never reset.
     total_admitted: Arc<AtomicU64>,
     // NB: These maps grow unbounded but we accept this as we expect an overall limited
@@ -576,7 +535,6 @@ impl ThroughputRateLimiter {
         Self {
             config,
             global,
-            global_estimator: Arc::new(EwmaEstimator::new()),
             total_admitted: Arc::new(AtomicU64::new(0)),
             usecases: Arc::new(papaya::HashMap::new()),
             scopes: Arc::new(papaya::HashMap::new()),
@@ -587,24 +545,14 @@ impl ThroughputRateLimiter {
     fn start(&self) {
         let usecases = Arc::clone(&self.usecases);
         let scopes = Arc::clone(&self.scopes);
-        let global_estimator = Arc::clone(&self.global_estimator);
         let global_limit = self.config.global_rps;
-        // NB: This task has no shutdown mechanism — the rate limiter is only created once.
-        // The task is aborted when the Tokio runtime is dropped on process exit.
         tokio::task::spawn(async move {
-            const TICK: Duration = Duration::from_millis(50);
+            const TICK: Duration = Duration::from_secs(1);
             let mut interval = tokio::time::interval(TICK);
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             interval.tick().await;
-            let mut last = Instant::now();
-            let mut global_ewma: f64 = 0.0;
             loop {
                 interval.tick().await;
-                let now = Instant::now();
-                let to_rps = 1.0 / now.duration_since(last).as_secs_f64();
-                last = now;
-                global_estimator.update_ewma(&mut global_ewma, to_rps);
-                objectstore_metrics::gauge!("server.throughput.ewma" = global_ewma.floor() as u64);
                 if let Some(limit) = global_limit {
                     objectstore_metrics::gauge!(
                         "server.rate_limiter.throughput.limit" = u64::from(limit)
@@ -666,14 +614,7 @@ impl ThroughputRateLimiter {
             }
         }
 
-        // Count this admitted request in the EWMA accumulator and the cumulative counter.
-        // NB: u64 wrapping is not a practical concern — at 1M rps it takes ~585k years.
-        // Prometheus irate() also handles counter resets gracefully should it ever occur.
-        self.global_estimator
-            .accumulator
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        self.total_admitted
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.total_admitted.fetch_add(1, Ordering::Relaxed);
 
         None
     }
@@ -765,26 +706,24 @@ impl TokenBucket {
 
 /// A wrapper around a byte stream that measures bandwidth usage.
 ///
-/// Every time a chunk is polled successfully, all accumulators are incremented
-/// by its size. Generic over both the stream type `S` and its error type.
+/// Every time a chunk is polled successfully, all bandwidth buckets are charged
+/// and the total-bytes counter is incremented. Generic over both the stream
+/// type `S` and its error type.
 pub(crate) struct MeteredPayloadStream<S> {
     inner: S,
-    accumulators: Vec<Arc<AtomicU64>>,
+    handle: BandwidthHandle,
 }
 
 impl<S> MeteredPayloadStream<S> {
-    pub fn new(inner: S, accumulators: Vec<Arc<AtomicU64>>) -> Self {
-        Self {
-            inner,
-            accumulators,
-        }
+    pub fn new(inner: S, handle: BandwidthHandle) -> Self {
+        Self { inner, handle }
     }
 }
 
 impl<S> fmt::Debug for MeteredPayloadStream<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MeteredPayloadStream")
-            .field("accumulators", &self.accumulators)
+            .field("handle", &self.handle)
             .finish()
     }
 }
@@ -800,9 +739,7 @@ where
         let res = Pin::new(&mut this.inner).poll_next(cx);
         if let Poll::Ready(Some(Ok(ref bytes))) = res {
             let len = bytes.len() as u64;
-            for acc in &this.accumulators {
-                acc.fetch_add(len, std::sync::atomic::Ordering::Relaxed);
-            }
+            this.handle.record(len);
             objectstore_metrics::count!("server.bandwidth.bytes" += len);
         }
         res
@@ -823,65 +760,124 @@ mod tests {
         }
     }
 
+    // --- BandwidthBucket unit tests (explicit `now`, no sleeps) ---
+
     #[test]
-    fn ewma_estimator_update_applies_alpha() {
-        let estimator = EwmaEstimator::new();
-        const TICK: f64 = 0.05; // 50ms
-        let to_rate = 1.0 / TICK;
-        let mut ewma: f64 = 0.0;
+    fn bucket_spend_advances_tat() {
+        let bucket = BandwidthBucket::new(1000, 0); // 1000 bps, no burst
+        let now = 1_000_000_000u64; // 1s after epoch
 
-        // Simulate 10 events in one 50ms tick → 200 /s raw rate.
-        // After one step: 0.2 * 200 + 0.8 * 0 = 40.
-        estimator
-            .accumulator
-            .store(10, std::sync::atomic::Ordering::Relaxed);
-        estimator.update_ewma(&mut ewma, to_rate);
-        assert_eq!(
-            estimator
-                .estimate
-                .load(std::sync::atomic::Ordering::Relaxed),
-            40
-        );
+        bucket.spend(now, 500);
 
-        // Accumulator must have been zeroed.
-        assert_eq!(
-            estimator
-                .accumulator
-                .load(std::sync::atomic::Ordering::Relaxed),
-            0
-        );
+        // 500 bytes at 1e6 ns/byte = 500_000_000 ns ahead of `now`
+        let expected_tat = now + 500_000_000;
+        assert_eq!(bucket.tat.load(Ordering::Relaxed), expected_tat);
     }
 
     #[test]
-    fn throughput_check_increments_accumulator() {
+    fn bucket_spend_clamps_credit() {
+        let bucket = BandwidthBucket::new(1000, 0);
+        // Set TAT in the past (idle period).
+        bucket.tat.store(100, Ordering::Relaxed);
+        let now = 2_000_000_000u64;
+
+        bucket.spend(now, 100);
+
+        // TAT should have been clamped to `now` first, then advanced.
+        let weight = (100.0 * 1_000_000_000.0 / 1000.0) as u64;
+        let expected = now + weight;
+        assert_eq!(bucket.tat.load(Ordering::Relaxed), expected);
+    }
+
+    #[test]
+    fn bucket_check_admits_within_burst() {
+        let bucket = BandwidthBucket::new(1000, 1000); // 1s burst
+        let now = 1_000_000_000u64;
+
+        // Spend 1500 bytes: 1.5s of debt at 1000 bps
+        bucket.spend(now, 1500);
+
+        // debt = 1.5s, burst = 1s → rejected
+        assert!(!bucket.check(now));
+
+        // debt = 1.5s, but 0.6s have passed → debt = 0.9s < 1s burst → admitted
+        assert!(bucket.check(now + 600_000_000));
+    }
+
+    #[test]
+    fn bucket_check_zero_burst_rejects_any_debt() {
+        let bucket = BandwidthBucket::new(1000, 0);
+        let now = 1_000_000_000u64;
+
+        bucket.spend(now, 1);
+
+        // Any debt with burst=0 should reject
+        assert!(!bucket.check(now));
+
+        // After enough time passes, debt is paid off
+        let weight = (1.0 * 1_000_000_000.0 / 1000.0) as u64;
+        assert!(bucket.check(now + weight));
+    }
+
+    #[test]
+    fn bucket_recovery_after_debt() {
+        let bucket = BandwidthBucket::new(1000, 0);
+        let now = 1_000_000_000u64;
+
+        bucket.spend(now, 2000);
+
+        // 2000 bytes at 1000 bps = 2s of debt
+        assert!(!bucket.check(now));
+        assert!(!bucket.check(now + 1_500_000_000));
+
+        // After 2s, debt is fully paid → admitted
+        assert!(bucket.check(now + 2_000_000_000));
+    }
+
+    #[test]
+    fn bandwidth_check_rejects_correct_variant() {
+        // Use generous burst so only the scope bucket overflows.
+        // Global = 1000 bps, usecase = 500 bps, scope = 250 bps; burst = 2s.
+        // Spending 600 bytes:
+        //   global debt = 600/1000 = 0.6s < 2s → admits
+        //   usecase debt = 600/500 = 1.2s < 2s → admits
+        //   scope debt  = 600/250 = 2.4s > 2s → rejects
+        let limiter = BandwidthRateLimiter::new(BandwidthLimits {
+            global_bps: Some(1000),
+            usecase_pct: Some(50),
+            scope_pct: Some(25),
+            burst_ms: 2000,
+            ..Default::default()
+        });
+
+        let context = make_context();
+        let handle = limiter.handle(&context);
+        handle.record(600);
+
+        let rejection = limiter.check(&context);
+        assert_eq!(rejection, Some(RateLimitRejection::BandwidthScope));
+    }
+
+    // --- Throughput ---
+
+    #[test]
+    fn throughput_check_counts_admitted() {
         let limiter = ThroughputRateLimiter::new(ThroughputLimits {
             global_rps: Some(1000),
             ..Default::default()
         });
 
-        assert_eq!(
-            limiter
-                .global_estimator
-                .accumulator
-                .load(std::sync::atomic::Ordering::Relaxed),
-            0
-        );
+        assert_eq!(limiter.total_admitted.load(Ordering::Relaxed), 0);
 
         let context = make_context();
         assert!(limiter.check(&context).is_none());
         assert!(limiter.check(&context).is_none());
 
-        assert_eq!(
-            limiter
-                .global_estimator
-                .accumulator
-                .load(std::sync::atomic::Ordering::Relaxed),
-            2
-        );
+        assert_eq!(limiter.total_admitted.load(Ordering::Relaxed), 2);
     }
 
     #[test]
-    fn throughput_rejected_does_not_increment_accumulator() {
+    fn throughput_rejected_does_not_count() {
         let limiter = ThroughputRateLimiter::new(ThroughputLimits {
             global_rps: Some(1),
             burst: 0,
@@ -893,51 +889,31 @@ mod tests {
         assert!(limiter.check(&context).is_none());
         assert!(limiter.check(&context).is_some());
 
-        assert_eq!(
-            limiter
-                .global_estimator
-                .accumulator
-                .load(std::sync::atomic::Ordering::Relaxed),
-            1 // only the admitted request
-        );
+        assert_eq!(limiter.total_admitted.load(Ordering::Relaxed), 1);
     }
 
     #[test]
-    fn bandwidth_rejection_does_not_increment_throughput_accumulator() {
-        // global_bps of 1 means the estimate (0 initially) is not > 1, so the first
-        // call passes the bandwidth check. Use 0 to guarantee an immediate reject.
-        // BandwidthRateLimiter::check rejects when estimate > global_bps, so set
-        // global_bps = 0 to make the bandwidth check always reject.
+    fn bandwidth_rejection_does_not_count_throughput() {
         let limiter = RateLimiter::new(RateLimits {
             throughput: ThroughputLimits {
                 global_rps: Some(1000),
                 ..Default::default()
             },
             bandwidth: BandwidthLimits {
-                global_bps: Some(0),
+                global_bps: Some(1),
+                burst_ms: 0,
                 ..Default::default()
             },
         });
 
-        // Prime the bandwidth EWMA so it exceeds the limit.
-        limiter
-            .bandwidth
-            .global
-            .estimate
-            .store(1, std::sync::atomic::Ordering::Relaxed);
-
+        // Put the bandwidth bucket in debt so the check rejects.
         let context = make_context();
+        let handle = limiter.bandwidth_handle(&context);
+        handle.record(1_000_000);
+
         assert!(!limiter.check(&context, None));
 
-        // The throughput accumulator must still be 0.
-        assert_eq!(
-            limiter
-                .throughput
-                .global_estimator
-                .accumulator
-                .load(std::sync::atomic::Ordering::Relaxed),
-            0
-        );
+        assert_eq!(limiter.throughput.total_admitted.load(Ordering::Relaxed), 0);
     }
 
     #[test]
@@ -955,9 +931,6 @@ mod tests {
 
         assert_eq!(rate_limiter.bandwidth_limit(), Some(1_000_000));
         assert_eq!(rate_limiter.throughput_limit(), Some(500));
-        // Estimates start at 0 before any background tick.
-        assert_eq!(rate_limiter.bandwidth_ewma(), 0);
-        assert_eq!(rate_limiter.throughput_rps(), 0);
     }
 
     #[test]
@@ -966,7 +939,5 @@ mod tests {
 
         assert_eq!(rate_limiter.bandwidth_limit(), None);
         assert_eq!(rate_limiter.throughput_limit(), None);
-        assert_eq!(rate_limiter.bandwidth_ewma(), 0);
-        assert_eq!(rate_limiter.throughput_rps(), 0);
     }
 }

--- a/objectstore-server/src/rate_limits.rs
+++ b/objectstore-server/src/rate_limits.rs
@@ -405,6 +405,7 @@ impl BandwidthRateLimiter {
 
     /// Returns nanoseconds elapsed since the shared epoch.
     fn now_nanos(&self) -> u64 {
+        // u64 nanos overflow after ~584 years of uptime, accepted.
         self.epoch.elapsed().as_nanos() as u64
     }
 

--- a/objectstore-server/src/state.rs
+++ b/objectstore-server/src/state.rs
@@ -99,7 +99,7 @@ impl Services {
     where
         S: Stream<Item = Result<Bytes, E>> + Send + 'static,
     {
-        MeteredPayloadStream::new(stream, self.rate_limiter.bytes_accumulators(context))
+        MeteredPayloadStream::new(stream, self.rate_limiter.bandwidth_handle(context))
     }
 
     /// Records bandwidth usage for the given context without wrapping a stream.

--- a/objectstore-server/tests/limits.rs
+++ b/objectstore-server/tests/limits.rs
@@ -345,6 +345,7 @@ async fn test_throughput_rule() -> Result<()> {
 
 #[tokio::test]
 async fn test_bandwidth_global_bps_limit() -> Result<()> {
+    // 100 bps with 0 burst: 100 bytes creates 1s of debt → immediate rejection.
     let server = TestServer::with_config(Config {
         auth: AuthZ {
             enforce: false,
@@ -352,7 +353,8 @@ async fn test_bandwidth_global_bps_limit() -> Result<()> {
         },
         rate_limits: RateLimits {
             bandwidth: BandwidthLimits {
-                global_bps: Some(500),
+                global_bps: Some(100),
+                burst_ms: 0,
                 ..Default::default()
             },
             ..Default::default()
@@ -362,11 +364,9 @@ async fn test_bandwidth_global_bps_limit() -> Result<()> {
     .await;
 
     let client = reqwest::Client::new();
-    let payload = vec![0xABu8; 4096];
+    let payload = vec![0xABu8; 100];
 
-    // Upload a 4KB payload to push the EWMA above the 500 bps limit.
-    // A single 4096-byte upload in one 50ms tick produces an EWMA sample of ~16384 bps,
-    // which is well above the 500 bps limit.
+    // First upload succeeds (admitted before any debt exists).
     let response = client
         .post(server.url("/v1/objects/test/org=1/"))
         .body(payload.clone())
@@ -374,10 +374,7 @@ async fn test_bandwidth_global_bps_limit() -> Result<()> {
         .await?;
     assert_eq!(response.status(), reqwest::StatusCode::CREATED);
 
-    // Wait a few EWMA ticks (50ms each) so the estimator incorporates the bandwidth.
-    tokio::time::sleep(Duration::from_millis(150)).await;
-
-    // The next request should be rejected with 429
+    // Immediately after, the bucket has 1s of debt → rejected.
     let response = client
         .post(server.url("/v1/objects/test/org=1/"))
         .body(payload.clone())
@@ -385,12 +382,10 @@ async fn test_bandwidth_global_bps_limit() -> Result<()> {
         .await?;
     assert_eq!(response.status(), reqwest::StatusCode::TOO_MANY_REQUESTS);
 
-    // Wait long enough for the EWMA to decay below the limit.
-    // With alpha=0.2, EWMA decays as 0.8^n per tick. Peak ~16384 needs ~16 ticks (800ms)
-    // to drop below 500. Use 2s for CI reliability.
+    // Wait for debt to drain (100 bytes / 100 bps = 1s, use 2s for CI reliability).
     tokio::time::sleep(Duration::from_secs(2)).await;
 
-    // After decay, the request should succeed again
+    // After recovery, request succeeds again.
     let response = client
         .post(server.url("/v1/objects/test/org=1/"))
         .body(payload.clone())
@@ -402,7 +397,9 @@ async fn test_bandwidth_global_bps_limit() -> Result<()> {
 }
 
 #[tokio::test]
-async fn test_bandwidth_report_only() -> Result<()> {
+async fn test_bandwidth_burst_tolerance() -> Result<()> {
+    // 100 bps with 1.5s burst → burst budget = 150 bytes.
+    // A 100-byte upload creates 1s of debt, within 1.5s burst → next request admitted.
     let server = TestServer::with_config(Config {
         auth: AuthZ {
             enforce: false,
@@ -410,7 +407,58 @@ async fn test_bandwidth_report_only() -> Result<()> {
         },
         rate_limits: RateLimits {
             bandwidth: BandwidthLimits {
-                global_bps: Some(500),
+                global_bps: Some(100),
+                burst_ms: 1500,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+    .await;
+
+    let client = reqwest::Client::new();
+    let payload = vec![0xABu8; 100];
+
+    // First upload creates 1s of debt, within the 1.5s burst tolerance.
+    let response = client
+        .post(server.url("/v1/objects/test/org=1/"))
+        .body(payload.clone())
+        .send()
+        .await?;
+    assert_eq!(response.status(), reqwest::StatusCode::CREATED);
+
+    // Next request is still admitted because debt ≤ tau.
+    let response = client
+        .post(server.url("/v1/objects/test/org=1/"))
+        .body(payload.clone())
+        .send()
+        .await?;
+    assert_eq!(response.status(), reqwest::StatusCode::CREATED);
+
+    // Now debt ≈ 2s > 1.5s burst → rejected.
+    let response = client
+        .post(server.url("/v1/objects/test/org=1/"))
+        .body(payload.clone())
+        .send()
+        .await?;
+    assert_eq!(response.status(), reqwest::StatusCode::TOO_MANY_REQUESTS);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_bandwidth_report_only() -> Result<()> {
+    // With report_only, requests succeed even when debt exceeds burst tolerance.
+    let server = TestServer::with_config(Config {
+        auth: AuthZ {
+            enforce: false,
+            ..Default::default()
+        },
+        rate_limits: RateLimits {
+            bandwidth: BandwidthLimits {
+                global_bps: Some(100),
+                burst_ms: 0,
                 report_only: true,
                 ..Default::default()
             },
@@ -421,9 +469,8 @@ async fn test_bandwidth_report_only() -> Result<()> {
     .await;
 
     let client = reqwest::Client::new();
-    let payload = vec![0xABu8; 4096];
+    let payload = vec![0xABu8; 100];
 
-    // Upload a 4KB payload to push the EWMA above the 500 bps limit.
     let response = client
         .post(server.url("/v1/objects/test/org=1/"))
         .body(payload.clone())
@@ -431,10 +478,7 @@ async fn test_bandwidth_report_only() -> Result<()> {
         .await?;
     assert_eq!(response.status(), reqwest::StatusCode::CREATED);
 
-    // Wait for the EWMA to incorporate the bandwidth.
-    tokio::time::sleep(Duration::from_millis(150)).await;
-
-    // With report_only, the request should succeed even though EWMA exceeds the limit.
+    // With report_only, the request should succeed even though debt exceeds the limit.
     let response = client
         .post(server.url("/v1/objects/test/org=1/"))
         .body(payload.clone())
@@ -442,17 +486,13 @@ async fn test_bandwidth_report_only() -> Result<()> {
         .await?;
     assert_eq!(response.status(), reqwest::StatusCode::CREATED);
 
-    // KEDA metrics should still report the EWMA and limit.
+    // KEDA metrics should still report the limit.
     let response = client.get(server.url("/keda")).send().await?;
     assert_eq!(response.status(), reqwest::StatusCode::OK);
 
     let body = response.text().await?;
     assert!(
-        body.contains("objectstore_bandwidth_ewma "),
-        "missing bandwidth_ewma"
-    );
-    assert!(
-        body.contains("objectstore_bandwidth_limit 500"),
+        body.contains("objectstore_bandwidth_limit 100"),
         "missing bandwidth_limit"
     );
 
@@ -461,6 +501,9 @@ async fn test_bandwidth_report_only() -> Result<()> {
 
 #[tokio::test]
 async fn test_bandwidth_usecase_pct_limit() -> Result<()> {
+    // 10_000 bps global, 1% per usecase = 100 bps per usecase.
+    // burst_ms=100 absorbs global debt (100/10000 = 0.01s) but the
+    // per-usecase debt (100/100 = 1s) exceeds it → usecase rejects.
     let server = TestServer::with_config(Config {
         auth: AuthZ {
             enforce: false,
@@ -468,8 +511,9 @@ async fn test_bandwidth_usecase_pct_limit() -> Result<()> {
         },
         rate_limits: RateLimits {
             bandwidth: BandwidthLimits {
-                global_bps: Some(100_000),
-                usecase_pct: Some(1), // = 1000 bps per usecase
+                global_bps: Some(10_000),
+                burst_ms: 100,
+                usecase_pct: Some(1),
                 ..Default::default()
             },
             ..Default::default()
@@ -479,11 +523,8 @@ async fn test_bandwidth_usecase_pct_limit() -> Result<()> {
     .await;
 
     let client = reqwest::Client::new();
+    let payload = vec![0xABu8; 100];
 
-    // Upload a 4KB payload to push the per-usecase EWMA above the 1000 bps limit.
-    // A single 4096-byte upload in one 50ms tick produces an EWMA sample of ~16384 bps,
-    // which is well above the 1000 bps per-usecase limit but below the 100000 bps global limit.
-    let payload = vec![0xABu8; 4096];
     let response = client
         .post(server.url("/v1/objects/test/org=1/"))
         .body(payload.clone())
@@ -491,10 +532,7 @@ async fn test_bandwidth_usecase_pct_limit() -> Result<()> {
         .await?;
     assert_eq!(response.status(), reqwest::StatusCode::CREATED);
 
-    // Wait a few EWMA ticks so the estimator incorporates the bandwidth.
-    tokio::time::sleep(Duration::from_millis(150)).await;
-
-    // The next request to the same usecase should be rejected with 429
+    // Same usecase should be rejected (per-usecase debt).
     let response = client
         .post(server.url("/v1/objects/test/org=1/"))
         .body(payload.clone())
@@ -502,7 +540,7 @@ async fn test_bandwidth_usecase_pct_limit() -> Result<()> {
         .await?;
     assert_eq!(response.status(), reqwest::StatusCode::TOO_MANY_REQUESTS);
 
-    // A different usecase should succeed (separate EWMA bucket)
+    // Different usecase has a separate bucket → admitted.
     let response = client
         .post(server.url("/v1/objects/other/org=1/"))
         .body(payload.clone())
@@ -510,10 +548,10 @@ async fn test_bandwidth_usecase_pct_limit() -> Result<()> {
         .await?;
     assert_eq!(response.status(), reqwest::StatusCode::CREATED);
 
-    // Wait for the EWMA to decay below the limit
+    // Wait for per-usecase debt to drain (100/100 = 1s, use 2s for CI).
     tokio::time::sleep(Duration::from_secs(2)).await;
 
-    // After decay, the request to the original usecase should succeed again
+    // After recovery, original usecase admits again.
     let response = client
         .post(server.url("/v1/objects/test/org=1/"))
         .body(payload.clone())
@@ -526,6 +564,8 @@ async fn test_bandwidth_usecase_pct_limit() -> Result<()> {
 
 #[tokio::test]
 async fn test_bandwidth_scope_pct_limit() -> Result<()> {
+    // 10_000 bps global, 1% per scope = 100 bps per scope.
+    // burst_ms=100 absorbs global debt but per-scope debt exceeds it.
     let server = TestServer::with_config(Config {
         auth: AuthZ {
             enforce: false,
@@ -533,8 +573,9 @@ async fn test_bandwidth_scope_pct_limit() -> Result<()> {
         },
         rate_limits: RateLimits {
             bandwidth: BandwidthLimits {
-                global_bps: Some(100_000),
-                scope_pct: Some(1), // = 1000 bps per scope
+                global_bps: Some(10_000),
+                burst_ms: 100,
+                scope_pct: Some(1),
                 ..Default::default()
             },
             ..Default::default()
@@ -544,11 +585,8 @@ async fn test_bandwidth_scope_pct_limit() -> Result<()> {
     .await;
 
     let client = reqwest::Client::new();
+    let payload = vec![0xABu8; 100];
 
-    // Upload a 4KB payload to push the per-scope EWMA above the 1000 bps limit.
-    // A single 4096-byte upload in one 50ms tick produces an EWMA sample of ~16384 bps,
-    // which is well above the 1000 bps per-scope limit but below the 100000 bps global limit.
-    let payload = vec![0xABu8; 4096];
     let response = client
         .post(server.url("/v1/objects/test/org=1/"))
         .body(payload.clone())
@@ -556,10 +594,7 @@ async fn test_bandwidth_scope_pct_limit() -> Result<()> {
         .await?;
     assert_eq!(response.status(), reqwest::StatusCode::CREATED);
 
-    // Wait a few EWMA ticks so the estimator incorporates the bandwidth.
-    tokio::time::sleep(Duration::from_millis(150)).await;
-
-    // The next request to the same scope should be rejected with 429
+    // Same scope should be rejected (per-scope debt).
     let response = client
         .post(server.url("/v1/objects/test/org=1/"))
         .body(payload.clone())
@@ -567,7 +602,7 @@ async fn test_bandwidth_scope_pct_limit() -> Result<()> {
         .await?;
     assert_eq!(response.status(), reqwest::StatusCode::TOO_MANY_REQUESTS);
 
-    // A different scope should succeed (separate EWMA bucket)
+    // Different scope has a separate bucket → admitted.
     let response = client
         .post(server.url("/v1/objects/test/org=2/"))
         .body(payload.clone())
@@ -575,10 +610,10 @@ async fn test_bandwidth_scope_pct_limit() -> Result<()> {
         .await?;
     assert_eq!(response.status(), reqwest::StatusCode::CREATED);
 
-    // Wait for the EWMA to decay below the limit
+    // Wait for per-scope debt to drain (100/100 = 1s, use 2s for CI).
     tokio::time::sleep(Duration::from_secs(2)).await;
 
-    // After decay, the request to the original scope should succeed again
+    // After recovery, original scope admits again.
     let response = client
         .post(server.url("/v1/objects/test/org=1/"))
         .body(payload.clone())
@@ -850,12 +885,6 @@ async fn test_keda() -> Result<()> {
     );
 
     let body = response.text().await?;
-
-    // One always-present gauge to verify the format.
-    assert!(
-        body.contains("objectstore_bandwidth_ewma "),
-        "missing bandwidth_ewma"
-    );
 
     // Optional gauges are present when the corresponding limits are configured.
     assert!(


### PR DESCRIPTION
Bandwidth rate limiting now uses debt-based GCRA (Generic Cell Rate Algorithm) buckets instead of EWMA estimation. Each bucket tracks a single atomic timestamp — the point at which all recorded traffic is "paid off." Admission checks compare this deadline against wall-clock time plus a configurable burst tolerance, with no background estimation task required.

This removes the 50ms EWMA tick and its associated state (per-scope/per-usecase shadow EWMA maps, the `EwmaEstimator` struct), replacing them with lock-free `AtomicU64::update` operations that are both simpler and more responsive — debt is visible immediately after bytes are recorded rather than after the next estimation tick. The `burst_ms` config parameter (default: 1000ms) controls how much transient overshoot is tolerated before rejection.

EWMA gauges are removed from the KEDA endpoint since the monotonic counters with `irate()` are strictly more responsive. The throughput background task is simplified to emit only the limit and map-size gauges at 1s intervals. The bandwidth limit gauge is now emitted once at construction.

Ref FS-436