### PR TITLE
feat(stresstest): allow setting custom TTL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4546,6 +4546,7 @@ dependencies = [
  "bytes",
  "bytesize",
  "futures",
+ "humantime",
  "humantime-serde",
  "indicatif",
  "objectstore-client",

--- a/stresstest/Cargo.toml
+++ b/stresstest/Cargo.toml
@@ -15,6 +15,7 @@ argh = { workspace = true }
 bytes = { workspace = true }
 bytesize = { workspace = true, features = ["serde"] }
 futures = { workspace = true }
+humantime = { workspace = true }
 humantime-serde = { workspace = true }
 indicatif = { workspace = true }
 objectstore-client = { workspace = true, features = ["multipart"] }

--- a/stresstest/README.md
+++ b/stresstest/README.md
@@ -21,6 +21,7 @@ full example.
 | `duration` | yes      | —       | How long to run the test (e.g. `5s`, `10m`, `1h`)       |
 | `workloads`| yes      | —       | List of workload definitions (see below)                |
 | `cleanup`  | no       | `false` | Delete all created objects after the test finishes      |
+| `ttl`      | no       | `1h`    | Object expiration. `never`/`none`/`manual` or a duration |
 
 ### Workload options
 

--- a/stresstest/config/example.yaml
+++ b/stresstest/config/example.yaml
@@ -2,6 +2,10 @@ remote: http://localhost:18888
 
 duration: 5s
 
+# Object expiration. Omit for the default 1h TTL, set a duration like `24h`, or
+# `never` to persist objects indefinitely (e.g. for storage/COGS analysis).
+# ttl: never
+
 workloads:
   - name: attachments
     mode: throughput

--- a/stresstest/src/config.rs
+++ b/stresstest/src/config.rs
@@ -3,8 +3,46 @@ use std::time::Duration;
 
 use anyhow::bail;
 use bytesize::ByteSize;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use stresstest::workload::{self, WorkloadMode};
+
+/// Time-to-live configuration for objects created during the stresstest.
+///
+/// Controls the [`ExpirationPolicy`](objectstore_client::ExpirationPolicy) that
+/// objects are written with, which in turn decides whether Bigtable garbage
+/// collects them:
+///
+/// - Omitted -> [`TtlConfig::Default`]: keep the built-in default TTL (1 hour).
+/// - `manual`/`none`/`never` -> [`TtlConfig::Never`]: objects never expire. This
+///   uses the `Manual` expiration policy, so objects are written to the
+///   non-GC (`fm`) column family and persist until explicitly deleted.
+/// - a humantime duration such as `24h` or `30m` -> [`TtlConfig::Fixed`]: objects
+///   expire after that period.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub enum TtlConfig {
+    /// Leave the stresstest's built-in default TTL in place.
+    #[default]
+    Default,
+    /// Never expire objects (persist indefinitely).
+    Never,
+    /// Expire objects after a fixed duration.
+    Fixed(Duration),
+}
+
+impl<'de> Deserialize<'de> for TtlConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "manual" | "none" | "never" | "off" => Ok(TtlConfig::Never),
+            other => humantime::parse_duration(other)
+                .map(TtlConfig::Fixed)
+                .map_err(serde::de::Error::custom),
+        }
+    }
+}
 
 #[derive(Debug, Deserialize)]
 pub struct Auth {
@@ -23,6 +61,13 @@ pub struct Config {
 
     #[serde(default)]
     pub cleanup: bool,
+
+    /// Time-to-live for objects created during the stresstest.
+    ///
+    /// See [`TtlConfig`] for accepted values. Defaults to the built-in TTL
+    /// (1 hour) when omitted; set to `never` to persist objects indefinitely.
+    #[serde(default)]
+    pub ttl: TtlConfig,
 
     #[serde(default)]
     pub auth: Option<Auth>,

--- a/stresstest/src/main.rs
+++ b/stresstest/src/main.rs
@@ -67,6 +67,15 @@ async fn main() -> anyhow::Result<()> {
         .duration(config.duration)
         .cleanup(config.cleanup);
 
+    // Apply the configured TTL. `Default` keeps the stresstest's built-in TTL,
+    // `Never` disables expiration (objects persist indefinitely), and `Fixed`
+    // sets an explicit expiration.
+    match config.ttl {
+        config::TtlConfig::Default => {}
+        config::TtlConfig::Never => stresstest = stresstest.ttl(None),
+        config::TtlConfig::Fixed(ttl) => stresstest = stresstest.ttl(Some(ttl)),
+    }
+
     for w in config.workloads {
         w.validate()?;
         let multipart = w.multipart_config();


### PR DESCRIPTION
i needed to generate a bunch of test data in our sandbox so i could test our GCS/Bigtable COGS rollup queries and measure their performance. this change to the stresstest is how i did it.