### PR TITLE
fix(python): Use pool scheme and bracket IPv6 hosts in object URLs

### DIFF
--- a/clients/python/src/objectstore_client/client.py
+++ b/clients/python/src/objectstore_client/client.py
@@ -272,11 +272,19 @@ class Session:
             headers["x-os-auth"] = f"Bearer {token}"
         return headers
 
+    def _base_url(self) -> str:
+        # urllib3 stores IPv6 hosts unbracketed (e.g. "::1"); bracket them so
+        # the result is a valid absolute URL.
+        host = self._pool.host
+        if ":" in host:
+            host = f"[{host}]"
+        return f"{self._pool.scheme}://{host}:{self._pool.port}"
+
     def _make_url(self, key: str | None, full: bool = False) -> str:
         relative_path = f"/v1/objects/{self._usecase.name}/{self._scope}/{key or ''}"
         path = utils.encode_path(self._base_path.rstrip("/") + relative_path)
         if full:
-            return f"http://{self._pool.host}:{self._pool.port}{path}"
+            return f"{self._base_url()}{path}"
         return path
 
     def _make_multipart_url(
@@ -521,14 +529,8 @@ class Session:
         canonical = presign.build_canonical_form(method, encoded_path, encoded_query)
         signature = self._token.signature_for_canonical_form(canonical)
 
-        # urllib3 stores IPv6 hosts unbracketed (e.g. "::1"); bracket them so the
-        # result is a valid absolute URL.
-        host = self._pool.host
-        if ":" in host:
-            host = f"[{host}]"
-
         return (
-            f"{self._pool.scheme}://{host}:{self._pool.port}"
+            f"{self._base_url()}"
             f"{encoded_path}?{encoded_query}&{presign.PARAM_SIG}={signature}"
         )
 

--- a/clients/python/tests/test_smoke.py
+++ b/clients/python/tests/test_smoke.py
@@ -18,6 +18,26 @@ def test_object_url() -> None:
     )
 
 
+def test_object_url_https() -> None:
+    client = Client("https://127.0.0.1:8888/")
+    session = client.session(Usecase("testing"), org=12345, project=1337)
+
+    assert (
+        session.object_url("foo/bar")
+        == "https://127.0.0.1:8888/v1/objects/testing/org=12345;project=1337/foo/bar"
+    )
+
+
+def test_object_url_ipv6() -> None:
+    client = Client("http://[::1]:8888/")
+    session = client.session(Usecase("testing"), org=12345, project=1337)
+
+    assert (
+        session.object_url("foo/bar")
+        == "http://[::1]:8888/v1/objects/testing/org=12345;project=1337/foo/bar"
+    )
+
+
 def test_object_url_with_base_path() -> None:
     client = Client("http://127.0.0.1:8888/api/prefix")
     session = client.session(Usecase("testing"), org=12345, project=1337)


### PR DESCRIPTION
`Session.object_url()` hardcoded the `http://` scheme and did not bracket IPv6 hosts, producing wrong or malformed URLs for HTTPS base URLs and IPv6 addresses. The sibling `presigned_object_url()` handled both correctly.

A shared `_base_url()` helper now reconstructs the origin from the pool's scheme, host, and port with proper IPv6 bracketing. Both `_make_url` and `presigned_object_url` use it, eliminating the duplication that caused the bug.

Fixes FS-430