### PR TITLE
fix(python): Align empty-scope URL rendering with Rust client

### DIFF
--- a/clients/python/src/objectstore_client/scope.py
+++ b/clients/python/src/objectstore_client/scope.py
@@ -5,6 +5,8 @@ import string
 # key and value of Scope components.
 SCOPE_VALUE_ALLOWED_CHARS = set(string.ascii_letters + string.digits + "-_()$!+'")
 
+EMPTY_SCOPES = "_"
+
 
 class Scope:
     def __init__(self, **scopes: str | int | bool):
@@ -12,7 +14,9 @@ class Scope:
         for key, value in scopes.items():
             if not key:
                 raise ValueError("Scope key cannot be empty")
-            if not value:
+
+            value_str = str(value)
+            if not value_str:
                 raise ValueError("Scope value cannot be empty")
 
             if any(c not in SCOPE_VALUE_ALLOWED_CHARS for c in key):
@@ -21,21 +25,20 @@ class Scope:
                     f"{''.join(SCOPE_VALUE_ALLOWED_CHARS)}"
                 )
 
-            value = str(value)
-            if any(c not in SCOPE_VALUE_ALLOWED_CHARS for c in value):
+            if any(c not in SCOPE_VALUE_ALLOWED_CHARS for c in value_str):
                 raise ValueError(
-                    f"Invalid scope value {value}. The valid character set is: "
+                    f"Invalid scope value {value_str}. The valid character set is: "
                     f"{''.join(SCOPE_VALUE_ALLOWED_CHARS)}"
                 )
 
-            formatted = f"{key}={value}"
+            formatted = f"{key}={value_str}"
             parts.append(formatted)
 
         self._scope = scopes
         self._scope_str = ";".join(parts)
 
     def __str__(self) -> str:
-        return self._scope_str
+        return self._scope_str or EMPTY_SCOPES
 
     def dict(self) -> dict[str, str | int | bool]:
         return self._scope

--- a/clients/python/src/objectstore_client/scope.py
+++ b/clients/python/src/objectstore_client/scope.py
@@ -15,6 +15,9 @@ class Scope:
             if not key:
                 raise ValueError("Scope key cannot be empty")
 
+            if value is None:
+                raise ValueError("Scope value cannot be empty")
+
             value_str = str(value)
             if not value_str:
                 raise ValueError("Scope value cannot be empty")

--- a/clients/python/tests/test_scope.py
+++ b/clients/python/tests/test_scope.py
@@ -38,6 +38,11 @@ def test_bool_true_is_accepted() -> None:
     assert str(scope) == "key=True"
 
 
+def test_none_value_rejected() -> None:
+    with pytest.raises(ValueError, match="Scope value cannot be empty"):
+        Scope(key=None)  # type: ignore[arg-type]
+
+
 def test_empty_string_value_rejected() -> None:
     with pytest.raises(ValueError, match="Scope value cannot be empty"):
         Scope(key="")

--- a/clients/python/tests/test_scope.py
+++ b/clients/python/tests/test_scope.py
@@ -1,0 +1,59 @@
+import pytest
+from objectstore_client.scope import EMPTY_SCOPES, Scope
+
+
+def test_empty_scope_renders_sentinel() -> None:
+    scope = Scope()
+    assert str(scope) == EMPTY_SCOPES
+    assert str(scope) == "_"
+
+
+def test_single_scope() -> None:
+    scope = Scope(org="12345")
+    assert str(scope) == "org=12345"
+
+
+def test_multiple_scopes() -> None:
+    scope = Scope(org="12345", project="1337")
+    assert str(scope) == "org=12345;project=1337"
+
+
+def test_integer_value() -> None:
+    scope = Scope(org=12345)
+    assert str(scope) == "org=12345"
+
+
+def test_integer_zero_is_accepted() -> None:
+    scope = Scope(key=0)
+    assert str(scope) == "key=0"
+
+
+def test_bool_false_is_accepted() -> None:
+    scope = Scope(key=False)
+    assert str(scope) == "key=False"
+
+
+def test_bool_true_is_accepted() -> None:
+    scope = Scope(key=True)
+    assert str(scope) == "key=True"
+
+
+def test_empty_string_value_rejected() -> None:
+    with pytest.raises(ValueError, match="Scope value cannot be empty"):
+        Scope(key="")
+
+
+def test_invalid_key_chars_rejected() -> None:
+    with pytest.raises(ValueError, match="Invalid scope key"):
+        Scope(**{"key/bad": "value"})
+
+
+def test_invalid_value_chars_rejected() -> None:
+    with pytest.raises(ValueError, match="Invalid scope value"):
+        Scope(key="val/ue")
+
+
+def test_dict_returns_original_values() -> None:
+    scope = Scope(org=42, project="test")
+    result = scope.dict()
+    assert result == {"org": 42, "project": "test"}

--- a/clients/python/tests/test_smoke.py
+++ b/clients/python/tests/test_smoke.py
@@ -26,3 +26,13 @@ def test_object_url_with_base_path() -> None:
         session.object_url("foo/bar")
         == "http://127.0.0.1:8888/api/prefix/v1/objects/testing/org=12345;project=1337/foo/bar"
     )
+
+
+def test_object_url_empty_scope() -> None:
+    client = Client("http://127.0.0.1:8888/")
+    session = client.session(Usecase("testing"))
+
+    assert (
+        session.object_url("foo/bar")
+        == "http://127.0.0.1:8888/v1/objects/testing/_/foo/bar"
+    )


### PR DESCRIPTION
The Python client rendered empty scopes as an empty string, producing `/v1/objects/{usecase}//{key}`, while the Rust client and server use the `_` sentinel, producing `/v1/objects/{usecase}/_/{key}`. An object written with one client under an empty scope was not addressable by the other.

This also fixes a bug where falsy scope values like `0` or `False` were rejected as "empty" because the truthiness check ran before `str()` conversion.

Fixes FS-435