### PR TITLE
fix(service): Scale TTI debounce proportionally for short TTI values

### DIFF
--- a/objectstore-service/src/backend/bigtable.rs
+++ b/objectstore-service/src/backend/bigtable.rs
@@ -136,8 +136,6 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// that attempt to use a certain channel after the server has closed it will pay the cost of the
 /// reconnection, resulting in increased latency for those requests.
 const MAX_CHANNEL_AGE: Option<Duration> = Some(Duration::from_mins(50));
-/// Time to debounce bumping an object with configured TTI.
-const TTI_DEBOUNCE: Duration = Duration::from_hours(24);
 /// Permission scopes required for accessing the BigTable data API.
 const TOKEN_SCOPES: &[&str] = &["https://www.googleapis.com/auth/bigtable.data"];
 
@@ -664,12 +662,13 @@ impl RowData {
         self.expiration_policy().is_timeout() && self.time_expires().is_some_and(|ts| ts < time)
     }
 
-    /// Returns `true` if this row's TTI deadline should be bumped.
-    fn needs_tti_bump(&self) -> bool {
-        matches!(
-            self.expiration_policy(),
-            ExpirationPolicy::TimeToIdle(tti) if self.expires_before(SystemTime::now() + tti - TTI_DEBOUNCE)
-        )
+    /// Checks whether this row's TTI deadline needs bumping.
+    ///
+    /// Returns `Some(new_expire_at)` when the deadline is stale enough to
+    /// justify a write, `None` otherwise.
+    fn check_tti_bump(&self, access_time: SystemTime) -> Option<SystemTime> {
+        self.expiration_policy()
+            .check_tti_bump(self.time_expires(), access_time)
     }
 }
 
@@ -1019,7 +1018,7 @@ impl HighVolumeBackend for BigTableBackend {
         };
 
         // TODO: extract into dedicated call from service
-        if row.needs_tti_bump() {
+        if row.check_tti_bump(SystemTime::now()).is_some() {
             self.bump_tti(path.clone(), &row, true, id).await;
         }
 
@@ -1058,7 +1057,7 @@ impl HighVolumeBackend for BigTableBackend {
         };
 
         // TODO: extract into dedicated call from service
-        if row.needs_tti_bump() {
+        if row.check_tti_bump(SystemTime::now()).is_some() {
             self.bump_tti(path.clone(), &row, false, id).await;
         }
 
@@ -1539,22 +1538,19 @@ mod tests {
 
     /// Verifies TTI bump via both `get_object` (loaded=true path) and `get_metadata` (loaded=false path).
     ///
-    /// The bump condition is: `expire_at < now + tti - TTI_DEBOUNCE`. We write a stale
-    /// timestamp just inside the bump window (still in the future, so the row is not GC'd)
-    /// and confirm that a subsequent read returns a later expiry.
+    /// We write a stale timestamp inside the bump window (still in the future,
+    /// so the row is not GC'd) and confirm that a subsequent read extends the expiry.
     #[tokio::test]
     async fn test_tti_bump() -> Result<()> {
         let backend = create_test_backend().await?;
-        // TTI must exceed TTI_DEBOUNCE (1 day) for the bump condition to be reachable.
         let tti = Duration::from_hours(2 * 24);
         let metadata = Metadata {
             expiration_policy: ExpirationPolicy::TimeToIdle(tti),
             ..Default::default()
         };
 
-        // Pass a backdated `now` so the written expiry is inside the bump window:
-        // expire_at = past_now + tti = now - TTI_DEBOUNCE - 60s (stale but not yet expired).
-        let past_now = SystemTime::now() - TTI_DEBOUNCE - Duration::from_mins(1);
+        // Backdate `now` so the written expiry (past_now + tti) is stale but not expired.
+        let past_now = SystemTime::now() - tti + Duration::from_mins(1);
 
         // Sub-sequence 1: get_object triggers bump (loaded=true path).
         let id1 = make_id();
@@ -1598,7 +1594,6 @@ mod tests {
         let backend = create_test_backend().await?;
 
         let id = make_id();
-        // TTI must exceed TTI_DEBOUNCE (1 day) for the bump condition to be reachable.
         let tti = Duration::from_hours(2 * 24);
         let metadata = Metadata {
             expiration_policy: ExpirationPolicy::TimeToIdle(tti),
@@ -2097,11 +2092,10 @@ mod tests {
         let id = make_id();
         let path = id.as_storage_path().to_string().into_bytes();
 
-        let tti = Duration::from_hours(2 * 24); // must exceed TTI_DEBOUNCE (1 day)
+        let tti = Duration::from_hours(2 * 24);
 
-        // Place time_expires just inside the bump window: past `now + tti - TTI_DEBOUNCE`
-        // but still in the future so `expires_before(now)` does not filter the row.
-        let old_deadline = SystemTime::now() + tti - TTI_DEBOUNCE - Duration::from_mins(1);
+        // Place time_expires inside the bump window but still in the future.
+        let old_deadline = SystemTime::now() + Duration::from_mins(1);
         write_legacy_tombstone(
             &backend,
             &id,

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -3,7 +3,7 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::future::Future;
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 use std::{fmt, io};
 
 use anyhow::Context;
@@ -78,8 +78,6 @@ pub struct GcsConfig {
 const DEFAULT_ENDPOINT: &str = "https://storage.googleapis.com";
 /// Permission scopes required for accessing GCS.
 const TOKEN_SCOPES: &[&str] = &["https://www.googleapis.com/auth/devstorage.read_write"];
-/// Time to debounce bumping an object with configured TTI.
-const TTI_DEBOUNCE: Duration = Duration::from_hours(24);
 /// How many times to retry failed operations.
 const REQUEST_RETRY_COUNT: usize = 2;
 
@@ -558,25 +556,23 @@ impl GcsBackend {
             return Ok(None);
         };
 
-        let expire_at = gcs_metadata.custom_time;
         let metadata = gcs_metadata.into_metadata()?;
 
         // TODO: Inject the access time from the request.
         let access_time = SystemTime::now();
 
         // Filter already expired objects but leave them to garbage collection
-        if metadata.expiration_policy.is_timeout() && expire_at.is_some_and(|ts| ts < access_time) {
+        if metadata.expiration_policy.is_timeout()
+            && metadata.time_expires.is_some_and(|ts| ts < access_time)
+        {
             objectstore_log::debug!("Object found but past expiry");
             return Ok(None);
         }
 
         // TODO: Schedule into background persistently so this doesn't get lost on restarts
-        if let ExpirationPolicy::TimeToIdle(tti) = metadata.expiration_policy {
-            let new_expire_at = access_time + tti;
-            if expire_at.is_some_and(|ts| ts < new_expire_at - TTI_DEBOUNCE) {
-                self.update_custom_time(object_url.clone(), new_expire_at)
-                    .await?;
-            }
+        if let Some(new_expire_at) = metadata.check_tti_bump(access_time) {
+            self.update_custom_time(object_url.clone(), new_expire_at)
+                .await?;
         }
 
         Ok(Some(metadata))
@@ -1086,6 +1082,7 @@ impl MultipartUploadBackend for GcsBackend {
 mod tests {
     use std::collections::BTreeMap;
     use std::num::NonZeroU32;
+    use std::time::Duration;
 
     use anyhow::Result;
     use objectstore_types::scope::{Scope, Scopes};
@@ -1327,7 +1324,6 @@ mod tests {
         let backend = create_test_backend().await?;
 
         let id = make_id();
-        // TTI must exceed TTI_DEBOUNCE (1 day) for the bump condition to be reachable.
         let tti = Duration::from_hours(2 * 24);
         let metadata = Metadata {
             content_type: "text/plain".into(),
@@ -1340,10 +1336,9 @@ mod tests {
             .put_object(&id, &metadata, stream::single("hello, world"))
             .await?;
 
-        // Manually set custom_time to just inside the bump window.
-        // The bump condition is: expire_at < now + tti - TTI_DEBOUNCE.
+        // Backdate custom_time so it falls inside the bump window.
         let object_url = backend.object_url(&id)?;
-        let old_deadline = SystemTime::now() + tti - TTI_DEBOUNCE - Duration::from_mins(1);
+        let old_deadline = SystemTime::now() + Duration::from_mins(1);
         backend.update_custom_time(object_url, old_deadline).await?;
 
         // First get_metadata sees the old timestamp and triggers a TTI bump.
@@ -1371,7 +1366,6 @@ mod tests {
         let backend = create_test_backend().await?;
 
         let id = make_id();
-        // TTI must exceed TTI_DEBOUNCE (1 day) for the bump condition to be reachable.
         let tti = Duration::from_hours(2 * 24);
         let metadata = Metadata {
             content_type: "text/plain".into(),
@@ -1395,6 +1389,43 @@ mod tests {
         assert_eq!(
             first_expiry, second_expiry,
             "Fresh TTI object should not have its expiry bumped"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_short_tti_bumps() -> Result<()> {
+        let backend = create_test_backend().await?;
+
+        let id = make_id();
+        let tti = Duration::from_hours(2);
+        let metadata = Metadata {
+            content_type: "text/plain".into(),
+            expiration_policy: ExpirationPolicy::TimeToIdle(tti),
+            time_expires: Some(SystemTime::now() + tti),
+            ..Default::default()
+        };
+
+        backend
+            .put_object(&id, &metadata, stream::single("hello, world"))
+            .await?;
+
+        // Backdate custom_time so it falls inside the bump window.
+        let object_url = backend.object_url(&id)?;
+        let old_deadline = SystemTime::now() + Duration::from_mins(1);
+        backend.update_custom_time(object_url, old_deadline).await?;
+
+        // First get_metadata triggers the bump.
+        let pre_meta = backend.get_metadata(&id).await?.unwrap();
+        let pre_expiry = pre_meta.time_expires.unwrap();
+
+        // Second get_metadata sees the bumped timestamp.
+        let post_meta = backend.get_metadata(&id).await?.unwrap();
+        let post_expiry = post_meta.time_expires.unwrap();
+        assert!(
+            post_expiry > pre_expiry,
+            "Short TTI bump should have extended the expiry: {pre_expiry:?} -> {post_expiry:?}"
         );
 
         Ok(())

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -1,10 +1,10 @@
 //! S3-compatible backend with generic protocol support.
 
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 use std::{fmt, io};
 
 use futures_util::{StreamExt, TryStreamExt};
-use objectstore_types::metadata::{ExpirationPolicy, Metadata};
+use objectstore_types::metadata::Metadata;
 use objectstore_types::range::{ByteRange, ContentRange};
 use reqwest::header::HeaderMap;
 use reqwest::{Body, IntoUrl, Method, RequestBuilder, Response, StatusCode};
@@ -63,8 +63,6 @@ const GCS_CUSTOM_PREFIX: &str = "x-goog-meta-";
 ///
 /// See: <https://cloud.google.com/storage/docs/xml-api/reference-headers#xgoogcustomtime>
 const GCS_CUSTOM_TIME: &str = "x-goog-custom-time";
-/// Time to debounce bumping an object with configured TTI.
-const TTI_DEBOUNCE: Duration = Duration::from_hours(24);
 
 /// An authentication token that can be passed as a bearer credential.
 pub trait Token: Send + Sync {
@@ -230,13 +228,10 @@ where
         // TODO: Inject the access time from the request.
         let access_time = SystemTime::now();
 
-        let expire_at = headers
-            .get(GCS_CUSTOM_TIME)
-            .and_then(|s| s.to_str().ok())
-            .and_then(|s| humantime::parse_rfc3339(s).ok());
-
         // Filter already expired objects but leave them to garbage collection
-        if metadata.expiration_policy.is_timeout() && expire_at.is_some_and(|ts| ts < access_time) {
+        if metadata.expiration_policy.is_timeout()
+            && metadata.time_expires.is_some_and(|ts| ts < access_time)
+        {
             objectstore_log::debug!("Object found but past expiry");
             response.drain_body().await;
             return Ok(None);
@@ -244,16 +239,10 @@ where
 
         // TODO: extract into dedicated call from service
         // TODO: Schedule into background persistently so this doesn't get lost on restarts
-        if let ExpirationPolicy::TimeToIdle(tti) = metadata.expiration_policy {
-            let expire_at = expire_at.unwrap_or(access_time);
-
-            if expire_at < access_time + tti - TTI_DEBOUNCE {
-                // The write helper persists `time_expires` verbatim, so refresh it to the bumped
-                // deadline here. The returned `metadata` keeps the pre-access value.
-                let mut bumped = metadata.clone();
-                bumped.time_expires = Some(access_time + tti);
-                self.update_metadata(id, &bumped).await?;
-            }
+        if let Some(new_expire_at) = metadata.check_tti_bump(access_time) {
+            let mut bumped = metadata.clone();
+            bumped.time_expires = Some(new_expire_at);
+            self.update_metadata(id, &bumped).await?;
         }
 
         Ok(Some((metadata, content_range, response)))
@@ -384,7 +373,10 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use anyhow::Result;
+    use objectstore_types::metadata::ExpirationPolicy;
     use objectstore_types::scope::{Scope, Scopes};
 
     use super::*;

--- a/objectstore-types/src/metadata.rs
+++ b/objectstore-types/src/metadata.rs
@@ -56,6 +56,14 @@ pub const HEADER_META_PREFIX: &str = "x-snme-";
 /// The default content type for objects without a known content type.
 pub const DEFAULT_CONTENT_TYPE: &str = "application/octet-stream";
 
+/// Upper bound on the TTI debounce window.
+///
+/// The debounce window for TTI bumps is `min(tti / 4, MAX_TTI_DEBOUNCE)`. For
+/// TTI values above 4 days the debounce stays at 24 hours (the historical
+/// constant); shorter TTI values get a proportionally smaller window so that
+/// bumps are not silently suppressed.
+const MAX_TTI_DEBOUNCE: Duration = Duration::from_hours(24);
+
 /// Errors that can happen dealing with metadata
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -145,6 +153,28 @@ impl ExpirationPolicy {
     /// Returns `true` if this policy is `Manual`.
     pub fn is_manual(&self) -> bool {
         *self == ExpirationPolicy::Manual
+    }
+
+    /// Checks whether a TTI deadline needs bumping given the current expiry and access time.
+    ///
+    /// Returns `Some(new_expire_at)` when the current deadline is stale enough
+    /// to justify a write, `None` otherwise. The debounce window scales with the
+    /// TTI duration so short-TTI objects get bumped more frequently.
+    pub fn check_tti_bump(
+        &self,
+        time_expires: Option<SystemTime>,
+        access_time: SystemTime,
+    ) -> Option<SystemTime> {
+        let ExpirationPolicy::TimeToIdle(tti) = *self else {
+            return None;
+        };
+
+        let new_expire_at = access_time + tti;
+        let debounce = (tti / 4).min(MAX_TTI_DEBOUNCE);
+        match time_expires {
+            Some(ts) if ts < new_expire_at - debounce => Some(new_expire_at),
+            _ => None,
+        }
     }
 }
 impl fmt::Display for ExpirationPolicy {
@@ -322,6 +352,14 @@ impl Metadata {
             ));
         }
         Ok(())
+    }
+
+    /// Checks whether this object's TTI deadline needs bumping.
+    ///
+    /// See [`ExpirationPolicy::check_tti_bump`] for details.
+    pub fn check_tti_bump(&self, access_time: SystemTime) -> Option<SystemTime> {
+        self.expiration_policy
+            .check_tti_bump(self.time_expires, access_time)
     }
 
     /// Extracts public API metadata from the given [`HeaderMap`].
@@ -958,5 +996,95 @@ mod tests {
     fn compression_parse_invalid() {
         assert!(Compression::from_str("gzip").is_err());
         assert!(Compression::from_str("").is_err());
+    }
+
+    #[test]
+    fn check_tti_bump_returns_none_for_manual() {
+        let metadata = Metadata::default();
+        assert!(metadata.check_tti_bump(SystemTime::now()).is_none());
+    }
+
+    #[test]
+    fn check_tti_bump_returns_none_for_ttl() {
+        let now = SystemTime::now();
+        let metadata = Metadata {
+            expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_hours(1)),
+            time_expires: Some(now + Duration::from_hours(1)),
+            ..Default::default()
+        };
+        assert!(metadata.check_tti_bump(now).is_none());
+    }
+
+    #[test]
+    fn check_tti_bump_returns_none_when_fresh() {
+        let now = SystemTime::now();
+        let tti = Duration::from_hours(2 * 24);
+        let metadata = Metadata {
+            expiration_policy: ExpirationPolicy::TimeToIdle(tti),
+            time_expires: Some(now + tti),
+            ..Default::default()
+        };
+        assert!(metadata.check_tti_bump(now).is_none());
+    }
+
+    #[test]
+    fn check_tti_bump_returns_new_deadline_when_stale() {
+        let now = SystemTime::now();
+        let tti = Duration::from_hours(2 * 24);
+        let debounce = tti / 4;
+        let stale_deadline = now + tti - debounce - Duration::from_mins(1);
+        let metadata = Metadata {
+            expiration_policy: ExpirationPolicy::TimeToIdle(tti),
+            time_expires: Some(stale_deadline),
+            ..Default::default()
+        };
+        let new_deadline = metadata.check_tti_bump(now).unwrap();
+        assert_eq!(new_deadline, now + tti);
+    }
+
+    #[test]
+    fn check_tti_bump_short_tti_triggers_bump() {
+        let now = SystemTime::now();
+        let tti = Duration::from_hours(2);
+        let debounce = tti / 4;
+        let stale_deadline = now + tti - debounce - Duration::from_mins(1);
+        let metadata = Metadata {
+            expiration_policy: ExpirationPolicy::TimeToIdle(tti),
+            time_expires: Some(stale_deadline),
+            ..Default::default()
+        };
+        let new_deadline = metadata.check_tti_bump(now).unwrap();
+        assert_eq!(new_deadline, now + tti);
+    }
+
+    #[test]
+    fn check_tti_bump_debounce_caps_at_24h() {
+        let now = SystemTime::now();
+        let tti = Duration::from_hours(30 * 24);
+        let capped_debounce = Duration::from_hours(24);
+        let stale_deadline = now + tti - capped_debounce - Duration::from_mins(1);
+        let metadata = Metadata {
+            expiration_policy: ExpirationPolicy::TimeToIdle(tti),
+            time_expires: Some(stale_deadline),
+            ..Default::default()
+        };
+        assert!(metadata.check_tti_bump(now).is_some());
+
+        let fresh_deadline = now + tti - capped_debounce + Duration::from_mins(1);
+        let metadata = Metadata {
+            time_expires: Some(fresh_deadline),
+            ..metadata
+        };
+        assert!(metadata.check_tti_bump(now).is_none());
+    }
+
+    #[test]
+    fn check_tti_bump_returns_none_when_time_expires_missing() {
+        let metadata = Metadata {
+            expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_hours(1)),
+            time_expires: None,
+            ..Default::default()
+        };
+        assert!(metadata.check_tti_bump(SystemTime::now()).is_none());
     }
 }


### PR DESCRIPTION
The fixed 24-hour `TTI_DEBOUNCE` constant silently prevented TTI bumps for any TTI value of 24 hours or less — the bump condition `expire_at < now + tti - 24h` could never be satisfied, so short-TTI objects degraded into fixed-TTL without any indication.

The debounce window now scales with the TTI duration:

- **TTI below 4 days:** uses `tti / 4` — e.g. a 2-hour TTI gets a 30-minute debounce so bumps actually fire.
- **TTI of 4 days or more:** stays at 24 hours, preserving existing behavior.

Fixes FS-403