### PR TITLE
ref(ci): Split and upload debug info to Sentry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
           llvm-objcopy --add-gnu-debuglink objectstore.debug objectstore
 
           sentry-cli difutil bundle-sources objectstore.debug
-          zip -objectstore-debug.zip objectstore.debug
+          zip objectstore-debug.zip objectstore.debug
 
           mkdir -p /tmp/artifacts/${{ matrix.platform }}
           mv objectstore-debug.zip objectstore.src.zip /tmp/artifacts/${{ matrix.platform }}/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,6 +209,10 @@ jobs:
           merge-multiple: true
 
       - name: Upload artifacts
+        env:
+          # the upload SA has no delete perms; disable parallel composite uploads
+          # since their chunk cleanup would fail on delete
+          CLOUDSDK_STORAGE_PARALLEL_COMPOSITE_UPLOAD_ENABLED: false
         run: |
           docker load --input /tmp/objectstore-amd64.tar
           docker run --rm amd64 version > /tmp/release-name

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,12 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y llvm
+          curl -sL https://sentry.io/get-cli/ | bash
+
       - name: Install Rust Toolchain
         run: |
           rustup toolchain install stable --profile minimal --target ${{ matrix.target }} --no-self-update
@@ -49,6 +55,18 @@ jobs:
           cargo build --release --locked --target=${{ matrix.target }} --bin objectstore --features profiling
           cp target/${{ matrix.target }}/release/objectstore ./objectstore
 
+      - name: Split Debug Info
+        run: |
+          llvm-objcopy --only-keep-debug objectstore objectstore.debug
+          llvm-objcopy --strip-debug --strip-unneeded objectstore
+          llvm-objcopy --add-gnu-debuglink objectstore.debug objectstore
+
+          sentry-cli difutil bundle-sources objectstore.debug
+          zip -objectstore-debug.zip objectstore.debug
+
+          mkdir -p /tmp/artifacts/${{ matrix.platform }}
+          mv objectstore-debug.zip objectstore.src.zip /tmp/artifacts/${{ matrix.platform }}/
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
@@ -58,19 +76,19 @@ jobs:
           context: .
           platforms: linux/${{ matrix.platform }}
           tags: ${{ matrix.platform }}
-          outputs: type=docker,dest=/tmp/objectstore-${{ matrix.platform }}.tar
+          outputs: type=docker,dest=/tmp/artifacts/objectstore-${{ matrix.platform }}.tar
           push: false
 
       - name: Test Image
         run: |
-          docker load --input /tmp/objectstore-${{ matrix.platform }}.tar
+          docker load --input /tmp/artifacts/objectstore-${{ matrix.platform }}.tar
           docker run --rm ${{ matrix.platform }} version | grep -q '^objectstore@'
 
-      - name: Upload Image
+      - name: Upload Artifacts
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: objectstore-${{ matrix.platform }}
-          path: /tmp/objectstore-${{ matrix.platform }}.tar
+          path: /tmp/artifacts/
 
   assemble-ghcr:
     name: Publish to GHCR
@@ -186,13 +204,21 @@ jobs:
       - name: Download Artifacts
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
-          pattern: objectstore-amd64
+          pattern: objectstore-*
           path: /tmp
+          merge-multiple: true
 
-      - name: Extract and upload artifacts
+      - name: Upload artifacts
         run: |
           docker load --input /tmp/objectstore-amd64.tar
           docker run --rm amd64 version > /tmp/release-name
 
           gcloud storage cp --no-clobber /tmp/release-name \
             "gs://dicd-team-devinfra-cd--objectstore/deployment-assets/$GITHUB_SHA/"
+
+          for PLATFORM in amd64 arm64; do
+            gcloud storage cp --no-clobber \
+              "/tmp/$PLATFORM/objectstore-debug.zip" \
+              "/tmp/$PLATFORM/objectstore.src.zip" \
+              "gs://dicd-team-devinfra-cd--objectstore/deployment-assets/$GITHUB_SHA/$PLATFORM/"
+          done

--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ caching and build output. The build results in two artifacts:
 - The binary at `target/x86_64-unknown-linux-gnu/release/objectstore`
 - The docker container, tagged with `objectstore:latest`
 
+Debug info is stripped by default to reduce binary size. To include debug
+symbols, set `CARGO_PROFILE_RELEASE_DEBUG=true` before running the script.
+
 ## Development
 
 ### Environment Setup

--- a/gocd/templates/bash/create-sentry-release.sh
+++ b/gocd/templates/bash/create-sentry-release.sh
@@ -1,9 +1,20 @@
 #!/bin/bash
+set -eu
 
 ENVIRONMENT="${SENTRY_ENVIRONMENT:-production}"
+GCS_PATH="gs://dicd-team-devinfra-cd--objectstore/deployment-assets/${GO_REVISION_OBJECTSTORE_REPO}"
 
-RELEASE="$(gsutil cat "gs://dicd-team-devinfra-cd--objectstore/deployment-assets/${GO_REVISION_OBJECTSTORE_REPO}/release-name")"
+for PLATFORM in "amd64" "arm64"; do
+  gsutil cp \
+    "${GCS_PATH}/${PLATFORM}/objectstore-debug.zip" \
+    "${GCS_PATH}/${PLATFORM}/objectstore.src.zip" \
+    .
+  sentry-cli upload-dif ./objectstore-debug.zip ./objectstore.src.zip
+  rm objectstore-debug.zip objectstore.src.zip
+done
+
+RELEASE="$(gsutil cat "${GCS_PATH}/release-name")"
 
 sentry-cli releases new "${RELEASE}"
-sentry-cli releases deploys "${RELEASE}" new -e ${ENVIRONMENT}
+sentry-cli releases deploys "${RELEASE}" new -e "${ENVIRONMENT}"
 sentry-cli releases finalize "${RELEASE}"

--- a/gocd/templates/bash/github-check-runs.sh
+++ b/gocd/templates/bash/github-check-runs.sh
@@ -5,3 +5,4 @@ checks-githubactions-checkruns \
     "${GO_REVISION_OBJECTSTORE_REPO}" \
     "Test (all features)" \
     "Publish to GCR" \
+    "Upload Build Artifacts for GoCD" \

--- a/scripts/build-cross.sh
+++ b/scripts/build-cross.sh
@@ -30,6 +30,7 @@ docker build \
 
 docker run --rm \
     --platform linux/arm64 \
+    -e CARGO_PROFILE_RELEASE_DEBUG="${CARGO_PROFILE_RELEASE_DEBUG:-false}" \
     -v "$(pwd)":/workspace \
     -v "$HOME/.cargo/registry":/usr/local/cargo/registry \
     -v "$HOME/.cargo/git":/usr/local/cargo/git \


### PR DESCRIPTION
The release binary included debug info (`debug = true`) for local symbolication of stack traces, but this produces large binaries and Docker images. 

The CI build now splits debug info out of the binary using `llvm-objcopy`, strips the binary, and bundles sources with `sentry-cli`. Both the debug zip and source bundle are uploaded to GCS alongside the existing release-name, and the Docker image ships the smaller stripped binary.

At deploy time, the GoCD `create-sentry-release` script downloads the debug info and source bundle for both platforms and runs `sentry-cli upload-dif` before creating the Sentry release, so production stack traces can be symbolicated.

The local cross-build script also disables debug info by default to reduce upload size for sandbox builds. `CARGO_PROFILE_RELEASE_DEBUG=true` re-enables it.

Fixes FS-444