### PR TITLE
fix(service): Force HTTP/1-only for backend reqwest client

### DIFF
--- a/objectstore-service/src/backend/common.rs
+++ b/objectstore-service/src/backend/common.rs
@@ -272,6 +272,7 @@ pub(super) fn reqwest_client() -> reqwest::Client {
     reqwest::Client::builder()
         .user_agent(USER_AGENT)
         .hickory_dns(true)
+        .http1_only()
         .no_zstd()
         .no_brotli()
         .no_gzip()


### PR DESCRIPTION
Upgrading Sentry unified our dependency graph such that the current Sentry release enables HTTP/2 negotiation on the `reqwest` client.
Under many concurrent requests to GCS, turns out that HTTP/2 introduces high latency.

The shared backend `reqwest` client now forces HTTP/1 only.

Close FS-455