### PR TITLE
fix: Minor improvement in error handling

### DIFF
--- a/objectstore-server/src/observability.rs
+++ b/objectstore-server/src/observability.rs
@@ -20,8 +20,18 @@ pub fn init_sentry(config: &Config) -> Option<sentry::ClientInitGuard> {
     let config = &config.sentry;
     let dsn = config.dsn.as_ref()?;
 
+    let dsn = match dsn.expose_secret().parse() {
+        Ok(dsn) => Some(dsn),
+        Err(error) => {
+            // Sentry is initialized before the tracing subscriber, so a `warn!` here would be
+            // dropped. Write to stderr instead to make the misconfiguration visible.
+            eprintln!("WARN: invalid Sentry DSN, error reporting is disabled: {error}");
+            None
+        }
+    };
+
     let guard = sentry::init(sentry::ClientOptions {
-        dsn: dsn.expose_secret().parse().ok(),
+        dsn,
         release: Some(RELEASE.into()),
         environment: config.environment.clone(),
         server_name: config.server_name.clone(),

--- a/objectstore-service/src/backend/common.rs
+++ b/objectstore-service/src/backend/common.rs
@@ -278,5 +278,7 @@ pub(super) fn reqwest_client() -> reqwest::Client {
         .no_gzip()
         .no_deflate()
         .build()
-        .expect("Client::new()")
+        // INVARIANT: Building fails only if the TLS backend cannot be initialized, which
+        // is checked at startup when the rustls crypto provider is installed.
+        .expect("failed to build backend HTTP client")
 }


### PR DESCRIPTION
Two unrelated improvements that were found while working on other features:

1. Improve the `expect` when creating the backend HTTP client. This will panic
   regardless, but improves the error message.
2. Log a warning when parsing the Sentry DSN fails. This makes it easier to
   investigate when no data turns up in Sentry.


