### PR TITLE
fix(options): Update sentry-options and use provided refresh function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4186,9 +4186,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-options"
-version = "1.2.1"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43de0ef77feb227951c1d3eda86e84469389ec2805d7f27eee68e38fe20f2e40"
+checksum = "fe58061c4293466647ead4b29731176a331c64f7a72ec441a47851df93a6410b"
 dependencies = [
  "arc-swap",
  "num",
@@ -4196,13 +4196,14 @@ dependencies = [
  "serde_json",
  "sha1",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
 name = "sentry-options-validation"
-version = "1.2.1"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60660c98c3ef950d6ac6986792a55280fe3fa38c2846389b2a4ca99676c1efd0"
+checksum = "0eeb041b3e565d0b7f7e2438d5a5d08c594ce6a855ed3fd301fd42e08fd9122b"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4212,6 +4213,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ reqwest = { version = "0.13.4", default-features = false }
 rustls = { version = "0.23.40", default-features = false }
 secrecy = "0.10.3"
 sentry = "0.48.3"
-sentry-options = "1.2.1"
+sentry-options = "1.2.4"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 serde_yaml = "0.9.34-deprecated"

--- a/objectstore-typed-options-derive/src/lib.rs
+++ b/objectstore-typed-options-derive/src/lib.rs
@@ -216,8 +216,7 @@ fn expand(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
                     return ::std::result::Result::Ok(());
                 };
 
-                // Force a reload of the underlying values file.
-                let _ = inner.get_forced(#namespace_str, "");
+                inner.refresh()?;
 
                 let new_snapshot =
                     <#name as ::objectstore_typed_options::SentryOptions>::deserialize(inner)?;


### PR DESCRIPTION
`Options::refresh()` reloaded values by calling `get_forced(namespace, "")` purely for its
reload side effect, discarding the guaranteed-to-fail result. sentry-options 1.2.4 now
officially supports this via a real `Options::refresh()`, so the workaround is no longer
needed. Bumped the dependency to 1.2.4 and switched the derive macro to call it directly,
propagating its errors instead of swallowing them.
