### PR TITLE
fix(types): Restrict the duration wire format to days and smaller

### DIFF
--- a/clients/python/src/objectstore_client/metadata.py
+++ b/clients/python/src/objectstore_client/metadata.py
@@ -170,7 +170,8 @@ def parse_timedelta(delta: str) -> timedelta:
     """
     Parses a duration in the wire format, such as `400d 1m 30s`.
 
-    Raises a `ValueError` for units outside the wire format.
+    Units are matched exactly, so anything outside the wire format raises a
+    `ValueError` rather than being mistaken for a unit it merely starts with.
     """
     words = TIME_SPLIT.findall(delta)
     seconds = 0
@@ -178,13 +179,13 @@ def parse_timedelta(delta: str) -> timedelta:
     for num, unit in itertools_batched(words, n=2, strict=True):
         num = int(num)
 
-        if unit.startswith("d"):
+        if unit == "d":
             multiplier = 86400
-        elif unit.startswith("h"):
+        elif unit == "h":
             multiplier = 3600
-        elif unit.startswith("m") and not unit.startswith("ms"):
+        elif unit == "m":
             multiplier = 60
-        elif unit.startswith("s"):
+        elif unit == "s":
             multiplier = 1
         else:
             raise ValueError(f"unknown time unit {unit!r} in duration {delta!r}")

--- a/clients/python/src/objectstore_client/metadata.py
+++ b/clients/python/src/objectstore_client/metadata.py
@@ -148,30 +148,37 @@ def parse_expiration(value: str) -> ExpirationPolicy | None:
 
 
 def format_timedelta(delta: timedelta) -> str:
-    days = delta.days
-    output = f"{days} days" if days else ""
-    if seconds := delta.seconds:
-        if output:
-            output += " "
-        output += f"{seconds} seconds"
+    """
+    Formats a duration in the wire format, such as `400d 1m 30s`.
 
-    return output
+    Days are the largest unit, components that are zero are omitted, and a zero duration
+    is written as `0s`. Any sub-second remainder is truncated.
+    """
+    minutes, seconds = divmod(delta.seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+
+    components = ((delta.days, "d"), (hours, "h"), (minutes, "m"), (seconds, "s"))
+    output = " ".join(f"{value}{unit}" for value, unit in components if value)
+
+    return output or "0s"
 
 
 TIME_SPLIT = re.compile(r"[^\W\d_]+|\d+")
 
 
 def parse_timedelta(delta: str) -> timedelta:
+    """
+    Parses a duration in the wire format, such as `400d 1m 30s`.
+
+    Raises a `ValueError` for units outside the wire format.
+    """
     words = TIME_SPLIT.findall(delta)
     seconds = 0
 
     for num, unit in itertools_batched(words, n=2, strict=True):
         num = int(num)
-        multiplier = 0
 
-        if unit.startswith("w"):
-            multiplier = 86400 * 7
-        elif unit.startswith("d"):
+        if unit.startswith("d"):
             multiplier = 86400
         elif unit.startswith("h"):
             multiplier = 3600
@@ -179,6 +186,8 @@ def parse_timedelta(delta: str) -> timedelta:
             multiplier = 60
         elif unit.startswith("s"):
             multiplier = 1
+        else:
+            raise ValueError(f"unknown time unit {unit!r} in duration {delta!r}")
 
         seconds += num * multiplier
 

--- a/clients/python/tests/test_e2e.py
+++ b/clients/python/tests/test_e2e.py
@@ -258,6 +258,33 @@ def test_full_cycle_with_unicode_metadata(server_url: str) -> None:
     assert head.custom["release"] == "vérsion-1.0-🚀"
 
 
+def test_round_trips_expiration_policy_beyond_a_year(server_url: str) -> None:
+    client = Client(
+        server_url,
+        token=TestSecretKey.get(),
+    )
+
+    # Serializes as "400d 1h 18m 31s"
+    ttl = timedelta(days=400, seconds=4711)
+    test_usecase = Usecase(
+        "test-usecase",
+        expiration_policy=TimeToLive(ttl),
+    )
+
+    session = client.session(test_usecase, org=42, project=1337)
+
+    object_key = session.put(b"test data")
+
+    metadata = session.head(object_key)
+    assert metadata is not None
+    assert metadata.expiration_policy == TimeToLive(ttl)
+    assert metadata.time_expires is not None
+
+    retrieved = session.get(object_key)
+    assert retrieved is not None
+    assert retrieved.metadata.expiration_policy == TimeToLive(ttl)
+
+
 def test_full_cycle_uncompressed(server_url: str) -> None:
     client = Client(
         server_url,

--- a/clients/python/tests/test_metadata.py
+++ b/clients/python/tests/test_metadata.py
@@ -1,0 +1,56 @@
+from datetime import timedelta
+
+import pytest
+from objectstore_client.metadata import (
+    TimeToIdle,
+    TimeToLive,
+    format_expiration,
+    format_timedelta,
+    parse_expiration,
+    parse_timedelta,
+)
+
+# Durations and their wire format, used in both directions.
+ROUND_TRIP_CASES = [
+    (timedelta(0), "0s"),
+    (timedelta(seconds=30), "30s"),
+    (timedelta(minutes=1), "1m"),
+    (timedelta(hours=1), "1h"),
+    (timedelta(days=1), "1d"),
+    (timedelta(days=2, hours=3, seconds=4), "2d 3h 4s"),
+    # Durations beyond a day stay in days, they never roll over to larger units.
+    (timedelta(days=7), "7d"),
+    (timedelta(days=400, hours=1), "400d 1h"),
+]
+
+
+@pytest.mark.parametrize(("delta", "formatted"), ROUND_TRIP_CASES)
+def test_format_timedelta(delta: timedelta, formatted: str) -> None:
+    assert format_timedelta(delta) == formatted
+
+
+@pytest.mark.parametrize(("delta", "formatted"), ROUND_TRIP_CASES)
+def test_parse_timedelta(delta: timedelta, formatted: str) -> None:
+    assert parse_timedelta(formatted) == delta
+
+
+def test_format_timedelta_truncates_sub_second_remainder() -> None:
+    assert format_timedelta(timedelta(milliseconds=1500)) == "1s"
+    assert format_timedelta(timedelta(milliseconds=500)) == "0s"
+
+
+@pytest.mark.parametrize("value", ["2weeks", "1year", "500ms"])
+def test_parse_timedelta_rejects_unit_outside_wire_format(value: str) -> None:
+    with pytest.raises(ValueError, match="unknown time unit"):
+        parse_timedelta(value)
+
+
+def test_format_expiration() -> None:
+    assert format_expiration(TimeToLive(timedelta(days=400))) == "ttl:400d"
+    assert format_expiration(TimeToIdle(timedelta(hours=1))) == "tti:1h"
+
+
+def test_parse_expiration() -> None:
+    assert parse_expiration("ttl:400d") == TimeToLive(timedelta(days=400))
+    assert parse_expiration("tti:1h") == TimeToIdle(timedelta(hours=1))
+    assert parse_expiration("manual") is None

--- a/clients/python/tests/test_metadata.py
+++ b/clients/python/tests/test_metadata.py
@@ -39,7 +39,22 @@ def test_format_timedelta_truncates_sub_second_remainder() -> None:
     assert format_timedelta(timedelta(milliseconds=500)) == "0s"
 
 
-@pytest.mark.parametrize("value", ["2weeks", "1year", "500ms"])
+@pytest.mark.parametrize(
+    "value",
+    [
+        "2weeks",
+        "1year",
+        "500ms",
+        # Units that merely start with one of the wire format units must not be
+        # mistaken for it: `13months` is not 13 minutes.
+        "13months",
+        "1month",
+        "1minute",
+        "30sec",
+        "1day",
+        "2hours",
+    ],
+)
 def test_parse_timedelta_rejects_unit_outside_wire_format(value: str) -> None:
     with pytest.raises(ValueError, match="unknown time unit"):
         parse_timedelta(value)

--- a/clients/rust/tests/e2e.rs
+++ b/clients/rust/tests/e2e.rs
@@ -2,10 +2,11 @@ mod common;
 
 use std::collections::{BTreeMap, HashSet};
 use std::io::Write as _;
+use std::time::Duration;
 
 use futures_util::StreamExt as _;
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode, get_current_timestamp};
-use objectstore_client::{Client, Error, OperationResult, Permission, Usecase};
+use objectstore_client::{Client, Error, ExpirationPolicy, OperationResult, Permission, Usecase};
 use objectstore_test::server::{TEST_EDDSA_KID, TEST_EDDSA_PRIVKEY};
 use objectstore_types::metadata::Compression;
 use reqwest::StatusCode;
@@ -786,6 +787,37 @@ async fn head_returns_metadata() {
 
     let missing = session.head("nonexistent-key").send().await.unwrap();
     assert!(missing.is_none());
+}
+
+#[tokio::test]
+async fn round_trips_expiration_policy_beyond_a_year() {
+    let server = test_server().await;
+
+    let client = Client::builder(server.url("/"))
+        .token(test_token_generator())
+        .build()
+        .unwrap();
+    let usecase = Usecase::new("usecase");
+    let session = client.session(usecase.for_project(12345, 1337)).unwrap();
+
+    // Serializes as "400d 1h 18m 31s"
+    let ttl = Duration::from_secs(400 * 86400 + 4711);
+    let policy = ExpirationPolicy::TimeToLive(ttl);
+
+    let stored_id = session
+        .put("hello long ttl!")
+        .expiration_policy(policy)
+        .send()
+        .await
+        .unwrap()
+        .key;
+
+    let metadata = session.head(&stored_id).send().await.unwrap().unwrap();
+    assert_eq!(metadata.expiration_policy, policy);
+    assert!(metadata.time_expires.is_some());
+
+    let response = session.get(&stored_id).send().await.unwrap().unwrap();
+    assert_eq!(response.metadata.expiration_policy, policy);
 }
 
 #[tokio::test]

--- a/objectstore-server/src/usecases.rs
+++ b/objectstore-server/src/usecases.rs
@@ -29,6 +29,7 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
+use objectstore_types::duration::format_duration;
 use objectstore_types::metadata::{ExpirationPolicy, Metadata};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -84,8 +85,8 @@ impl UseCaseConfig {
                 {
                     return Err(UseCaseError::DurationExceeded {
                         usecase: usecase.to_owned(),
-                        duration: humantime::format_duration(duration).to_string(),
-                        max: humantime::format_duration(max).to_string(),
+                        duration: format_duration(duration).to_string(),
+                        max: format_duration(max).to_string(),
                     });
                 }
             }
@@ -101,8 +102,8 @@ impl UseCaseConfig {
                 {
                     return Err(UseCaseError::DurationExceeded {
                         usecase: usecase.to_owned(),
-                        duration: humantime::format_duration(duration).to_string(),
-                        max: humantime::format_duration(max).to_string(),
+                        duration: format_duration(duration).to_string(),
+                        max: format_duration(max).to_string(),
                     });
                 }
             }
@@ -174,9 +175,9 @@ pub enum UseCaseError {
     DurationExceeded {
         /// The use case name.
         usecase: String,
-        /// The requested duration, in humantime format.
+        /// The requested duration, in wire format.
         duration: String,
-        /// The configured maximum, in humantime format.
+        /// The configured maximum, in wire format.
         max: String,
     },
 }

--- a/objectstore-types/src/duration.rs
+++ b/objectstore-types/src/duration.rs
@@ -167,15 +167,6 @@ mod tests {
     }
 
     #[test]
-    fn reports_invalid_input() {
-        let error = parse_duration("1fortnight").unwrap_err();
-        assert!(
-            error.to_string().starts_with("invalid duration: "),
-            "{error}"
-        );
-    }
-
-    #[test]
     fn parses_units_that_are_never_emitted() {
         assert_eq!(
             parse_duration("2weeks").unwrap(),

--- a/objectstore-types/src/duration.rs
+++ b/objectstore-types/src/duration.rs
@@ -1,0 +1,167 @@
+//! The wire format for durations.
+//!
+//! Durations are exchanged as part of the
+//! [`x-sn-expiration`](crate::metadata::HEADER_EXPIRATION) header, for instance as `ttl:7d 12h`.
+//!
+//! # Emitted format
+//!
+//! A duration is written as a space-separated list of `<integer><unit>` components, ordered from
+//! the largest unit to the smallest. Components that are zero are omitted, and a zero duration is
+//! written as `0s`. Only four units are ever emitted:
+//!
+//! | Unit | Meaning       |
+//! |------|---------------|
+//! | `d`  | day, 24 hours |
+//! | `h`  | hour          |
+//! | `m`  | minute        |
+//! | `s`  | second        |
+//!
+//! Day is deliberately the largest unit. Weeks, months, and years are never emitted, because they
+//! either have no fixed length (a calendar month) or invite a definition that differs between
+//! implementations (is a year 365 or 365.25 days?). Durations longer than a day therefore stay in
+//! days: 400 days is written as `400d`, never as `1y 1m 5d`.
+//!
+//! Second is the smallest unit; any sub-second remainder is truncated.
+//!
+//! # Parsing
+//!
+//! [`parse_duration`] accepts a superset of the emitted format, including units this crate never
+//! writes. That leniency exists to keep reading values that older versions persisted, and is not
+//! part of the wire format: do not rely on it, and do not reproduce it in clients.
+
+use std::fmt;
+use std::time::Duration;
+
+pub use humantime::DurationError;
+
+const SECS_PER_MINUTE: u64 = 60;
+const SECS_PER_HOUR: u64 = 60 * SECS_PER_MINUTE;
+const SECS_PER_DAY: u64 = 24 * SECS_PER_HOUR;
+
+/// Formats a duration in the wire format.
+///
+/// Returns a displayable value that writes the duration using the `d`, `h`, `m`, and `s` units,
+/// as described in the [module documentation](self). Sub-second remainders are truncated.
+///
+/// # Example
+///
+/// ```
+/// use std::time::Duration;
+/// use objectstore_types::duration::format_duration;
+///
+/// let formatted = format_duration(Duration::from_secs(400 * 86400 + 90));
+/// assert_eq!(formatted.to_string(), "400d 1m 30s");
+/// ```
+pub fn format_duration(duration: Duration) -> FormattedDuration {
+    FormattedDuration(duration)
+}
+
+/// Parses a duration from the wire format.
+///
+/// # Example
+///
+/// ```
+/// use std::time::Duration;
+/// use objectstore_types::duration::parse_duration;
+///
+/// let duration = parse_duration("400d 1m 30s")?;
+/// assert_eq!(duration, Duration::from_secs(400 * 86400 + 90));
+/// # Ok::<(), objectstore_types::duration::DurationError>(())
+/// ```
+///
+/// # Errors
+///
+/// Returns a [`DurationError`] if `input` is not a valid duration.
+pub fn parse_duration(input: &str) -> Result<Duration, DurationError> {
+    humantime::parse_duration(input)
+}
+
+/// A [`Duration`] that displays in the wire format.
+///
+/// Created by [`format_duration`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FormattedDuration(Duration);
+
+impl fmt::Display for FormattedDuration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let secs = self.0.as_secs();
+        if secs == 0 {
+            return f.write_str("0s");
+        }
+
+        let components = [
+            (secs / SECS_PER_DAY, "d"),
+            (secs % SECS_PER_DAY / SECS_PER_HOUR, "h"),
+            (secs % SECS_PER_HOUR / SECS_PER_MINUTE, "m"),
+            (secs % SECS_PER_MINUTE, "s"),
+        ];
+
+        let mut separator = "";
+        for (value, unit) in components {
+            if value > 0 {
+                write!(f, "{separator}{value}{unit}")?;
+                separator = " ";
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn format(duration: Duration) -> String {
+        format_duration(duration).to_string()
+    }
+
+    #[test]
+    fn formats_units() {
+        assert_eq!(format(Duration::ZERO), "0s");
+        assert_eq!(format(Duration::from_secs(30)), "30s");
+        assert_eq!(format(Duration::from_secs(60)), "1m");
+        assert_eq!(format(Duration::from_secs(3600)), "1h");
+        assert_eq!(format(Duration::from_secs(86400)), "1d");
+    }
+
+    #[test]
+    fn formats_combined_units_and_skips_zeroes() {
+        let duration = Duration::from_secs(2 * 86400 + 3 * 3600 + 4);
+        assert_eq!(format(duration), "2d 3h 4s");
+    }
+
+    #[test]
+    fn keeps_long_durations_in_days() {
+        // Neither of these may roll over into weeks, months, or years.
+        assert_eq!(format(Duration::from_secs(7 * 86400)), "7d");
+        assert_eq!(format(Duration::from_secs(400 * 86400)), "400d");
+    }
+
+    #[test]
+    fn truncates_sub_second_remainder() {
+        assert_eq!(format(Duration::from_millis(1500)), "1s");
+        assert_eq!(format(Duration::from_millis(500)), "0s");
+    }
+
+    #[test]
+    fn round_trips_through_parse() {
+        for secs in [0, 1, 59, 60, 3661, 86400, 396 * 86400 + 62208] {
+            let duration = Duration::from_secs(secs);
+            let formatted = format(duration);
+            assert_eq!(parse_duration(&formatted).unwrap(), duration, "{formatted}");
+        }
+    }
+
+    #[test]
+    fn parses_units_that_are_never_emitted() {
+        assert_eq!(
+            parse_duration("2weeks").unwrap(),
+            Duration::from_secs(1_209_600)
+        );
+        assert_eq!(
+            parse_duration("1year").unwrap(),
+            Duration::from_secs(31_557_600)
+        );
+    }
+}

--- a/objectstore-types/src/duration.rs
+++ b/objectstore-types/src/duration.rs
@@ -29,10 +29,9 @@
 //! writes. That leniency exists to keep reading values that older versions persisted, and is not
 //! part of the wire format: do not rely on it, and do not reproduce it in clients.
 
+use std::error::Error;
 use std::fmt;
 use std::time::Duration;
-
-pub use humantime::DurationError;
 
 const SECS_PER_MINUTE: u64 = 60;
 const SECS_PER_HOUR: u64 = 60 * SECS_PER_MINUTE;
@@ -66,15 +65,29 @@ pub fn format_duration(duration: Duration) -> FormattedDuration {
 ///
 /// let duration = parse_duration("400d 1m 30s")?;
 /// assert_eq!(duration, Duration::from_secs(400 * 86400 + 90));
-/// # Ok::<(), objectstore_types::duration::DurationError>(())
+/// # Ok::<(), objectstore_types::duration::ParseDurationError>(())
 /// ```
 ///
 /// # Errors
 ///
-/// Returns a [`DurationError`] if `input` is not a valid duration.
-pub fn parse_duration(input: &str) -> Result<Duration, DurationError> {
-    humantime::parse_duration(input)
+/// Returns a [`ParseDurationError`] if `input` is not a valid duration.
+pub fn parse_duration(input: &str) -> Result<Duration, ParseDurationError> {
+    humantime::parse_duration(input).map_err(ParseDurationError)
 }
+
+/// The error returned when a string is not a valid duration in the wire format.
+///
+/// Returned by [`parse_duration`].
+#[derive(Debug)]
+pub struct ParseDurationError(humantime::DurationError);
+
+impl fmt::Display for ParseDurationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Error for ParseDurationError {}
 
 /// A [`Duration`] that displays in the wire format.
 ///
@@ -151,6 +164,15 @@ mod tests {
             let formatted = format(duration);
             assert_eq!(parse_duration(&formatted).unwrap(), duration, "{formatted}");
         }
+    }
+
+    #[test]
+    fn reports_invalid_input() {
+        let error = parse_duration("1fortnight").unwrap_err();
+        assert!(
+            error.to_string().starts_with("invalid duration: "),
+            "{error}"
+        );
     }
 
     #[test]

--- a/objectstore-types/src/lib.rs
+++ b/objectstore-types/src/lib.rs
@@ -6,6 +6,7 @@
 #![warn(missing_debug_implementations)]
 
 pub mod auth;
+pub mod duration;
 pub mod headers;
 pub mod metadata;
 pub mod multipart;

--- a/objectstore-types/src/metadata.rs
+++ b/objectstore-types/src/metadata.rs
@@ -53,9 +53,10 @@ use std::str::FromStr;
 use std::time::{Duration, SystemTime};
 
 use http::header::{self, HeaderMap, HeaderName};
-use humantime::{format_duration, format_rfc3339_micros, parse_duration, parse_rfc3339};
+use humantime::{format_rfc3339_micros, parse_rfc3339};
 use serde::{Deserialize, Serialize};
 
+use crate::duration::{format_duration, parse_duration};
 use crate::headers;
 
 /// The custom HTTP header that contains the serialized [`ExpirationPolicy`].
@@ -141,8 +142,8 @@ impl From<header::ToStrError> for Error {
 /// | `TimeToLive` | `ttl:30s`   | Expires after a fixed duration from creation |
 /// | `TimeToIdle` | `tti:1h`    | Expires after a duration of no access        |
 ///
-/// Durations use [humantime](https://docs.rs/humantime) format (e.g. `30s`,
-/// `5m`, `1h`, `7d`).
+/// Durations use the [wire format](crate::duration), which is written in days, hours, minutes,
+/// and seconds (e.g. `30s`, `5m`, `1h`, `7d`, `400d 12h`).
 ///
 /// **Important:** `Manual` is the default and must remain so — persisted objects
 /// without an explicit policy are deserialized as `Manual`.
@@ -710,6 +711,29 @@ mod tests {
             metadata.expiration_policy,
             ExpirationPolicy::TimeToLive(Duration::from_secs(30))
         );
+    }
+
+    #[test]
+    fn expiration_policy_keeps_long_durations_in_days() {
+        let ttl = Duration::from_secs(400 * 86400 + 3600);
+        let policy = ExpirationPolicy::TimeToLive(ttl);
+
+        assert_eq!(policy.to_string(), "ttl:400d 1h");
+        assert_eq!(
+            policy.to_string().parse::<ExpirationPolicy>().unwrap(),
+            policy
+        );
+    }
+
+    #[test]
+    fn expiration_policy_parses_units_that_are_never_emitted() {
+        let policy: ExpirationPolicy = "tti:2weeks".parse().unwrap();
+        assert_eq!(
+            policy,
+            ExpirationPolicy::TimeToIdle(Duration::from_secs(14 * 86400))
+        );
+        // Re-emitting normalizes to the units of the wire format.
+        assert_eq!(policy.to_string(), "tti:14d");
     }
 
     #[test]

--- a/objectstore-types/src/metadata.rs
+++ b/objectstore-types/src/metadata.rs
@@ -56,7 +56,7 @@ use http::header::{self, HeaderMap, HeaderName};
 use humantime::{format_rfc3339_micros, parse_rfc3339};
 use serde::{Deserialize, Serialize};
 
-use crate::duration::{format_duration, parse_duration};
+use crate::duration::{ParseDurationError, format_duration, parse_duration};
 use crate::headers;
 
 /// The custom HTTP header that contains the serialized [`ExpirationPolicy`].
@@ -93,7 +93,7 @@ pub enum Error {
     Header(#[from] Option<http::Error>),
     /// The value for the expiration policy is invalid.
     #[error("invalid expiration policy value")]
-    Expiration(#[from] Option<humantime::DurationError>),
+    Expiration(#[from] Option<ParseDurationError>),
     /// The compression algorithm is invalid.
     #[error("invalid compression value")]
     Compression,


### PR DESCRIPTION
Durations in the `x-sn-expiration` header are now emitted with only the `d`, `h`, `m`, and `s` units. Anything longer than a day stays in days, so a 400-day TTL serializes as `400d`, never `1year 1month 5days`. The new `objectstore_types::duration` module owns the format and documents it explicitly, including that seconds are the smallest unit and sub-second remainders are truncated.

This fixes a real round-trip bug. The Python client only understood `w/d/h/m/s`, so when the server formatted a TTL above a year it dropped the `1year` component and read `1month` as one minute — any expiration over a year was reported wrong by `get` and `head`. Uploads were unaffected.

Parsing stays lenient and still accepts weeks, months, and years, because the GCS backend persists the formatted string as object metadata and older objects carry those units. That leniency is deliberately not part of the documented format, so clients do not have to reproduce it: the Python client now formats exactly like the server and rejects units outside the contract instead of silently mis-parsing them.

Server-side use-case validation errors use the same formatter, so the durations in those messages match what clients see on the wire.

Fixes FS-433
