### PR TITLE
fix(sentry): Propagate request scope to background tasks

### DIFF
--- a/objectstore-server/src/web/app.rs
+++ b/objectstore-server/src/web/app.rs
@@ -32,9 +32,9 @@ impl App {
         //  - Requests go from top to bottom
         //  - Responses go from bottom to top
         let middleware = ServiceBuilder::new()
-            .layer(axum::middleware::from_fn(m::emit_request_metrics))
             .layer(NewSentryLayer::new_from_top())
             .layer(SentryHttpLayer::new().enable_transaction())
+            .layer(axum::middleware::from_fn(m::emit_request_metrics))
             .layer(axum::middleware::from_fn(m::bind_sentry_body))
             .layer(axum::middleware::from_fn_with_state(
                 state.request_counter.clone(),

--- a/objectstore-service/src/backend/changelog.rs
+++ b/objectstore-service/src/backend/changelog.rs
@@ -24,6 +24,7 @@ use std::fmt;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 
+use sentry::{Hub, SentryFutureExt};
 use tokio_util::task::TaskTracker;
 use tokio_util::task::task_tracker::TaskTrackerToken;
 
@@ -136,7 +137,10 @@ impl ChangeManager {
             _token: token,
         };
 
-        Ok(ChangeGuard { state: Some(state) })
+        Ok(ChangeGuard {
+            state: Some(state),
+            hub: Hub::current(),
+        })
     }
 
     /// Records the change to the log and returns a guard in the `Assembling` state.
@@ -159,13 +163,17 @@ impl ChangeManager {
             _token: token,
         };
 
-        Ok(ChangeGuard { state: Some(state) })
+        Ok(ChangeGuard {
+            state: Some(state),
+            hub: Hub::current(),
+        })
     }
 
     /// Scans the changelog for outstanding entries and runs cleanup for each.
     ///
     /// Spawn this into a background task at startup to recover from any orphaned objects after a
     /// crash. During normal operation, this should return an empty list and have no effect.
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn recover(self: Arc<Self>) -> Result<()> {
         // Hold one token for the duration of recovery to prevent premature shutdown.
         let _token = self.tracker.token();
@@ -351,6 +359,7 @@ impl ChangeState {
     }
 
     /// Determines tombstone state and runs cleanup for unreferenced objects.
+    #[tracing::instrument(level = "debug", skip_all, fields(phase= ?self.phase, new = ?self.change.new, old = ?self.change.old))]
     async fn cleanup(self) {
         let current = match self.phase {
             // For `Recovered`, we must first check the state of the tombstone.
@@ -447,9 +456,9 @@ impl Drop for ChangeState {
 /// When dropped in a non-`Completed` phase, determines the LT blob to clean up
 /// and spawns a background task to delete it. If no tokio runtime is available
 /// (e.g., during shutdown), the drop logs an error instead of panicking.
-#[derive(Debug)]
 pub struct ChangeGuard {
     state: Option<ChangeState>,
+    hub: Arc<Hub>,
 }
 
 impl ChangeGuard {
@@ -461,6 +470,15 @@ impl ChangeGuard {
     }
 }
 
+impl fmt::Debug for ChangeGuard {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ChangeGuard")
+            .field("state", &self.state)
+            // hide `hub` intentionally
+            .finish()
+    }
+}
+
 impl Drop for ChangeGuard {
     fn drop(&mut self) {
         if let Some(state) = self.state.take()
@@ -468,7 +486,8 @@ impl Drop for ChangeGuard {
             && state.phase != ChangePhase::Completed
             && let Ok(handle) = tokio::runtime::Handle::try_current()
         {
-            handle.spawn(state.cleanup());
+            let hub = Hub::new_from_top(&self.hub);
+            handle.spawn(state.cleanup().bind_hub(hub));
         }
 
         // NB: Drop of `ChangeState` logs an error if cleanup is not scheduled.

--- a/objectstore-service/src/backend/tiered.rs
+++ b/objectstore-service/src/backend/tiered.rs
@@ -106,6 +106,7 @@ use bytes::Bytes;
 use futures_util::{Stream, StreamExt};
 use objectstore_types::metadata::Metadata;
 use objectstore_types::range::ByteRange;
+use sentry::{Hub, SentryFutureExt};
 use serde::{Deserialize, Serialize};
 
 use crate::backend::changelog::{Change, ChangeGuard, ChangeLog, ChangeManager, ChangePhase};
@@ -238,9 +239,10 @@ impl TieredStorage {
         changelog: Box<dyn ChangeLog>,
     ) -> Self {
         let inner = ChangeManager::new(high_volume, long_term, changelog);
+        let hub = Hub::new_from_top(Hub::current());
         // Note on cancellation: Our `join` method will wait for all tasks tracked by the spawned
         // recovery job, so we defer shutdown until recovery is complete or times out.
-        tokio::spawn(inner.clone().recover());
+        tokio::spawn(inner.clone().recover().bind_hub(hub));
         Self { inner }
     }
 


### PR DESCRIPTION
Backend operations that occur as part of tiered storage changelog cleanup had no request context. That is because cleanup was spawned without binding the correct hub.

`ChangeGuard` now carries a Sentry hub and attaches it to the spawned cleanup task. Likewise, we create a new spawn and bind around recovery, so that once changelog recovery is implemented, these tasks also carry their context.

This uncovered that the `downstream-service` tag is leaked between requests. That is because it was tracked _before_ the sentry middleware would attach the hub. We now invert the middlewares so that the service extractor runs later.
