### PR TITLE
fix(server): Prefer query param over header in auth

### DIFF
--- a/objectstore-server/docs/architecture.md
+++ b/objectstore-server/docs/architecture.md
@@ -96,7 +96,8 @@ Tokens must include:
 The token is supplied in the `x-os-auth` header (falling back to the standard
 `Authorization` header), optionally prefixed with `Bearer `. It may also be
 supplied as an `os_auth` query parameter, which lets callers embed a token
-directly in a URL. The header takes precedence when both are present.
+directly in a URL. The query parameter takes precedence when both are
+present.
 
 ### Key Management
 

--- a/objectstore-server/src/extractors/service.rs
+++ b/objectstore-server/src/extractors/service.rs
@@ -18,8 +18,8 @@ const BEARER_PREFIX: &str = "Bearer ";
 const HEADER_AUTH: &str = "x-os-auth";
 
 /// Query parameters carrying authentication, as an alternative to the
-/// `x-os-auth`/`Authorization` header. The header takes precedence when both
-/// are present.
+/// `x-os-auth`/`Authorization` header. The query parameter takes precedence
+/// when both are present.
 #[derive(Debug, Deserialize)]
 struct AuthParams {
     /// A JWT, mirroring the `x-os-auth` header value (without the `Bearer `
@@ -29,24 +29,23 @@ struct AuthParams {
 
 impl AuthAwareService {
     fn from_token(parts: &mut Parts, state: &ServiceState) -> Result<AuthContext, AuthError> {
-        let header_token = parts
-            .headers
-            .get(HEADER_AUTH)
-            .or_else(|| parts.headers.get(header::AUTHORIZATION))
-            .and_then(|v| v.to_str().ok())
-            .and_then(strip_bearer);
+        let query_token = Query::<AuthParams>::try_from_uri(&parts.uri)
+            .map_err(|_| AuthError::BadRequest("invalid query string"))?
+            .0
+            .os_auth;
 
-        let query_token = match header_token {
+        let header_token = match query_token {
             Some(_) => None,
-            None => {
-                Query::<AuthParams>::try_from_uri(&parts.uri)
-                    .map_err(|_| AuthError::BadRequest("invalid query string"))?
-                    .0
-                    .os_auth
-            }
+            None => parts
+                .headers
+                .get(HEADER_AUTH)
+                .or_else(|| parts.headers.get(header::AUTHORIZATION))
+                .and_then(|v| v.to_str().ok())
+                .and_then(strip_bearer)
+                .map(str::to_owned),
         };
 
-        let token = header_token.or(query_token.as_deref());
+        let token = query_token.as_deref().or(header_token.as_deref());
 
         AuthContext::from_encoded_jwt(token, &state.key_directory)
     }

--- a/objectstore-server/tests/query_auth.rs
+++ b/objectstore-server/tests/query_auth.rs
@@ -1,8 +1,8 @@
 //! End-to-end tests for the `os_auth` query parameter authentication path.
 //!
 //! A JWT can be supplied either via the `x-os-auth`/`Authorization` header or,
-//! as-is, via the `os_auth` query parameter. The header takes precedence when
-//! both are present.
+//! as-is, via the `os_auth` query parameter. The query parameter takes
+//! precedence when both are present.
 
 use anyhow::Result;
 use http::header;
@@ -85,12 +85,35 @@ async fn query_auth_tampered_token_is_unauthorized() -> Result<()> {
 }
 
 #[tokio::test]
-async fn header_takes_precedence_over_query() -> Result<()> {
+async fn query_takes_precedence_over_header() -> Result<()> {
     let server = test_server().await;
     seed_object(&server, "hello").await?;
 
-    // Valid header token, garbage query token: the header must win, so the
-    // request succeeds despite the unusable query value.
+    // Valid query token, garbage header token: the query value must win, so
+    // the request succeeds despite the unusable header.
+    let url = format!(
+        "{}?os_auth={}",
+        server.url(OBJECT_PATH),
+        jwt(&["object.read"])
+    );
+    let resp = reqwest::Client::new()
+        .get(url)
+        .header(header::AUTHORIZATION.as_str(), "Bearer not-a-valid-jwt")
+        .send()
+        .await?;
+
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    assert_eq!(resp.text().await?, "hello");
+    Ok(())
+}
+
+#[tokio::test]
+async fn invalid_query_token_is_unauthorized_even_with_valid_header() -> Result<()> {
+    let server = test_server().await;
+    seed_object(&server, "hello").await?;
+
+    // Garbage query token, valid header: the query value still wins, so the
+    // request fails rather than falling back to the header.
     let url = format!("{}?os_auth=not-a-valid-jwt", server.url(OBJECT_PATH));
     let resp = reqwest::Client::new()
         .get(url)
@@ -101,7 +124,6 @@ async fn header_takes_precedence_over_query() -> Result<()> {
         .send()
         .await?;
 
-    assert_eq!(resp.status(), reqwest::StatusCode::OK);
-    assert_eq!(resp.text().await?, "hello");
+    assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
     Ok(())
 }


### PR DESCRIPTION
A `os_auth` query parameter should always override headers, so that when
a standard `Authorization` header is attached to an objectstore request,
the visible one from the URL takes precedence.

There are currently auth failures in attachment downloads, because the
proxy also forwards an `Authorization` header, which overrides the query
parameter for presigned URLs.

Ref FS-485