### PR TITLE
feat(config): resolve ${file:...} and ${VAR} references in config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,7 +1131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1810,7 +1810,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2503,7 +2503,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2919,6 +2919,7 @@ dependencies = [
  "secrecy",
  "sentry",
  "serde",
+ "serde-vars",
  "serde_json",
  "stresstest",
  "tempfile",
@@ -3545,7 +3546,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror",
  "tokio",
  "tracing",
@@ -3583,7 +3584,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4009,7 +4010,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4068,7 +4069,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4203,7 +4204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4402,6 +4403,15 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-vars"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31ed6ad0418012bd1f7493bb01d9b107e81aec23042be9292d7d154909a5c45"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4637,7 +4647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4768,7 +4778,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5585,7 +5595,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ rdkafka = { version = "0.39.0", features = [
     "tracing",
 ] }
 serde = { version = "1.0.228", features = ["derive"] }
+serde-vars = "0.3.1"
 serde_json = "1.0.150"
 serde_yaml = "0.9.34-deprecated"
 sketches-ddsketch = "0.3.1"

--- a/objectstore-server/Cargo.toml
+++ b/objectstore-server/Cargo.toml
@@ -42,6 +42,7 @@ rustls = { workspace = true }
 secrecy = { workspace = true, features = ["serde"] }
 sentry = { workspace = true, features = ["tower-axum-matched-path", "tracing", "logs"] }
 serde = { workspace = true }
+serde-vars = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 thread_local = { workspace = true }

--- a/objectstore-server/src/config.rs
+++ b/objectstore-server/src/config.rs
@@ -30,6 +30,29 @@
 //!   type: filesystem
 //!   path: /data
 //! ```
+//!
+//! # Variable References
+//!
+//! Any configuration value may be written as a reference, which is resolved after all
+//! sources have been merged. `${file:PATH}` is replaced by that file's contents and
+//! `${VAR_NAME}` by that environment variable:
+//!
+//! ```yaml
+//! storage_cogs:
+//!   type: kafka
+//!   override_params:
+//!     sasl.password: ${file:/var/secrets/kafka-password}
+//! ```
+//!
+//! A reference must be the entire value: `${A}` works, `prefix-${A}` does not. Referencing
+//! a file that cannot be read, or an environment variable that is not set, is an error at
+//! startup.
+//!
+//! ## Relationship to `OS__` environment variables
+//!
+//! These are different mechanisms and neither replaces the other. They can even be used
+//! together: `OS__SENTRY__DSN=${SENTRY_DSN}` will set the `sentry.dsn` YAML key to the
+//! value of the `SENTRY_DSN` environment variable.
 
 use std::borrow::Cow;
 use std::collections::{BTreeMap, HashSet};
@@ -685,20 +708,44 @@ impl Config {
     /// 2. YAML configuration file (if provided in `args`)
     /// 3. Environment variables (prefixed with `OS__`)
     ///
+    /// Any value in the merged configuration may then be written as `${file:PATH}` or
+    /// `${VAR_NAME}` to have it replaced by that file's contents or that environment
+    /// variable — see [variable references](self#variable-references).
+    ///
     /// # Errors
     ///
     /// Returns an error if:
     /// - The YAML configuration file cannot be read or parsed
     /// - Environment variables contain invalid values
     /// - Required fields are missing or invalid
+    /// - A `${file:PATH}` reference names a file that cannot be read, or a `${VAR_NAME}`
+    ///   reference names an environment variable that is not set
     pub fn load(path: Option<&Path>) -> Result<Self> {
         let mut figment = figment::Figment::from(Serialized::defaults(Config::default()));
         if let Some(path) = path {
             figment = figment.merge(Yaml::file(path));
         }
-        let config = figment
+
+        // Merge first, then resolve variables against the merged value, so a reference is
+        // resolved wherever it came from and whichever layer won.
+        let merged: figment::value::Value = figment
             .merge(Env::prefixed(ENV_PREFIX).split("__"))
             .extract()?;
+
+        let base_path = path.and_then(Path::parent).unwrap_or(Path::new(""));
+
+        // The file source must come first: `${file:x}` also matches the environment
+        // source's `${` prefix, which would otherwise look up a variable named `file:x`.
+        let mut source = (
+            serde_vars::FileSource::new()
+                .with_variable_prefix("${file:")
+                .with_variable_suffix("}")
+                .with_base_path(base_path),
+            serde_vars::EnvSource::default()
+                .with_variable_prefix("${")
+                .with_variable_suffix("}"),
+        );
+        let config = serde_vars::deserialize(&merged, &mut source)?;
 
         Ok(config)
     }
@@ -947,6 +994,102 @@ mod tests {
             assert!(
                 config.storage_cogs.is_none(),
                 "no transport is configured by default"
+            );
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn serde_var_yaml_references() {
+        let secrets = tempfile::tempdir().unwrap();
+        let absolute_secret = secrets.path().join("kafka-password");
+        std::fs::write(&absolute_secret, "hunter2").unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("relative-password"), "hunter3").unwrap();
+
+        let config_path = dir.path().join("config.yml");
+        std::fs::write(
+            &config_path,
+            format!(
+                r#"
+            storage_cogs:
+                type: kafka
+                override_params:
+                    sasl.mechanism: SCRAM-SHA-256
+                    not.a.reference: prod-${{NOT_A_VAR
+                    from.env: ${{KAFKA_SASL_PASSWORD}}
+                    from.relative.file: ${{file:relative-password}}
+                    from.absolute.file: ${{file:{}}}
+            "#,
+                absolute_secret.display()
+            ),
+        )
+        .unwrap();
+
+        figment::Jail::expect_with(|jail| {
+            jail.set_env("KAFKA_SASL_PASSWORD", "hunter1");
+
+            let config = Config::load(Some(&config_path)).unwrap();
+
+            let CostTrackerConfig::Kafka(sink) =
+                config.storage_cogs.as_ref().expect("kafka transport");
+            assert_eq!(sink.override_params["from.env"], "hunter1");
+            assert_eq!(sink.override_params["from.relative.file"], "hunter3");
+            assert_eq!(
+                sink.override_params["from.absolute.file"], "hunter2",
+                "an absolute path ignores the config directory"
+            );
+            assert_eq!(sink.override_params["sasl.mechanism"], "SCRAM-SHA-256");
+            assert_eq!(
+                sink.override_params["not.a.reference"], "prod-${NOT_A_VAR",
+                "a value that is not a reference is left alone"
+            );
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn serde_vars_yaml_reference_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        for (name, reference) in [
+            ("missing-file.yml", "${file:nope}"),
+            ("unset-var.yml", "${FAKE_VAR}"),
+        ] {
+            let config_path = dir.path().join(name);
+            std::fs::write(
+                &config_path,
+                format!(
+                    r#"
+                storage_cogs:
+                    type: kafka
+                    override_params:
+                        sasl.password: {reference}
+                "#
+                ),
+            )
+            .unwrap();
+
+            figment::Jail::expect_with(|_jail| {
+                assert!(Config::load(Some(&config_path)).is_err(), "{reference}");
+                Ok(())
+            });
+        }
+    }
+
+    #[test]
+    fn serde_vars_env_reference() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env("SENTRY_DSN", "https://public@example.invalid/1");
+            jail.set_env("OS__SENTRY__DSN", "${SENTRY_DSN}");
+
+            let config = Config::load(None).unwrap();
+
+            assert_eq!(
+                config.sentry.dsn.unwrap().expose_secret().as_str(),
+                "https://public@example.invalid/1"
             );
 
             Ok(())


### PR DESCRIPTION
Add `serde-vars` crate to allow `${file:...}` and `${VAR}` to be used as values in our config for deferred loads.

```yaml
storage_cogs:
  type: kafka
  override_params:
    sasl.password: ${file:/var/secrets/kafka-password}
    # sasl.password: ${KAFKA_PASSWORD} # alternate
```

This is helpful for a few reasons:
- YAML config can be complete. Static YAML can name secrets/runtime values while deferring the actual loading.
- We don't need to write bespoke file I/O for secrets/configs that are mounted as files (e.g. GCP secrets).
- Edge case: the `sasl.password` config key above.

The `override_params` map is passed verbatim to `rdkafka` and `rdkafka` expects keys such as `sasl.password`. That value is obviously secret, so we can't include it in our config YAML. However, because the config key contains a `.`, we can't set it with an environment variable and can _only_ set it in YAML. `serde-vars` lets us configure the secret in YAML while deferring the actual loading of the secret value until later.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>