### PR TITLE
feat(python-client): Send a default User-Agent header

### DIFF
--- a/clients/python/src/objectstore_client/client.py
+++ b/clients/python/src/objectstore_client/client.py
@@ -164,10 +164,9 @@ class Client:
         if connection_kwargs:
             connection_kwargs_to_use = {**connection_kwargs_to_use, **connection_kwargs}
 
-        connection_kwargs_to_use["headers"] = {
-            "User-Agent": USER_AGENT,
-            **connection_kwargs_to_use.get("headers", {}),
-        }
+        headers = urllib3.HTTPHeaderDict({"User-Agent": USER_AGENT})
+        headers.update(connection_kwargs_to_use.get("headers") or {})
+        connection_kwargs_to_use["headers"] = headers
 
         self._pool = urllib3.connectionpool.connection_from_url(
             base_url, **connection_kwargs_to_use

--- a/clients/python/src/objectstore_client/client.py
+++ b/clients/python/src/objectstore_client/client.py
@@ -5,6 +5,7 @@ import warnings
 from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime, timedelta
+from importlib.metadata import version
 from io import BytesIO
 from typing import IO, Any, Literal, NamedTuple, cast
 from urllib.parse import urlparse
@@ -37,6 +38,9 @@ from objectstore_client.scope import Scope
 
 # Query parameter carrying a JWT, mirroring the `x-os-auth` header.
 PARAM_AUTH = "os_auth"
+
+# Identifies this library to the server, mirroring the Rust client's user agent.
+USER_AGENT = f"objectstore-client/{version('objectstore-client')}"
 
 
 class GetResponse(NamedTuple):
@@ -122,7 +126,9 @@ class Client:
 
         connection_kwargs: Additional keyword arguments to pass to the underlying
             urllib3 connection pool (e.g., custom headers, SSL settings, advanced
-            timeouts).
+            timeouts). By default, requests carry a ``User-Agent`` header of
+            ``objectstore-client/{version}``; pass a ``headers`` mapping with a
+            ``User-Agent`` key here to override it.
         token: A ``SecretKey`` that signs a fresh JWT for each request
             using an EdDSA keypair, or a static pre-signed JWT string used
             as-is for every request. Use a ``SecretKey`` for internal
@@ -157,6 +163,11 @@ class Client:
 
         if connection_kwargs:
             connection_kwargs_to_use = {**connection_kwargs_to_use, **connection_kwargs}
+
+        connection_kwargs_to_use["headers"] = {
+            "User-Agent": USER_AGENT,
+            **connection_kwargs_to_use.get("headers", {}),
+        }
 
         self._pool = urllib3.connectionpool.connection_from_url(
             base_url, **connection_kwargs_to_use

--- a/clients/python/tests/test_smoke.py
+++ b/clients/python/tests/test_smoke.py
@@ -72,3 +72,14 @@ def test_user_agent_can_be_overridden() -> None:
     )
 
     assert client._pool.headers["User-Agent"] == "custom-agent/1.0"
+
+
+def test_user_agent_override_is_case_insensitive() -> None:
+    client = Client(
+        "http://127.0.0.1:8888/",
+        connection_kwargs={"headers": {"user-agent": "custom-agent/1.0"}},
+    )
+
+    headers = client._pool.headers
+    assert headers["User-Agent"] == "custom-agent/1.0"
+    assert len(headers) == 1

--- a/clients/python/tests/test_smoke.py
+++ b/clients/python/tests/test_smoke.py
@@ -1,4 +1,5 @@
 from objectstore_client import Client, Usecase
+from objectstore_client.client import USER_AGENT
 
 
 def test_imports() -> None:
@@ -56,3 +57,18 @@ def test_object_url_empty_scope() -> None:
         session.object_url("foo/bar")
         == "http://127.0.0.1:8888/v1/objects/testing/_/foo/bar"
     )
+
+
+def test_default_user_agent() -> None:
+    client = Client("http://127.0.0.1:8888/")
+
+    assert client._pool.headers["User-Agent"] == USER_AGENT
+
+
+def test_user_agent_can_be_overridden() -> None:
+    client = Client(
+        "http://127.0.0.1:8888/",
+        connection_kwargs={"headers": {"User-Agent": "custom-agent/1.0"}},
+    )
+
+    assert client._pool.headers["User-Agent"] == "custom-agent/1.0"


### PR DESCRIPTION
The Python client sent no `User-Agent` header at all. The Rust client already sends `objectstore-client/{version}`.

This change adds the same default to the Python client, using its own package version. A caller can still override it by passing a `headers` mapping in `connection_kwargs`.

Closes FS-432
