### PR TITLE
feat(python-client): Deprecate `propagate_traces`

### DIFF
--- a/clients/python/src/objectstore_client/client.py
+++ b/clients/python/src/objectstore_client/client.py
@@ -104,8 +104,13 @@ class Client:
             "http://objectstore:8888"). metrics_backend: Optional metrics backend for
             tracking storage operations. Defaults to ``NoOpMetricsBackend`` if not
             provided.
-        propagate_traces: Whether to propagate Sentry trace headers in requests to
-            objectstore. Defaults to ``False``.
+        propagate_traces: **Deprecated.** Use Sentry's ``StdlibIntegration``
+            instead; it propagates traces on the underlying HTTP request
+            regardless of this flag, unless the host application's Sentry SDK
+            is configured to opt out.
+
+            This only controls headers this client adds itself. Defaults to
+            ``False``.
         retries: Number of connection retries for failed requests.
             Defaults to ``3`` if not specified. **Note:** only connection failures are
             retried, not read failures (as compression streams cannot be rewound).
@@ -146,6 +151,14 @@ class Client:
         connection_kwargs: Mapping[str, Any] | None = None,
         token: TokenProvider | None = None,
     ):
+        if propagate_traces:
+            warnings.warn(
+                "`propagate_traces` is deprecated; Sentry's `StdlibIntegration` "
+                "already propagates traces on the underlying HTTP request",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         connection_kwargs_to_use = asdict(_ConnectionDefaults())
 
         if retries:


### PR DESCRIPTION
`propagate_traces` only controls headers the objectstore client adds itself. Sentry's `StdlibIntegration` already propagates trace headers on the underlying HTTP request regardless of this flag, unless the host application's Sentry SDK opts out. This makes the flag redundant.

This marks `propagate_traces` as deprecated in the docstring and emits a `DeprecationWarning` when a caller passes `True`. The parameter still works for now.
