### PR TITLE
feat(server): Make Sentry stack traces configurable

### DIFF
--- a/objectstore-server/src/config.rs
+++ b/objectstore-server/src/config.rs
@@ -269,12 +269,11 @@ pub struct Sentry {
 
     /// Whether to attach stack traces to captured errors and messages.
     ///
-    /// The attached stack trace starts where the event is captured. Disable this to reduce the
-    /// processing overhead and event size of error reporting.
+    /// When enabled, the attached stack trace starts where the event is captured.
     ///
     /// # Default
     ///
-    /// `true`
+    /// `false`
     ///
     /// # Environment Variable
     ///
@@ -340,7 +339,7 @@ impl Default for Sentry {
             sample_rate: 1.0,
             traces_sample_rate: 0.01,
             inherit_sampling_decision: true,
-            attach_stacktrace: true,
+            attach_stacktrace: false,
             debug: false,
             tags: BTreeMap::new(),
         }
@@ -795,7 +794,7 @@ mod tests {
             jail.set_env("OS__SENTRY__ENVIRONMENT", "production");
             jail.set_env("OS__SENTRY__SERVER_NAME", "objectstore-deadbeef");
             jail.set_env("OS__SENTRY__TRACES_SAMPLE_RATE", "0.5");
-            jail.set_env("OS__SENTRY__ATTACH_STACKTRACE", "false");
+            jail.set_env("OS__SENTRY__ATTACH_STACKTRACE", "true");
 
             let config = Config::load(None).unwrap();
 
@@ -817,7 +816,7 @@ mod tests {
             );
             assert_eq!(config.sentry.sample_rate, 0.5);
             assert_eq!(config.sentry.traces_sample_rate, 0.5);
-            assert!(!config.sentry.attach_stacktrace);
+            assert!(config.sentry.attach_stacktrace);
 
             Ok(())
         });
@@ -839,7 +838,7 @@ mod tests {
                 server_name: objectstore-deadbeef
                 sample_rate: 0.5
                 traces_sample_rate: 0.5
-                attach_stacktrace: false
+                attach_stacktrace: true
             "#,
             )
             .unwrap();
@@ -861,7 +860,7 @@ mod tests {
             );
             assert_eq!(config.sentry.sample_rate, 0.5);
             assert_eq!(config.sentry.traces_sample_rate, 0.5);
-            assert!(!config.sentry.attach_stacktrace);
+            assert!(config.sentry.attach_stacktrace);
 
             Ok(())
         });

--- a/objectstore-server/src/config.rs
+++ b/objectstore-server/src/config.rs
@@ -267,6 +267,20 @@ pub struct Sentry {
     /// `OS__SENTRY__INHERIT_SAMPLING_DECISION`
     pub inherit_sampling_decision: bool,
 
+    /// Whether to attach stack traces to captured errors and messages.
+    ///
+    /// The attached stack trace starts where the event is captured. Disable this to reduce the
+    /// processing overhead and event size of error reporting.
+    ///
+    /// # Default
+    ///
+    /// `true`
+    ///
+    /// # Environment Variable
+    ///
+    /// `OS__SENTRY__ATTACH_STACKTRACE`
+    pub attach_stacktrace: bool,
+
     /// Enable Sentry SDK debug mode.
     ///
     /// When enabled, the Sentry SDK will output debug information to stderr, which can be useful
@@ -326,6 +340,7 @@ impl Default for Sentry {
             sample_rate: 1.0,
             traces_sample_rate: 0.01,
             inherit_sampling_decision: true,
+            attach_stacktrace: true,
             debug: false,
             tags: BTreeMap::new(),
         }
@@ -780,6 +795,7 @@ mod tests {
             jail.set_env("OS__SENTRY__ENVIRONMENT", "production");
             jail.set_env("OS__SENTRY__SERVER_NAME", "objectstore-deadbeef");
             jail.set_env("OS__SENTRY__TRACES_SAMPLE_RATE", "0.5");
+            jail.set_env("OS__SENTRY__ATTACH_STACKTRACE", "false");
 
             let config = Config::load(None).unwrap();
 
@@ -801,6 +817,7 @@ mod tests {
             );
             assert_eq!(config.sentry.sample_rate, 0.5);
             assert_eq!(config.sentry.traces_sample_rate, 0.5);
+            assert!(!config.sentry.attach_stacktrace);
 
             Ok(())
         });
@@ -822,6 +839,7 @@ mod tests {
                 server_name: objectstore-deadbeef
                 sample_rate: 0.5
                 traces_sample_rate: 0.5
+                attach_stacktrace: false
             "#,
             )
             .unwrap();
@@ -843,6 +861,7 @@ mod tests {
             );
             assert_eq!(config.sentry.sample_rate, 0.5);
             assert_eq!(config.sentry.traces_sample_rate, 0.5);
+            assert!(!config.sentry.attach_stacktrace);
 
             Ok(())
         });

--- a/objectstore-server/src/observability.rs
+++ b/objectstore-server/src/observability.rs
@@ -50,6 +50,7 @@ pub fn init_sentry(config: &Config) -> Option<sentry::ClientInitGuard> {
             }))
         },
         enable_logs: true,
+        attach_stacktrace: config.attach_stacktrace,
         debug: config.debug,
         ..Default::default()
     });


### PR DESCRIPTION
Make Sentry stack traces configurable while leaving them disabled by default.

The setting is available as `sentry.attach_stacktrace` in YAML and `OS__SENTRY__ATTACH_STACKTRACE` in the environment. It will remain disabled in production.
