### PR TITLE
ci: Install sentry-cli via action-setup-cli

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,9 @@ jobs:
           # libcurl4-openssl-dev: librdkafka is built from source and links against libcurl,
           # whose headers are not on the runner by default.
           sudo apt-get install -y llvm libcurl4-openssl-dev
-          curl -sL https://sentry.io/get-cli/ | bash
+
+      - name: Install sentry-cli
+        uses: getsentry/action-setup-cli@70d7e587b84c2e78cf4d37cd33d7b74fb3729c1b # v1
 
       - name: Install Rust Toolchain
         run: |


### PR DESCRIPTION
Replace the `curl | bash` install of sentry-cli in the build workflow with `getsentry/action-setup-cli`, which verifies the release asset's sha256 before installing.

Same approach as getsentry/sentry-fastlane-plugin#529.

Fixes VULN-2499 VULN-2847