### PR TITLE
build(gocd): Update pipedream to v3.0.8

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v3.0.7"
+      "version": "v3.0.8"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "5eac1ffce92df58ea41712ad8c82f55aa628350f",
-      "sum": "V0sY265XbQP5OVTjn8s/ZQdyRQHzndWNJs+wY1zgr8M="
+      "version": "0811c41dba0b256bd5838e3c1da10640c3897fea",
+      "sum": "UZ8CiwRbQ6xmuK4A2tczb4ezu3hIW+50eWgP+ik8+Kk="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
Updates the `gocd-jsonnet` library, which removes the US2 deployment.

Closes FS-501