### PR TITLE
fix(service): Move TTI renewal to the background

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2999,6 +2999,7 @@ dependencies = [
  "objectstore-log",
  "objectstore-metrics",
  "objectstore-types",
+ "papaya",
  "quick-xml",
  "regex",
  "reqwest 0.13.4",

--- a/objectstore-server/src/config.rs
+++ b/objectstore-server/src/config.rs
@@ -577,6 +577,7 @@ pub struct Config {
 /// - `OS__SERVICE__CONCURRENCY_QUEUE`
 /// - `OS__SERVICE__CONCURRENCY_TIMEOUT`
 /// - `OS__SERVICE__BULK_CONCURRENCY_PCT`
+/// - `OS__SERVICE__BACKGROUND_QUEUE`
 /// - `OS__SERVICE__RESUMABLE_TOKEN_ENCRYPTION__ACTIVE_KEY_ID`
 /// - `OS__SERVICE__RESUMABLE_TOKEN_ENCRYPTION__KEYS`
 #[derive(Debug, Deserialize, Serialize)]
@@ -633,6 +634,16 @@ pub struct Service {
     ///
     /// `60`
     pub bulk_concurrency_pct: u32,
+
+    /// Maximum number of deduplicated TTI renewals waiting for background processing.
+    ///
+    /// Scheduling never waits for space. A renewal is dropped when this queue is full.
+    /// Values below one are clamped to one.
+    ///
+    /// # Default
+    ///
+    /// `1000`
+    pub background_queue: usize,
 
     /// Persistent encryption keys for resumable-upload session tokens returned to clients.
     ///
@@ -698,6 +709,7 @@ impl Default for Service {
             concurrency_queue: 0,
             concurrency_timeout: Duration::from_secs(1),
             bulk_concurrency_pct: 60,
+            background_queue: objectstore_service::service::DEFAULT_BACKGROUND_QUEUE_LIMIT,
             resumable_token_encryption: None,
         }
     }
@@ -856,6 +868,7 @@ mod tests {
             jail.set_env("OS__SENTRY__SERVER_NAME", "objectstore-deadbeef");
             jail.set_env("OS__SENTRY__TRACES_SAMPLE_RATE", "0.5");
             jail.set_env("OS__SENTRY__ATTACH_STACKTRACE", "true");
+            jail.set_env("OS__SERVICE__BACKGROUND_QUEUE", "2048");
 
             let config = Config::load(None).unwrap();
 
@@ -878,6 +891,7 @@ mod tests {
             assert_eq!(config.sentry.sample_rate, 0.5);
             assert_eq!(config.sentry.traces_sample_rate, 0.5);
             assert!(config.sentry.attach_stacktrace);
+            assert_eq!(config.service.background_queue, 2048);
 
             Ok(())
         });
@@ -900,6 +914,8 @@ mod tests {
                 sample_rate: 0.5
                 traces_sample_rate: 0.5
                 attach_stacktrace: true
+            service:
+                background_queue: 2048
             "#,
             )
             .unwrap();
@@ -922,6 +938,7 @@ mod tests {
             assert_eq!(config.sentry.sample_rate, 0.5);
             assert_eq!(config.sentry.traces_sample_rate, 0.5);
             assert!(config.sentry.attach_stacktrace);
+            assert_eq!(config.service.background_queue, 2048);
 
             Ok(())
         });

--- a/objectstore-server/src/state.rs
+++ b/objectstore-server/src/state.rs
@@ -80,8 +80,9 @@ impl Services {
             .with_queue(config.service.concurrency_queue)
             .with_timeout(config.service.concurrency_timeout)
             .with_bulk(config.service.bulk_concurrency_pct);
-        let service =
-            StorageService::new(backend, resumable_token_encryption).with_concurrency(concurrency);
+        let mut service = StorageService::new(backend, resumable_token_encryption)
+            .with_concurrency(concurrency)
+            .with_background_queue_limit(config.service.background_queue);
         service.start();
 
         let key_directory = Arc::new(PublicKeyDirectory::from_config(&config.auth).await?);

--- a/objectstore-service/Cargo.toml
+++ b/objectstore-service/Cargo.toml
@@ -24,6 +24,7 @@ objectstore-inventory-tracker = { workspace = true, features = ["kafka"], option
 objectstore-log = { workspace = true }
 objectstore-metrics = { workspace = true }
 objectstore-types = { workspace = true }
+papaya = { workspace = true }
 quick-xml = { workspace = true, features = ["serialize"] }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["charset", "http2", "hickory-dns", "json", "multipart", "native-tls-no-alpn", "stream", "system-proxy"] }

--- a/objectstore-service/docs/architecture.md
+++ b/objectstore-service/docs/architecture.md
@@ -223,9 +223,10 @@ collection.
 Backend reads are side-effect-free. After a successful GET or HEAD of a TTI
 object, the service may schedule a best-effort background deadline extension.
 The extension is debounced by `min(tti / 4, 24h)`, deduplicated per object, and
-limited to 32 concurrent tasks without a waiting queue. The read returns the
-metadata it observed and does not wait for the extension. Graceful shutdown
-drains scheduled extensions.
+placed into a bounded queue without making the read wait. A background worker
+drains the queue using the service's bulk concurrency budget. The queue capacity
+defaults to 1,000 and is configurable by the server through
+`service.background_queue`. Graceful shutdown drains all accepted extensions.
 
 Apart from the expiration policy, metadata during object creation must carry a
 `time_expires` field with the correct expiration timestamp. This is ensured

--- a/objectstore-service/docs/architecture.md
+++ b/objectstore-service/docs/architecture.md
@@ -146,9 +146,8 @@ rate-limiting failures at a higher layer) are not counted.
 
 This is gated behind the `storage_cogs` Cargo feature.
 
-Each backend reports every write/overwrite, TTI bump, and delete it performs on
-stored objects to a [`ChangeStream`](change_stream::ChangeStream). To
-turn this change stream into COGS data, a stream consumer has to merge each
+Each backend reports every write/overwrite, applied expiry extension, and delete it performs on stored objects to a [`ChangeStream`](change_stream::ChangeStream).
+To turn this change stream into COGS data, a stream consumer has to merge each
 change event into an external table to update an inventory of objects. The
 inventory table can be queried to break down each backend's storage utilization
 by `app_feature`. Note that [`NoopStream`](change_stream::NoopStream) is used
@@ -216,11 +215,17 @@ is streamed end-to-end.
 ## Expiration
 
 Expiration policies are part of the built-in object metadata and can carry
-special semantics. The service delegates expiry **entirely** to the backend
-implementation, allowing each backend to leverage its underlying system's native
-capabilities. For example, BigTable has built-in TTL via garbage collection
-policies, and GCS supports object lifecycle management. The service does not
-perform active garbage collection.
+special semantics. Backends use their underlying system's native expiry
+capabilities. For example, BigTable uses garbage collection policies, and GCS
+uses object lifecycle management. The service does not perform active garbage
+collection.
+
+Backend reads are side-effect-free. After a successful GET or HEAD of a TTI
+object, the service may schedule a best-effort background deadline extension.
+The extension is debounced by `min(tti / 4, 24h)`, deduplicated per object, and
+limited to 32 concurrent tasks without a waiting queue. The read returns the
+metadata it observed and does not wait for the extension. Graceful shutdown
+drains scheduled extensions.
 
 Apart from the expiration policy, metadata during object creation must carry a
 `time_expires` field with the correct expiration timestamp. This is ensured

--- a/objectstore-service/src/backend/bigtable.rs
+++ b/objectstore-service/src/backend/bigtable.rs
@@ -45,7 +45,7 @@ use tracing::Instrument;
 
 use crate::backend::common::{
     Backend, DeleteResponse, GetResponse, HighVolumeBackend, MetadataResponse, PutResponse,
-    TieredGet, TieredMetadata, TieredWrite, Tombstone,
+    TieredGet, TieredMetadata, TieredUpdate, TieredWrite, Tombstone,
 };
 use crate::change_stream::{
     ChangeStream, ChangeStreamFactory, CostTrackerStreamConfig, flush_change_stream,
@@ -1061,7 +1061,13 @@ impl Backend for BigTableBackend {
     }
 
     async fn set_expiry(&self, id: &ObjectId, expire_at: SystemTime) -> Result<bool> {
-        <Self as HighVolumeBackend>::set_expiry_if_matches(self, id, expire_at, None).await
+        <Self as HighVolumeBackend>::compare_and_update(
+            self,
+            id,
+            None,
+            TieredUpdate::SetExpiry(expire_at),
+        )
+        .await
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
@@ -1206,12 +1212,14 @@ impl HighVolumeBackend for BigTableBackend {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn set_expiry_if_matches(
+    async fn compare_and_update(
         &self,
         id: &ObjectId,
-        expire_at: SystemTime,
-        expected_target: Option<&ObjectId>,
+        current: Option<&ObjectId>,
+        update: TieredUpdate,
     ) -> Result<bool> {
+        let TieredUpdate::SetExpiry(expire_at) = update;
+        let expected_target = current;
         let expire_at = super::common::normalize_expiry(expire_at)?;
         let path = id.as_storage_path().to_string().into_bytes();
 
@@ -1939,17 +1947,21 @@ mod tests {
         let later = old_expiry + Duration::from_hours(2);
         assert!(
             !backend
-                .set_expiry_if_matches(&id, later, Some(&wrong_target))
+                .compare_and_update(&id, Some(&wrong_target), TieredUpdate::SetExpiry(later),)
                 .await?
         );
         assert!(
             backend
-                .set_expiry_if_matches(&id, later, Some(&target))
+                .compare_and_update(&id, Some(&target), TieredUpdate::SetExpiry(later))
                 .await?
         );
         assert!(
             backend
-                .set_expiry_if_matches(&id, old_expiry + Duration::from_mins(30), Some(&target),)
+                .compare_and_update(
+                    &id,
+                    Some(&target),
+                    TieredUpdate::SetExpiry(old_expiry + Duration::from_mins(30)),
+                )
                 .await?
         );
         let TieredMetadata::Tombstone(tombstone) = backend.get_tiered_metadata(&id).await? else {
@@ -2499,7 +2511,7 @@ mod tests {
         let requested = SystemTime::now() + tti;
         assert!(
             backend
-                .set_expiry_if_matches(&id, requested, Some(&id))
+                .compare_and_update(&id, Some(&id), TieredUpdate::SetExpiry(requested))
                 .await?
         );
 

--- a/objectstore-service/src/backend/bigtable.rs
+++ b/objectstore-service/src/backend/bigtable.rs
@@ -491,10 +491,6 @@ fn exact_expiry_filter(expire_at: SystemTime) -> Result<v2::RowFilter> {
 }
 
 /// Matches an inline row whose metadata cell has the observed expiry timestamp.
-///
-/// Millisecond expiry timestamps are not unique revisions. A replacement inline
-/// object with the same row kind and expiry can therefore still be overwritten
-/// by this rewrite. A dedicated persisted revision token is deferred.
 fn inline_expiry_predicate(observed_expiry: SystemTime) -> Result<MutatePredicate> {
     let inline_at_expiry = v2::RowFilter {
         filter: Some(v2::row_filter::Filter::Chain(v2::row_filter::Chain {

--- a/objectstore-service/src/backend/bigtable.rs
+++ b/objectstore-service/src/backend/bigtable.rs
@@ -800,14 +800,6 @@ impl RowData {
         })
     }
 
-    /// Returns the expiration policy for this row, regardless of variant.
-    fn expiration_policy(&self) -> ExpirationPolicy {
-        match self {
-            RowData::Object { metadata, .. } => metadata.expiration_policy,
-            RowData::Tombstone { meta, .. } => meta.expiration_policy,
-        }
-    }
-
     /// Returns the resolved expiration timestamp for this row, regardless of variant.
     fn time_expires(&self) -> Option<SystemTime> {
         match self {
@@ -820,7 +812,7 @@ impl RowData {
     ///
     /// Only applies to rows with an expiration policy set.
     fn expires_before(&self, time: SystemTime) -> bool {
-        self.expiration_policy().is_timeout() && self.time_expires().is_some_and(|ts| ts < time)
+        self.time_expires().is_some_and(|ts| ts < time)
     }
 }
 
@@ -1238,20 +1230,20 @@ impl HighVolumeBackend for BigTableBackend {
                     },
                     None,
                 ) => {
-                    let Some(observed_expiry) = metadata.time_expires else {
+                    let Some(old_expiry) = metadata.time_expires else {
                         return Ok(false);
                     };
-                    if metadata.expiration_policy.is_manual() || observed_expiry < now {
-                        return Ok(false);
-                    }
-                    if observed_expiry >= expire_at {
-                        return Ok(true);
+
+                    if old_expiry < now {
+                        return Ok(false); // already expired
+                    } else if old_expiry >= expire_at {
+                        return Ok(true); // already satisfied
                     }
 
                     // Observing a live cell here is not atomic with wall-clock
                     // expiry or Bigtable GC. The conditional write may still lose
                     // to either and then returns false.
-                    let predicate = inline_expiry_predicate(observed_expiry)?;
+                    let predicate = inline_expiry_predicate(old_expiry)?;
                     metadata.time_expires = Some(expire_at);
                     let (mutations, _) = object_mutations(&path, metadata, payload)?;
                     (predicate, mutations.into())
@@ -1265,20 +1257,17 @@ impl HighVolumeBackend for BigTableBackend {
                     Some(expected),
                 ) => {
                     let target = parse_redirect_target(&target, id)?;
-                    let Some(observed_expiry) = time_expires else {
+                    let Some(old_expiry) = time_expires else {
                         return Ok(false);
                     };
-                    if target != *expected
-                        || meta.expiration_policy.is_manual()
-                        || observed_expiry < now
-                    {
-                        return Ok(false);
-                    }
-                    if observed_expiry >= expire_at {
-                        return Ok(true);
+
+                    if target != *expected || old_expiry < now {
+                        return Ok(false); // wrong target or already expired
+                    } else if old_expiry >= expire_at {
+                        return Ok(true); // already satisfied
                     }
 
-                    let predicate = redirect_expiry_predicate(expected, id, observed_expiry)?;
+                    let predicate = redirect_expiry_predicate(expected, id, old_expiry)?;
                     let tombstone = Tombstone {
                         target,
                         expiration_policy: meta.expiration_policy,

--- a/objectstore-service/src/backend/bigtable.rs
+++ b/objectstore-service/src/backend/bigtable.rs
@@ -1782,7 +1782,7 @@ mod tests {
 
     /// Backend reads are side-effect-free; explicit extension preserves payload.
     #[tokio::test]
-    async fn test_reads_do_not_bump_tti_and_set_expiry_preserves_payload() -> Result<()> {
+    async fn test_set_expiry() -> Result<()> {
         let backend = create_test_backend().await?;
         let tti = Duration::from_hours(2 * 24);
         let metadata = Metadata {
@@ -1818,7 +1818,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn set_expiry_returns_false_for_missing_and_conflicting_inline_rows() -> Result<()> {
+    async fn test_expiry_conflict() -> Result<()> {
         let backend = create_test_backend().await?;
         let missing = make_id();
         assert!(
@@ -1863,43 +1863,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn same_expiry_timestamp_replacement_documents_revision_boundary() -> Result<()> {
-        let backend = create_test_backend().await?;
-        let id = make_id();
-        let observed_expiry = persisted_expiry(SystemTime::now() + Duration::from_hours(1));
-        let original = Metadata {
-            expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_hours(1)),
-            time_expires: Some(observed_expiry),
-            ..Default::default()
-        };
-        create_object(&backend, &id, &original, b"original", SystemTime::now()).await?;
-
-        let path = id.as_storage_path().to_string().into_bytes();
-        let predicate = inline_expiry_predicate(observed_expiry)?;
-        let mut extended = original.clone();
-        extended.time_expires = Some(observed_expiry + Duration::from_hours(1));
-        let (extension, _) = object_mutations(&path, extended, b"original".to_vec())?;
-
-        create_object(
-            &backend,
-            &id,
-            &original,
-            b"same-timestamp-replacement",
-            SystemTime::now(),
-        )
-        .await?;
-        assert!(
-            backend
-                .check_and_mutate(path, predicate, extension, "test-expiry-collision")
-                .await?
-        );
-        let (_, _, payload) = backend.get_object(&id, None).await?.unwrap();
-        assert_eq!(stream::read_to_vec(payload).await?, b"original");
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn conditional_redirect_extension_requires_target_and_never_shortens() -> Result<()> {
+    async fn test_redirect_expiry() -> Result<()> {
         let backend = create_test_backend().await?;
         let id = make_id();
         let target = ObjectId::random(id.context().clone());
@@ -1941,32 +1905,6 @@ mod tests {
             panic!("expected tombstone");
         };
         assert_eq!(tombstone.time_expires, Some(later));
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_tti_no_bump_when_fresh() -> Result<()> {
-        let backend = create_test_backend().await?;
-
-        let id = make_id();
-        let tti = Duration::from_hours(2 * 24);
-        let metadata = Metadata {
-            expiration_policy: ExpirationPolicy::TimeToIdle(tti),
-            ..Default::default()
-        };
-        create_object(&backend, &id, &metadata, b"hello, world", SystemTime::now()).await?;
-
-        // A freshly written object has time_expires ≈ now + 2d, well outside the bump
-        // window (now + 2d - 1d = now + 1d). No bump should occur.
-        let first = backend.get_metadata(&id).await?.unwrap();
-        let second = backend.get_metadata(&id).await?.unwrap();
-
-        assert_eq!(
-            first.time_expires.unwrap(),
-            second.time_expires.unwrap(),
-            "fresh TTI object must not be bumped"
-        );
-
         Ok(())
     }
 

--- a/objectstore-service/src/backend/bigtable.rs
+++ b/objectstore-service/src/backend/bigtable.rs
@@ -44,7 +44,7 @@ use tonic::Code;
 use tracing::Instrument;
 
 use crate::backend::common::{
-    Backend, DeleteResponse, GetResponse, HighVolumeBackend, MetadataResponse, PutResponse,
+    self, Backend, DeleteResponse, GetResponse, HighVolumeBackend, MetadataResponse, PutResponse,
     TieredGet, TieredMetadata, TieredUpdate, TieredWrite, Tombstone,
 };
 use crate::change_stream::{
@@ -1220,7 +1220,7 @@ impl HighVolumeBackend for BigTableBackend {
     ) -> Result<bool> {
         let TieredUpdate::SetExpiry(expire_at) = update;
         let expected_target = current;
-        let expire_at = super::common::normalize_expiry(expire_at)?;
+        let expire_at = common::normalize_expiry(expire_at)?;
         let path = id.as_storage_path().to_string().into_bytes();
 
         // Inline extension needs metadata and payload from the same read so a
@@ -1832,7 +1832,7 @@ mod tests {
         assert!(backend.set_expiry(&id, requested).await?);
         assert_eq!(
             backend.get_metadata(&id).await?.unwrap().time_expires,
-            Some(crate::backend::common::normalize_expiry(requested)?)
+            Some(common::normalize_expiry(requested)?)
         );
         let (_, _, stream) = backend.get_object(&id, None).await?.unwrap();
         let payload = stream::read_to_vec(stream).await?;
@@ -1853,7 +1853,7 @@ mod tests {
 
         let id = make_id();
         let observed_expiry =
-            crate::backend::common::normalize_expiry(SystemTime::now() + Duration::from_hours(1))?;
+            common::normalize_expiry(SystemTime::now() + Duration::from_hours(1))?;
         let original = Metadata {
             expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_hours(1)),
             time_expires: Some(observed_expiry),
@@ -1892,7 +1892,7 @@ mod tests {
         let backend = create_test_backend().await?;
         let id = make_id();
         let observed_expiry =
-            crate::backend::common::normalize_expiry(SystemTime::now() + Duration::from_hours(1))?;
+            common::normalize_expiry(SystemTime::now() + Duration::from_hours(1))?;
         let original = Metadata {
             expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_hours(1)),
             time_expires: Some(observed_expiry),
@@ -1930,8 +1930,7 @@ mod tests {
         let id = make_id();
         let target = ObjectId::random(id.context().clone());
         let wrong_target = ObjectId::random(id.context().clone());
-        let old_expiry =
-            crate::backend::common::normalize_expiry(SystemTime::now() + Duration::from_hours(1))?;
+        let old_expiry = common::normalize_expiry(SystemTime::now() + Duration::from_hours(1))?;
         create_tombstone(
             &backend,
             &id,
@@ -2486,8 +2485,7 @@ mod tests {
         let tti = Duration::from_hours(2 * 24);
 
         // Place time_expires near expiry but still in the future.
-        let old_deadline =
-            crate::backend::common::normalize_expiry(SystemTime::now() + Duration::from_mins(1))?;
+        let old_deadline = common::normalize_expiry(SystemTime::now() + Duration::from_mins(1))?;
         write_legacy_tombstone(
             &backend,
             &id,

--- a/objectstore-service/src/backend/bigtable.rs
+++ b/objectstore-service/src/backend/bigtable.rs
@@ -658,17 +658,9 @@ struct TombstoneMeta {
 ///
 /// Used by both unconditional tombstone writes and the conditional expiry-extension paths.
 fn tombstone_mutations(tombstone: &Tombstone) -> Result<[v2::Mutation; 3]> {
-    let (family, timestamp_micros) = match (tombstone.expiration_policy, tombstone.time_expires) {
-        (ExpirationPolicy::Manual, _) => (FAMILY_MANUAL, -1),
-        (policy, Some(deadline)) if policy.is_timeout() => {
-            (FAMILY_GC, system_time_to_micros(deadline)?)
-        }
-        _ => {
-            return Err(Error::new(
-                ErrorKind::Internal,
-                "expiring tombstone missing resolved deadline",
-            ));
-        }
+    let (family, timestamp_micros) = match tombstone.time_expires {
+        None => (FAMILY_MANUAL, -1),
+        Some(deadline) => (FAMILY_GC, system_time_to_micros(deadline)?),
     };
 
     let tombstone_meta = TombstoneMeta {
@@ -1053,13 +1045,8 @@ impl Backend for BigTableBackend {
     }
 
     async fn set_expiry(&self, id: &ObjectId, expire_at: SystemTime) -> Result<bool> {
-        <Self as HighVolumeBackend>::compare_and_update(
-            self,
-            id,
-            None,
-            TieredUpdate::SetExpiry(expire_at),
-        )
-        .await
+        self.compare_and_update(id, None, TieredUpdate::SetExpiry(expire_at))
+            .await
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
@@ -1211,79 +1198,76 @@ impl HighVolumeBackend for BigTableBackend {
         update: TieredUpdate,
     ) -> Result<bool> {
         let TieredUpdate::SetExpiry(expire_at) = update;
-        let expected_target = current;
         let path = id.as_storage_path().to_string().into_bytes();
+        let access_time = SystemTime::now();
 
         // Inline extension needs metadata and payload from the same read so a
         // successful conditional rewrite can preserve the payload verbatim.
         let Some(row) = self.read_row(&path, None, "set_expiry").await? else {
             return Ok(false);
         };
-        let now = SystemTime::now();
 
-        let (predicate, mutations): (MutatePredicate, Vec<v2::Mutation>) =
-            match (row, expected_target) {
-                (
-                    RowData::Object {
-                        mut metadata,
-                        payload,
-                    },
-                    None,
-                ) => {
-                    let Some(old_expiry) = metadata.time_expires else {
-                        return Ok(false);
-                    };
-
-                    if old_expiry < now {
-                        return Ok(false); // already expired
-                    } else if old_expiry >= expire_at {
-                        return Ok(true); // already satisfied
-                    }
-
-                    // Observing a live cell here is not atomic with wall-clock
-                    // expiry or Bigtable GC. The conditional write may still lose
-                    // to either and then returns false.
-                    let predicate = inline_expiry_predicate(old_expiry)?;
-                    metadata.time_expires = Some(expire_at);
-                    let (mutations, _) = object_mutations(&path, metadata, payload)?;
-                    (predicate, mutations.into())
+        let (predicate, mutations) = match row {
+            RowData::Object { metadata, payload } => {
+                if current.is_some() {
+                    return Ok(false); // wrong row kind
                 }
-                (
-                    RowData::Tombstone {
-                        target,
-                        meta,
-                        time_expires,
-                    },
-                    Some(expected),
-                ) => {
-                    let target = parse_redirect_target(&target, id)?;
-                    let Some(old_expiry) = time_expires else {
-                        return Ok(false);
-                    };
+                let Some(old_expiry) = metadata.time_expires else {
+                    return Ok(false);
+                };
 
-                    if target != *expected || old_expiry < now {
-                        return Ok(false); // wrong target or already expired
-                    } else if old_expiry >= expire_at {
-                        return Ok(true); // already satisfied
-                    }
-
-                    let predicate = redirect_expiry_predicate(expected, id, old_expiry)?;
-                    let tombstone = Tombstone {
-                        target,
-                        expiration_policy: meta.expiration_policy,
-                        time_expires: Some(expire_at),
-                    };
-                    (predicate, tombstone_mutations(&tombstone)?.into())
+                if old_expiry < access_time {
+                    return Ok(false); // already expired
+                } else if old_expiry >= expire_at {
+                    return Ok(true); // already satisfied
                 }
-                _ => return Ok(false),
-            };
+
+                // Observing a live cell here is not atomic with wall-clock
+                // expiry or Bigtable GC. The conditional write may still lose
+                // to either and then returns false.
+                let predicate = inline_expiry_predicate(old_expiry)?;
+                let mut metadata = metadata;
+                metadata.time_expires = Some(expire_at);
+                let (mutations, _) = object_mutations(&path, metadata, payload)?;
+                (predicate, mutations.to_vec())
+            }
+            RowData::Tombstone {
+                target,
+                meta,
+                time_expires,
+            } => {
+                let Some(expected) = current else {
+                    return Ok(false); // wrong row kind
+                };
+                let Some(old_expiry) = time_expires else {
+                    return Ok(false);
+                };
+
+                let target = parse_redirect_target(&target, id)?;
+                if target != *expected || old_expiry < access_time {
+                    return Ok(false); // wrong target or already expired
+                } else if old_expiry >= expire_at {
+                    return Ok(true); // already satisfied
+                }
+
+                let predicate = redirect_expiry_predicate(expected, id, old_expiry)?;
+                let tombstone = Tombstone {
+                    target,
+                    expiration_policy: meta.expiration_policy,
+                    time_expires: Some(expire_at),
+                };
+                (predicate, tombstone_mutations(&tombstone)?.to_vec())
+            }
+        };
 
         let applied = self
             .check_and_mutate(path, predicate, mutations, "set_expiry")
             .await?;
+
         if applied {
             self.change_stream.update(id, Some(expire_at));
         }
+
         Ok(applied)
     }
 

--- a/objectstore-service/src/backend/bigtable.rs
+++ b/objectstore-service/src/backend/bigtable.rs
@@ -1207,7 +1207,7 @@ impl HighVolumeBackend for BigTableBackend {
             return Ok(false);
         };
 
-        let (predicate, mutations) = match row {
+        let (predicate, mutations): (_, Vec<_>) = match row {
             RowData::Object { metadata, payload } => {
                 if current.is_some() {
                     return Ok(false); // wrong row kind
@@ -1229,7 +1229,7 @@ impl HighVolumeBackend for BigTableBackend {
                 let mut metadata = metadata;
                 metadata.time_expires = Some(expire_at);
                 let (mutations, _) = object_mutations(&path, metadata, payload)?;
-                (predicate, mutations.to_vec())
+                (predicate, mutations.into())
             }
             RowData::Tombstone {
                 target,
@@ -1256,7 +1256,7 @@ impl HighVolumeBackend for BigTableBackend {
                     expiration_policy: meta.expiration_policy,
                     time_expires: Some(expire_at),
                 };
-                (predicate, tombstone_mutations(&tombstone)?.to_vec())
+                (predicate, tombstone_mutations(&tombstone)?.into())
             }
         };
 

--- a/objectstore-service/src/backend/bigtable.rs
+++ b/objectstore-service/src/backend/bigtable.rs
@@ -44,7 +44,7 @@ use tonic::Code;
 use tracing::Instrument;
 
 use crate::backend::common::{
-    self, Backend, DeleteResponse, GetResponse, HighVolumeBackend, MetadataResponse, PutResponse,
+    Backend, DeleteResponse, GetResponse, HighVolumeBackend, MetadataResponse, PutResponse,
     TieredGet, TieredMetadata, TieredUpdate, TieredWrite, Tombstone,
 };
 use crate::change_stream::{
@@ -1220,7 +1220,6 @@ impl HighVolumeBackend for BigTableBackend {
     ) -> Result<bool> {
         let TieredUpdate::SetExpiry(expire_at) = update;
         let expected_target = current;
-        let expire_at = common::normalize_expiry(expire_at)?;
         let path = id.as_storage_path().to_string().into_bytes();
 
         // Inline extension needs metadata and payload from the same read so a
@@ -1551,6 +1550,10 @@ mod tests {
     use crate::id::ObjectContext;
     use crate::stream;
 
+    fn persisted_expiry(expire_at: SystemTime) -> SystemTime {
+        micros_to_time(system_time_to_micros(expire_at).unwrap()).unwrap()
+    }
+
     // NB: Most of these tests require a BigTable emulator running. This is done
     // automatically in CI.
     //
@@ -1832,7 +1835,7 @@ mod tests {
         assert!(backend.set_expiry(&id, requested).await?);
         assert_eq!(
             backend.get_metadata(&id).await?.unwrap().time_expires,
-            Some(common::normalize_expiry(requested)?)
+            Some(persisted_expiry(requested))
         );
         let (_, _, stream) = backend.get_object(&id, None).await?.unwrap();
         let payload = stream::read_to_vec(stream).await?;
@@ -1852,8 +1855,7 @@ mod tests {
         );
 
         let id = make_id();
-        let observed_expiry =
-            common::normalize_expiry(SystemTime::now() + Duration::from_hours(1))?;
+        let observed_expiry = persisted_expiry(SystemTime::now() + Duration::from_hours(1));
         let original = Metadata {
             expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_hours(1)),
             time_expires: Some(observed_expiry),
@@ -1891,8 +1893,7 @@ mod tests {
     async fn same_expiry_timestamp_replacement_documents_revision_boundary() -> Result<()> {
         let backend = create_test_backend().await?;
         let id = make_id();
-        let observed_expiry =
-            common::normalize_expiry(SystemTime::now() + Duration::from_hours(1))?;
+        let observed_expiry = persisted_expiry(SystemTime::now() + Duration::from_hours(1));
         let original = Metadata {
             expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_hours(1)),
             time_expires: Some(observed_expiry),
@@ -1930,7 +1931,7 @@ mod tests {
         let id = make_id();
         let target = ObjectId::random(id.context().clone());
         let wrong_target = ObjectId::random(id.context().clone());
-        let old_expiry = common::normalize_expiry(SystemTime::now() + Duration::from_hours(1))?;
+        let old_expiry = persisted_expiry(SystemTime::now() + Duration::from_hours(1));
         create_tombstone(
             &backend,
             &id,
@@ -2485,7 +2486,7 @@ mod tests {
         let tti = Duration::from_hours(2 * 24);
 
         // Place time_expires near expiry but still in the future.
-        let old_deadline = common::normalize_expiry(SystemTime::now() + Duration::from_mins(1))?;
+        let old_deadline = persisted_expiry(SystemTime::now() + Duration::from_mins(1));
         write_legacy_tombstone(
             &backend,
             &id,

--- a/objectstore-service/src/backend/bigtable.rs
+++ b/objectstore-service/src/backend/bigtable.rs
@@ -25,8 +25,8 @@
 //! Tombstones written before the `r`/`t` column layout used the object-row format with an
 //! empty `p` column and `"is_redirect_tombstone": true` in the `m` JSON. Both formats are
 //! supported for reading. A `bigtable.legacy_tombstone_read` metric is emitted on each legacy
-//! read. Legacy tombstones expire naturally by TTL/GC; TTI bumps transparently upgrade them
-//! to the new format.
+//! read. Legacy tombstones expire naturally by TTL/GC; a successful conditional
+//! expiry extension upgrades them to the new format.
 
 use std::fmt;
 use std::future::Future;
@@ -461,6 +461,78 @@ fn optional_target_predicate(target: &ObjectId, own_id: &ObjectId) -> MutatePred
     })
 }
 
+fn exact_expiry_filter(expire_at: SystemTime) -> Result<v2::RowFilter> {
+    let start = system_time_to_micros(expire_at)?;
+    let end = start.checked_add(1).ok_or_else(|| {
+        Error::new(
+            ErrorKind::Internal,
+            "building Bigtable expiration predicate",
+        )
+    })?;
+    Ok(v2::RowFilter {
+        filter: Some(v2::row_filter::Filter::Chain(v2::row_filter::Chain {
+            filters: vec![
+                v2::RowFilter {
+                    filter: Some(v2::row_filter::Filter::FamilyNameRegexFilter(format!(
+                        "^{FAMILY_GC}$"
+                    ))),
+                },
+                v2::RowFilter {
+                    filter: Some(v2::row_filter::Filter::TimestampRangeFilter(
+                        v2::TimestampRange {
+                            start_timestamp_micros: start,
+                            end_timestamp_micros: end,
+                        },
+                    )),
+                },
+            ],
+        })),
+    })
+}
+
+/// Matches an inline row whose metadata cell has the observed expiry timestamp.
+///
+/// Millisecond expiry timestamps are not unique revisions. A replacement inline
+/// object with the same row kind and expiry can therefore still be overwritten
+/// by this rewrite. A dedicated persisted revision token is deferred.
+fn inline_expiry_predicate(observed_expiry: SystemTime) -> Result<MutatePredicate> {
+    let inline_at_expiry = v2::RowFilter {
+        filter: Some(v2::row_filter::Filter::Chain(v2::row_filter::Chain {
+            filters: vec![
+                column_filter(COLUMN_METADATA),
+                exact_expiry_filter(observed_expiry)?,
+            ],
+        })),
+    };
+
+    Ok(MutatePredicate::Include(v2::RowFilter {
+        filter: Some(v2::row_filter::Filter::Condition(Box::new(
+            v2::row_filter::Condition {
+                predicate_filter: Some(Box::new(tombstone_filter())),
+                true_filter: Some(Box::new(v2::RowFilter {
+                    filter: Some(v2::row_filter::Filter::BlockAllFilter(true)),
+                })),
+                false_filter: Some(Box::new(inline_at_expiry)),
+            },
+        ))),
+    }))
+}
+
+fn redirect_expiry_predicate(
+    target: &ObjectId,
+    own_id: &ObjectId,
+    observed_expiry: SystemTime,
+) -> Result<MutatePredicate> {
+    Ok(MutatePredicate::Include(v2::RowFilter {
+        filter: Some(v2::row_filter::Filter::Chain(v2::row_filter::Chain {
+            filters: vec![
+                redirect_target_filter(target, own_id),
+                exact_expiry_filter(observed_expiry)?,
+            ],
+        })),
+    }))
+}
+
 /// The condition under which a [`BigTableBackend::check_and_mutate`] write proceeds.
 ///
 /// Each variant pairs a row filter with the state that makes the write safe:
@@ -500,19 +572,6 @@ fn delete_row_mutation() -> v2::Mutation {
     mutation(mutation::Mutation::DeleteFromRow(
         mutation::DeleteFromRow {},
     ))
-}
-
-/// Returns a clone of `metadata` with `time_expires` refreshed for a TTI bump.
-///
-/// [`object_mutations`] persists `time_expires` verbatim, so the bumped deadline must be applied
-/// to the metadata before rewriting the row.
-fn bumped_tti_metadata(metadata: &Metadata) -> Metadata {
-    let mut metadata = metadata.clone();
-    metadata.time_expires = metadata
-        .expiration_policy
-        .expires_in()
-        .map(|tti| SystemTime::now() + tti);
-    metadata
 }
 
 /// Builds the three mutations that write an object row: clear existing data,
@@ -576,6 +635,7 @@ fn row_size(path: &[u8], mutations: &[v2::Mutation]) -> u64 {
 /// The moment a row written now under `policy` is expected to be reclaimed.
 ///
 /// Returns `None` for [`ExpirationPolicy::Manual`], which never expires on its own.
+#[cfg(test)]
 fn expiry_from_policy(policy: ExpirationPolicy, now: SystemTime) -> Option<SystemTime> {
     policy.expires_in().map(|ttl| now + ttl)
 }
@@ -596,13 +656,19 @@ struct TombstoneMeta {
 /// Builds the three mutations that write a tombstone row: clear existing data,
 /// then set the redirect sentinel and tombstone-meta cells.
 ///
-/// Used by both [`BigTableBackend::put_tombstone_row`] (unconditional write) and the
-/// TTI bump path in tiered reads.
-fn tombstone_mutations(tombstone: &Tombstone, now: SystemTime) -> Result<[v2::Mutation; 3]> {
-    let (family, timestamp_micros) = match tombstone.expiration_policy {
-        ExpirationPolicy::Manual => (FAMILY_MANUAL, -1),
-        ExpirationPolicy::TimeToLive(ttl) => (FAMILY_GC, ttl_to_micros(ttl, now)?),
-        ExpirationPolicy::TimeToIdle(tti) => (FAMILY_GC, ttl_to_micros(tti, now)?),
+/// Used by both unconditional tombstone writes and the conditional expiry-extension paths.
+fn tombstone_mutations(tombstone: &Tombstone) -> Result<[v2::Mutation; 3]> {
+    let (family, timestamp_micros) = match (tombstone.expiration_policy, tombstone.time_expires) {
+        (ExpirationPolicy::Manual, _) => (FAMILY_MANUAL, -1),
+        (policy, Some(deadline)) if policy.is_timeout() => {
+            (FAMILY_GC, system_time_to_micros(deadline)?)
+        }
+        _ => {
+            return Err(Error::new(
+                ErrorKind::Internal,
+                "expiring tombstone missing resolved deadline",
+            ));
+        }
     };
 
     let tombstone_meta = TombstoneMeta {
@@ -727,7 +793,7 @@ impl RowData {
                 time_expires: expire_at,
             }
         } else {
-            // Metadata may have been skipped during read - payload-only read for TTI bump.
+            // Metadata may have been skipped by a payload-only internal read.
             let mut metadata = metadata_opt.unwrap_or_default();
             metadata.time_expires = expire_at;
             RowData::Object { metadata, payload }
@@ -755,15 +821,6 @@ impl RowData {
     /// Only applies to rows with an expiration policy set.
     fn expires_before(&self, time: SystemTime) -> bool {
         self.expiration_policy().is_timeout() && self.time_expires().is_some_and(|ts| ts < time)
-    }
-
-    /// Checks whether this row's TTI deadline needs bumping.
-    ///
-    /// Returns `Some(new_expire_at)` when the deadline is stale enough to
-    /// justify a write, `None` otherwise.
-    fn check_tti_bump(&self, access_time: SystemTime) -> Option<SystemTime> {
-        self.expiration_policy()
-            .check_tti_bump(self.time_expires(), access_time)
     }
 }
 
@@ -914,80 +971,6 @@ impl BigTableBackend {
         Ok((response, size))
     }
 
-    async fn put_tombstone_row(
-        &self,
-        path: Vec<u8>,
-        tombstone: &Tombstone,
-        action: &'static str,
-    ) -> Result<v2::MutateRowResponse> {
-        let mutations = tombstone_mutations(tombstone, SystemTime::now())?;
-        self.mutate(path, mutations, action).await
-    }
-
-    /// Best-effort TTI bump for a row.
-    ///
-    /// If the payload isn't loaded, it will be fetched. Failures are ignored silently.
-    ///
-    /// A successful bump is reported to the [`ChangeStream`].
-    #[tracing::instrument(level = "debug", fields(?hv_id, loaded), skip_all)]
-    async fn bump_tti(&self, path: Vec<u8>, row: &RowData, loaded: bool, hv_id: &ObjectId) {
-        let expiration_policy = row.expiration_policy();
-
-        match row {
-            RowData::Tombstone { target, .. } => {
-                let target = match parse_redirect_target(target, hv_id) {
-                    Ok(target) => target,
-                    Err(e) => {
-                        objectstore_log::error!(!!&e, "invalid redirect target in tombstone row");
-                        return;
-                    }
-                };
-
-                let now = SystemTime::now();
-                let tombstone = Tombstone {
-                    target,
-                    expiration_policy,
-                };
-                if self
-                    .put_tombstone_row(path, &tombstone, "tti-bump")
-                    .await
-                    .is_ok()
-                {
-                    self.change_stream
-                        .update(hv_id, expiry_from_policy(expiration_policy, now));
-                }
-            }
-            RowData::Object { metadata, payload } if loaded => {
-                let bumped = bumped_tti_metadata(metadata);
-                let expires_at = bumped.time_expires;
-                if self
-                    .put_row(path, bumped, payload.clone(), "tti-bump")
-                    .await
-                    .is_ok()
-                {
-                    self.change_stream.update(hv_id, expires_at);
-                }
-            }
-            RowData::Object { metadata, .. } => {
-                let payload_read = self
-                    .read_row(&path, Some(column_filter(COLUMN_PAYLOAD)), "tti-bump")
-                    .await;
-
-                if let Ok(Some(RowData::Object { payload, .. })) = payload_read {
-                    let bumped = bumped_tti_metadata(metadata);
-                    let expires_at = bumped.time_expires;
-                    if self
-                        .put_row(path, bumped, payload, "tti-bump")
-                        .await
-                        .is_ok()
-                    {
-                        self.change_stream.update(hv_id, expires_at);
-                    }
-                }
-            }
-        }
-    }
-
     /// Executes a `CheckAndMutateRow` request.
     #[tracing::instrument(level = "debug", fields(action = context), skip_all)]
     async fn check_and_mutate(
@@ -1077,6 +1060,10 @@ impl Backend for BigTableBackend {
         }
     }
 
+    async fn set_expiry(&self, id: &ObjectId, expire_at: SystemTime) -> Result<bool> {
+        <Self as HighVolumeBackend>::set_expiry_if_matches(self, id, expire_at, None).await
+    }
+
     #[tracing::instrument(level = "debug", skip(self))]
     async fn delete_object(&self, id: &ObjectId) -> Result<DeleteResponse> {
         objectstore_log::debug!("Deleting from Bigtable backend");
@@ -1128,10 +1115,15 @@ impl HighVolumeBackend for BigTableBackend {
                 .await?;
 
             match row {
-                Some(RowData::Tombstone { target, meta, .. }) => {
+                Some(RowData::Tombstone {
+                    target,
+                    meta,
+                    time_expires,
+                }) => {
                     return Ok(Some(Tombstone {
                         target: parse_redirect_target(&target, id)?,
                         expiration_policy: meta.expiration_policy,
+                        time_expires,
                     }));
                 }
                 // Race: Tombstone was replaced by an object, retry to overwrite
@@ -1160,15 +1152,15 @@ impl HighVolumeBackend for BigTableBackend {
             return Ok(TieredGet::NotFound);
         };
 
-        // TODO: extract into dedicated call from service
-        if row.check_tti_bump(SystemTime::now()).is_some() {
-            self.bump_tti(path.clone(), &row, true, id).await;
-        }
-
         Ok(match row {
-            RowData::Tombstone { meta, target, .. } => TieredGet::Tombstone(Tombstone {
+            RowData::Tombstone {
+                meta,
+                target,
+                time_expires,
+            } => TieredGet::Tombstone(Tombstone {
                 target: parse_redirect_target(&target, id)?,
                 expiration_policy: meta.expiration_policy,
+                time_expires,
             }),
             RowData::Object { metadata, payload } => {
                 let mut metadata = metadata;
@@ -1199,18 +1191,104 @@ impl HighVolumeBackend for BigTableBackend {
             return Ok(TieredMetadata::NotFound);
         };
 
-        // TODO: extract into dedicated call from service
-        if row.check_tti_bump(SystemTime::now()).is_some() {
-            self.bump_tti(path.clone(), &row, false, id).await;
-        }
-
         Ok(match row {
-            RowData::Tombstone { meta, target, .. } => TieredMetadata::Tombstone(Tombstone {
+            RowData::Tombstone {
+                meta,
+                target,
+                time_expires,
+            } => TieredMetadata::Tombstone(Tombstone {
                 target: parse_redirect_target(&target, id)?,
                 expiration_policy: meta.expiration_policy,
+                time_expires,
             }),
             RowData::Object { metadata, .. } => TieredMetadata::Object(metadata),
         })
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    async fn set_expiry_if_matches(
+        &self,
+        id: &ObjectId,
+        expire_at: SystemTime,
+        expected_target: Option<&ObjectId>,
+    ) -> Result<bool> {
+        let expire_at = super::common::normalize_expiry(expire_at)?;
+        let path = id.as_storage_path().to_string().into_bytes();
+
+        // Inline extension needs metadata and payload from the same read so a
+        // successful conditional rewrite can preserve the payload verbatim.
+        let Some(row) = self.read_row(&path, None, "set_expiry").await? else {
+            return Ok(false);
+        };
+        let now = SystemTime::now();
+
+        let (predicate, mutations): (MutatePredicate, Vec<v2::Mutation>) =
+            match (row, expected_target) {
+                (
+                    RowData::Object {
+                        mut metadata,
+                        payload,
+                    },
+                    None,
+                ) => {
+                    let Some(observed_expiry) = metadata.time_expires else {
+                        return Ok(false);
+                    };
+                    if metadata.expiration_policy.is_manual() || observed_expiry < now {
+                        return Ok(false);
+                    }
+                    if observed_expiry >= expire_at {
+                        return Ok(true);
+                    }
+
+                    // Observing a live cell here is not atomic with wall-clock
+                    // expiry or Bigtable GC. The conditional write may still lose
+                    // to either and then returns false.
+                    let predicate = inline_expiry_predicate(observed_expiry)?;
+                    metadata.time_expires = Some(expire_at);
+                    let (mutations, _) = object_mutations(&path, metadata, payload)?;
+                    (predicate, mutations.into())
+                }
+                (
+                    RowData::Tombstone {
+                        target,
+                        meta,
+                        time_expires,
+                    },
+                    Some(expected),
+                ) => {
+                    let target = parse_redirect_target(&target, id)?;
+                    let Some(observed_expiry) = time_expires else {
+                        return Ok(false);
+                    };
+                    if target != *expected
+                        || meta.expiration_policy.is_manual()
+                        || observed_expiry < now
+                    {
+                        return Ok(false);
+                    }
+                    if observed_expiry >= expire_at {
+                        return Ok(true);
+                    }
+
+                    let predicate = redirect_expiry_predicate(expected, id, observed_expiry)?;
+                    let tombstone = Tombstone {
+                        target,
+                        expiration_policy: meta.expiration_policy,
+                        time_expires: Some(expire_at),
+                    };
+                    (predicate, tombstone_mutations(&tombstone)?.into())
+                }
+                _ => return Ok(false),
+            };
+
+        let applied = self
+            .check_and_mutate(path, predicate, mutations, "set_expiry")
+            .await?;
+        if applied {
+            self.change_stream.update(id, Some(expire_at));
+        }
+        Ok(applied)
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
@@ -1241,10 +1319,15 @@ impl HighVolumeBackend for BigTableBackend {
                 .await?;
 
             match row {
-                Some(RowData::Tombstone { target, meta, .. }) => {
+                Some(RowData::Tombstone {
+                    target,
+                    meta,
+                    time_expires,
+                }) => {
                     return Ok(Some(Tombstone {
                         target: parse_redirect_target(&target, id)?,
                         expiration_policy: meta.expiration_policy,
+                        time_expires,
                     }));
                 }
                 // Race: An object appeared since the predicate ran, delete the new object now.
@@ -1270,8 +1353,6 @@ impl HighVolumeBackend for BigTableBackend {
         objectstore_log::debug!("CAS put to Bigtable backend");
 
         let path = id.as_storage_path().to_string().into_bytes();
-        let now = SystemTime::now();
-
         let predicate = match (current, write.target()) {
             (Some(old), Some(new)) => update_predicate(old, new, id),
             (Some(target), None) => optional_target_predicate(target, id),
@@ -1284,8 +1365,8 @@ impl HighVolumeBackend for BigTableBackend {
         // without an expiration date, `expires_at` is `Some(None)`.
         let (mutations, expires_at): (Vec<v2::Mutation>, Option<Option<SystemTime>>) = match write {
             TieredWrite::Tombstone(tombstone) => (
-                tombstone_mutations(&tombstone, now)?.into(),
-                Some(expiry_from_policy(tombstone.expiration_policy, now)),
+                tombstone_mutations(&tombstone)?.into(),
+                Some(tombstone.time_expires),
             ),
             TieredWrite::Object(m, p) => {
                 let expires_at = m.time_expires;
@@ -1318,19 +1399,6 @@ impl HighVolumeBackend for BigTableBackend {
 
         Ok(written)
     }
-}
-
-/// Converts the given TTL duration to a microsecond-precision unix timestamp.
-///
-/// The TTL is anchored at the provided `from` timestamp, which defaults to `SystemTime::now()`. As
-/// required by BigTable, the resulting timestamp has millisecond precision, with the last digits at
-/// 0.
-fn ttl_to_micros(ttl: Duration, from: SystemTime) -> Result<i64> {
-    let deadline = from
-        .checked_add(ttl)
-        .ok_or_else(|| Error::new(ErrorKind::Internal, "calculating Bigtable expiration"))?;
-
-    system_time_to_micros(deadline)
 }
 
 /// Converts a [`SystemTime`] to a microsecond-precision unix timestamp.
@@ -1543,7 +1611,11 @@ mod tests {
         now: SystemTime,
     ) -> Result<()> {
         let path = id.as_storage_path().to_string().into_bytes();
-        let mutations = tombstone_mutations(tombstone, now)?;
+        let mut tombstone = tombstone.clone();
+        if tombstone.time_expires.is_none() {
+            tombstone.time_expires = expiry_from_policy(tombstone.expiration_policy, now);
+        }
+        let mutations = tombstone_mutations(&tombstone)?;
         backend.mutate(path, mutations, "test-setup").await?;
         Ok(())
     }
@@ -1724,12 +1796,9 @@ mod tests {
         Ok(())
     }
 
-    /// Verifies TTI bump via both `get_object` (loaded=true path) and `get_metadata` (loaded=false path).
-    ///
-    /// We write a stale timestamp inside the bump window (still in the future,
-    /// so the row is not GC'd) and confirm that a subsequent read extends the expiry.
+    /// Backend reads are side-effect-free; explicit extension preserves payload.
     #[tokio::test]
-    async fn test_tti_bump() -> Result<()> {
+    async fn test_reads_do_not_bump_tti_and_set_expiry_preserves_payload() -> Result<()> {
         let backend = create_test_backend().await?;
         let tti = Duration::from_hours(2 * 24);
         let metadata = Metadata {
@@ -1740,40 +1809,153 @@ mod tests {
         // Backdate `now` so the written expiry (past_now + tti) is stale but not expired.
         let past_now = SystemTime::now() - tti + Duration::from_mins(1);
 
-        // Sub-sequence 1: get_object triggers bump (loaded=true path).
-        let id1 = make_id();
-        create_object(&backend, &id1, &metadata, b"hello, world", past_now).await?;
+        let id = make_id();
+        create_object(&backend, &id, &metadata, b"hello, world", past_now).await?;
 
-        // get_object reads the stale row, triggers bump, and returns the pre-bump metadata.
-        let (pre_obj_meta, _, _) = backend.get_object(&id1, None).await?.unwrap();
-        let pre_obj_expiry = pre_obj_meta.time_expires.unwrap();
-
-        // A second get_metadata reads the freshly bumped row.
-        let post_obj_meta = backend.get_metadata(&id1).await?.unwrap();
-        let post_obj_expiry = post_obj_meta.time_expires.unwrap();
-        assert!(
-            post_obj_expiry > pre_obj_expiry,
-            "bump should extend expiry"
+        let (observed, _, _) = backend.get_object(&id, None).await?.unwrap();
+        let observed_expiry = observed.time_expires.unwrap();
+        assert_eq!(
+            backend.get_metadata(&id).await?.unwrap().time_expires,
+            Some(observed_expiry),
+            "backend reads must not renew TTI"
         );
 
-        // Sub-sequence 2: get_metadata triggers bump (loaded=false path).
-        let id2 = make_id();
-        create_object(&backend, &id2, &metadata, b"hello, world", past_now).await?;
-
-        // First get_metadata sees the stale row and triggers a bump.
-        let pre_meta = backend.get_metadata(&id2).await?.unwrap();
-        let pre_expiry = pre_meta.time_expires.unwrap();
-
-        // Second get_metadata reads the freshly bumped row.
-        let post_meta = backend.get_metadata(&id2).await?.unwrap();
-        let post_expiry = post_meta.time_expires.unwrap();
-        assert!(post_expiry > pre_expiry, "bump should extend expiry");
-
-        // Payload must be intact after the loaded=false bump (which re-fetches the payload).
-        let (_, _, stream) = backend.get_object(&id2, None).await?.unwrap();
+        let requested = SystemTime::now() + tti;
+        assert!(backend.set_expiry(&id, requested).await?);
+        assert_eq!(
+            backend.get_metadata(&id).await?.unwrap().time_expires,
+            Some(crate::backend::common::normalize_expiry(requested)?)
+        );
+        let (_, _, stream) = backend.get_object(&id, None).await?.unwrap();
         let payload = stream::read_to_vec(stream).await?;
         assert_eq!(payload, b"hello, world");
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn set_expiry_returns_false_for_missing_and_conflicting_inline_rows() -> Result<()> {
+        let backend = create_test_backend().await?;
+        let missing = make_id();
+        assert!(
+            !backend
+                .set_expiry(&missing, SystemTime::now() + Duration::from_hours(2))
+                .await?
+        );
+
+        let id = make_id();
+        let observed_expiry =
+            crate::backend::common::normalize_expiry(SystemTime::now() + Duration::from_hours(1))?;
+        let original = Metadata {
+            expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_hours(1)),
+            time_expires: Some(observed_expiry),
+            ..Default::default()
+        };
+        create_object(&backend, &id, &original, b"original", SystemTime::now()).await?;
+
+        let path = id.as_storage_path().to_string().into_bytes();
+        let mut extended = original.clone();
+        extended.time_expires = Some(observed_expiry + Duration::from_hours(1));
+        let (extension, _) = object_mutations(&path, extended, b"original".to_vec())?;
+        let predicate = inline_expiry_predicate(observed_expiry)?;
+
+        let mut replacement = original.clone();
+        replacement.time_expires = Some(observed_expiry + Duration::from_mins(1));
+        create_object(
+            &backend,
+            &id,
+            &replacement,
+            b"replacement",
+            SystemTime::now(),
+        )
+        .await?;
+        assert!(
+            !backend
+                .check_and_mutate(path, predicate, extension, "test-expiry-conflict")
+                .await?
+        );
+        let (_, _, payload) = backend.get_object(&id, None).await?.unwrap();
+        assert_eq!(stream::read_to_vec(payload).await?, b"replacement");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn same_expiry_timestamp_replacement_documents_revision_boundary() -> Result<()> {
+        let backend = create_test_backend().await?;
+        let id = make_id();
+        let observed_expiry =
+            crate::backend::common::normalize_expiry(SystemTime::now() + Duration::from_hours(1))?;
+        let original = Metadata {
+            expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_hours(1)),
+            time_expires: Some(observed_expiry),
+            ..Default::default()
+        };
+        create_object(&backend, &id, &original, b"original", SystemTime::now()).await?;
+
+        let path = id.as_storage_path().to_string().into_bytes();
+        let predicate = inline_expiry_predicate(observed_expiry)?;
+        let mut extended = original.clone();
+        extended.time_expires = Some(observed_expiry + Duration::from_hours(1));
+        let (extension, _) = object_mutations(&path, extended, b"original".to_vec())?;
+
+        create_object(
+            &backend,
+            &id,
+            &original,
+            b"same-timestamp-replacement",
+            SystemTime::now(),
+        )
+        .await?;
+        assert!(
+            backend
+                .check_and_mutate(path, predicate, extension, "test-expiry-collision")
+                .await?
+        );
+        let (_, _, payload) = backend.get_object(&id, None).await?.unwrap();
+        assert_eq!(stream::read_to_vec(payload).await?, b"original");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn conditional_redirect_extension_requires_target_and_never_shortens() -> Result<()> {
+        let backend = create_test_backend().await?;
+        let id = make_id();
+        let target = ObjectId::random(id.context().clone());
+        let wrong_target = ObjectId::random(id.context().clone());
+        let old_expiry =
+            crate::backend::common::normalize_expiry(SystemTime::now() + Duration::from_hours(1))?;
+        create_tombstone(
+            &backend,
+            &id,
+            &Tombstone {
+                target: target.clone(),
+                expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_hours(1)),
+                time_expires: Some(old_expiry),
+            },
+            SystemTime::now(),
+        )
+        .await?;
+
+        let later = old_expiry + Duration::from_hours(2);
+        assert!(
+            !backend
+                .set_expiry_if_matches(&id, later, Some(&wrong_target))
+                .await?
+        );
+        assert!(
+            backend
+                .set_expiry_if_matches(&id, later, Some(&target))
+                .await?
+        );
+        assert!(
+            backend
+                .set_expiry_if_matches(&id, old_expiry + Duration::from_mins(30), Some(&target),)
+                .await?
+        );
+        let TieredMetadata::Tombstone(tombstone) = backend.get_tiered_metadata(&id).await? else {
+            panic!("expected tombstone");
+        };
+        assert_eq!(tombstone.time_expires, Some(later));
         Ok(())
     }
 
@@ -1897,6 +2079,7 @@ mod tests {
         let tombstone = Tombstone {
             target: lt_id.clone(),
             expiration_policy: ExpirationPolicy::Manual,
+            time_expires: None,
         };
         create_tombstone(&backend, &hv_id, &tombstone, SystemTime::now()).await?;
 
@@ -1947,6 +2130,7 @@ mod tests {
         let tombstone = Tombstone {
             target: lt_id.clone(),
             expiration_policy: ExpirationPolicy::Manual,
+            time_expires: None,
         };
         create_tombstone(&backend, &hv_id, &tombstone, SystemTime::now()).await?;
         let result = backend
@@ -1993,6 +2177,7 @@ mod tests {
         let tombstone = Tombstone {
             target: id.clone(),
             expiration_policy: ExpirationPolicy::Manual,
+            time_expires: None,
         };
         create_tombstone(&backend, &id, &tombstone, SystemTime::now()).await?;
         let tombstone = backend
@@ -2026,6 +2211,7 @@ mod tests {
         let tombstone = Tombstone {
             target: lt_id.clone(),
             expiration_policy,
+            time_expires: Some(SystemTime::now() + Duration::from_hours(1)),
         };
 
         // First create succeeds.
@@ -2081,6 +2267,7 @@ mod tests {
         let tombstone = Tombstone {
             target: old_lt_id.clone(),
             expiration_policy: ExpirationPolicy::Manual,
+            time_expires: None,
         };
         create_tombstone(&backend, &hv_id, &tombstone, SystemTime::now()).await?;
 
@@ -2088,6 +2275,7 @@ mod tests {
         let write = TieredWrite::Tombstone(Tombstone {
             target: new_lt_id.clone(),
             expiration_policy: ExpirationPolicy::Manual,
+            time_expires: None,
         });
         let swapped = backend
             .compare_and_write(&hv_id, Some(&wrong_lt_id), write.clone())
@@ -2129,6 +2317,7 @@ mod tests {
         let tombstone = Tombstone {
             target: lt_id.clone(),
             expiration_policy: ExpirationPolicy::Manual,
+            time_expires: None,
         };
         create_tombstone(&backend, &id, &tombstone, SystemTime::now()).await?;
 
@@ -2193,6 +2382,7 @@ mod tests {
         let tombstone = Tombstone {
             target: lt_id.clone(),
             expiration_policy: ExpirationPolicy::Manual,
+            time_expires: None,
         };
         create_tombstone(&backend, &id, &tombstone, SystemTime::now()).await?;
 
@@ -2274,10 +2464,7 @@ mod tests {
         Ok(())
     }
 
-    /// A legacy tombstone with TTI policy is upgraded to the new `r`/`t` column format on read.
-    ///
-    /// The bump path calls `put_tombstone_row`, which rewrites the row with `r` + `t` columns.
-    /// The upgraded row has a fresh cell timestamp (≈ now + TTI), so `time_expires` increases.
+    /// A conditional extension upgrades a legacy TTI tombstone to `r`/`t`.
     #[tokio::test]
     async fn test_legacy_tombstone_tti_upgrade() -> Result<()> {
         let backend = create_test_backend().await?;
@@ -2286,8 +2473,9 @@ mod tests {
 
         let tti = Duration::from_hours(2 * 24);
 
-        // Place time_expires inside the bump window but still in the future.
-        let old_deadline = SystemTime::now() + Duration::from_mins(1);
+        // Place time_expires near expiry but still in the future.
+        let old_deadline =
+            crate::backend::common::normalize_expiry(SystemTime::now() + Duration::from_mins(1))?;
         write_legacy_tombstone(
             &backend,
             &id,
@@ -2296,20 +2484,34 @@ mod tests {
         )
         .await?;
 
-        // First read detects the stale TTI and triggers `put_tombstone_row`.
+        // A read observes the legacy row but leaves it unchanged.
         let TieredMetadata::Tombstone(_) = backend.get_tiered_metadata(&id).await? else {
             panic!("expected tombstone");
         };
+        assert_eq!(
+            backend
+                .read_row(&path, None, "test-verify")
+                .await?
+                .and_then(|row| row.time_expires()),
+            Some(old_deadline)
+        );
 
-        // After the bump, the row is rewritten with a fresh timestamp (≈ now + TTI).
+        let requested = SystemTime::now() + tti;
+        assert!(
+            backend
+                .set_expiry_if_matches(&id, requested, Some(&id))
+                .await?
+        );
+
+        // After extension, the row uses the requested timestamp.
         let new_deadline = match backend.read_row(&path, None, "test-verify").await? {
             Some(RowData::Tombstone { time_expires, .. }) => time_expires.unwrap(),
-            _ => panic!("expected tombstone row after bump"),
+            _ => panic!("expected tombstone row after extension"),
         };
 
         assert!(
             new_deadline > old_deadline,
-            "TTI bump should extend tombstone expiry: {old_deadline:?} -> {new_deadline:?}"
+            "explicit extension should extend tombstone expiry: {old_deadline:?} -> {new_deadline:?}"
         );
 
         Ok(())
@@ -2398,6 +2600,7 @@ mod tests {
         let old_tombstone = Tombstone {
             target: old_lt_id,
             expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_secs(0)),
+            time_expires: None,
         };
         create_tombstone(&backend, &id, &old_tombstone, SystemTime::now()).await?;
 
@@ -2405,6 +2608,7 @@ mod tests {
         let new_tombstone = Tombstone {
             target: new_lt_id.clone(),
             expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_hours(1)),
+            time_expires: Some(SystemTime::now() + Duration::from_hours(1)),
         };
         let committed = backend
             .compare_and_write(&id, None, TieredWrite::Tombstone(new_tombstone))
@@ -2433,6 +2637,7 @@ mod tests {
         let tombstone = Tombstone {
             target: lt_id,
             expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_secs(0)),
+            time_expires: None,
         };
         create_tombstone(&backend, &id, &tombstone, SystemTime::now()).await?;
 
@@ -2578,8 +2783,9 @@ mod tests {
         let tombstone = Tombstone {
             target: ObjectId::from_storage_path("attachments/org.1/objects/abc/0199").unwrap(),
             expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_secs(60)),
+            time_expires: Some(SystemTime::now() + Duration::from_secs(60)),
         };
-        let mutations = tombstone_mutations(&tombstone, SystemTime::now()).unwrap();
+        let mutations = tombstone_mutations(&tombstone).unwrap();
 
         assert!(row_size(path, &mutations) > path.len() as u64);
     }
@@ -2647,6 +2853,7 @@ mod tests {
         let tombstone = Tombstone {
             target: ObjectId::random(id.context().clone()),
             expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_secs(0)),
+            time_expires: None,
         };
         create_tombstone(&backend, &id, &tombstone, SystemTime::now()).await?;
         assert_eq!(
@@ -2684,6 +2891,7 @@ mod tests {
         let tombstone = Tombstone {
             target: target.clone(),
             expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_secs(3600)),
+            time_expires: Some(SystemTime::now() + Duration::from_secs(3600)),
         };
         let written = backend
             .compare_and_write(&id, None, TieredWrite::Tombstone(tombstone))
@@ -2704,7 +2912,7 @@ mod tests {
 
     #[cfg(feature = "storage-cogs")]
     #[tokio::test]
-    async fn change_stream_reports_tti_bump_as_an_update() -> Result<()> {
+    async fn change_stream_reports_expiry_extension_as_an_update() -> Result<()> {
         let (backend, producer) = create_test_backend_with_change_stream().await?;
         let id = make_id();
         let metadata = Metadata {
@@ -2722,13 +2930,17 @@ mod tests {
             .await?;
         producer.clear();
 
-        // The stored deadline is far enough below `now + tti` to clear the debounce.
-        backend.get_tiered_object(&id, None).await?;
+        backend
+            .set_expiry(&id, SystemTime::now() + Duration::from_secs(3600))
+            .await?;
 
         let records = producer.records();
-        assert_eq!(records.len(), 1, "expected exactly one bump report");
+        assert_eq!(records.len(), 1, "expected exactly one extension report");
         assert_eq!(records[0].op_type, OpType::Update);
-        assert_eq!(records[0].size, None, "a bump does not change the size");
+        assert_eq!(
+            records[0].size, None,
+            "an extension does not change the size"
+        );
         assert!(records[0].expiration_time.is_some());
 
         Ok(())

--- a/objectstore-service/src/backend/common.rs
+++ b/objectstore-service/src/backend/common.rs
@@ -289,8 +289,8 @@ pub trait HighVolumeBackend: Backend {
     /// of an absent row.
     ///
     /// Returns `true` when the update was applied or its requested state was
-    /// already satisfied. Returns `false` for an absent, expired, manual-policy,
-    /// or conflicting entry.
+    /// already satisfied. Returns `false` for an absent, expired, or conflicting
+    /// entry.
     async fn compare_and_update(
         &self,
         id: &ObjectId,

--- a/objectstore-service/src/backend/common.rs
+++ b/objectstore-service/src/backend/common.rs
@@ -9,7 +9,7 @@ use objectstore_types::resumable::{SessionToken, UploadProgress};
 
 use bytes::Bytes;
 
-use crate::error::{ErrorKind, Result};
+use crate::error::{Error, ErrorKind, Result};
 use crate::id::ObjectId;
 use crate::multipart::{
     AbortMultipartResponse, CompleteMultipartResponse, CompletedPart, InitiateMultipartResponse,
@@ -302,7 +302,7 @@ pub(crate) fn normalize_expiry(expire_at: SystemTime) -> Result<SystemTime> {
     let millis = expire_at
         .duration_since(SystemTime::UNIX_EPOCH)
         .map_err(|error| {
-            crate::error::Error::with_context(
+            Error::with_context(
                 ErrorKind::Internal,
                 "normalizing expiration timestamp",
                 error,
@@ -310,7 +310,7 @@ pub(crate) fn normalize_expiry(expire_at: SystemTime) -> Result<SystemTime> {
         })?
         .as_millis();
     let millis = u64::try_from(millis).map_err(|error| {
-        crate::error::Error::with_context(
+        Error::with_context(
             ErrorKind::Internal,
             "normalizing expiration timestamp",
             error,

--- a/objectstore-service/src/backend/common.rs
+++ b/objectstore-service/src/backend/common.rs
@@ -1,6 +1,7 @@
 //! Shared trait definition and types for all backends.
 
 use std::fmt;
+use std::time::{Duration, SystemTime};
 
 use objectstore_types::metadata::{ExpirationPolicy, Metadata};
 use objectstore_types::range::{ByteRange, ContentRange};
@@ -55,6 +56,17 @@ pub trait Backend: fmt::Debug + Send + Sync + 'static {
             .await?
             .map(|(metadata, _range, _stream)| metadata))
     }
+
+    /// Extends the deadline of an existing object with expiration policy.
+    ///
+    /// The supplied deadline is normalized to millisecond precision. This only
+    /// changes the stored deadline: the expiration policy, duration, payload,
+    /// and all other metadata remain unchanged.
+    ///
+    /// Returns `true` when the deadline was extended or was already at least as
+    /// late as `expire_at`. Returns `false` when the object is absent, expired,
+    /// manually expired, or changed concurrently.
+    async fn set_expiry(&self, id: &ObjectId, expire_at: SystemTime) -> Result<bool>;
 
     /// Deletes the object at the given path.
     async fn delete_object(&self, id: &ObjectId) -> Result<DeleteResponse>;
@@ -221,6 +233,18 @@ pub trait HighVolumeBackend: Backend {
     /// fetching up to 1 MiB of data just to discover a tombstone.
     async fn get_tiered_metadata(&self, id: &ObjectId) -> Result<TieredMetadata>;
 
+    /// Conditionally extends the deadline of an inline object or redirect.
+    ///
+    /// `expected_target = None` requires a live inline object. `Some(target)`
+    /// requires a live redirect to exactly that target. A mismatched, absent,
+    /// expired, or manual-policy entry returns `false`.
+    async fn set_expiry_if_matches(
+        &self,
+        id: &ObjectId,
+        expire_at: SystemTime,
+        expected_target: Option<&ObjectId>,
+    ) -> Result<bool>;
+
     /// Deletes the object only if it is NOT a redirect tombstone.
     ///
     /// Returns `None` after deleting the row (or if the row was already absent),
@@ -263,6 +287,32 @@ pub struct Tombstone {
 
     /// The expiration policy copied from the original object.
     pub expiration_policy: ExpirationPolicy,
+
+    /// The concrete deadline stored on the redirect.
+    pub time_expires: Option<SystemTime>,
+}
+
+/// Normalizes an expiry deadline to the millisecond precision shared by all
+/// backends.
+pub(crate) fn normalize_expiry(expire_at: SystemTime) -> Result<SystemTime> {
+    let millis = expire_at
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map_err(|error| {
+            crate::error::Error::with_context(
+                ErrorKind::Internal,
+                "normalizing expiration timestamp",
+                error,
+            )
+        })?
+        .as_millis();
+    let millis = u64::try_from(millis).map_err(|error| {
+        crate::error::Error::with_context(
+            ErrorKind::Internal,
+            "normalizing expiration timestamp",
+            error,
+        )
+    })?;
+    Ok(SystemTime::UNIX_EPOCH + Duration::from_millis(millis))
 }
 
 /// Typed response from [`HighVolumeBackend::get_tiered_object`].

--- a/objectstore-service/src/backend/common.rs
+++ b/objectstore-service/src/backend/common.rs
@@ -1,7 +1,7 @@
 //! Shared trait definition and types for all backends.
 
 use std::fmt;
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
 use objectstore_types::metadata::{ExpirationPolicy, Metadata};
 use objectstore_types::range::{ByteRange, ContentRange};
@@ -9,7 +9,7 @@ use objectstore_types::resumable::{SessionToken, UploadProgress};
 
 use bytes::Bytes;
 
-use crate::error::{Error, ErrorKind, Result};
+use crate::error::{ErrorKind, Result};
 use crate::id::ObjectId;
 use crate::multipart::{
     AbortMultipartResponse, CompleteMultipartResponse, CompletedPart, InitiateMultipartResponse,
@@ -59,9 +59,8 @@ pub trait Backend: fmt::Debug + Send + Sync + 'static {
 
     /// Extends the deadline of an existing object with expiration policy.
     ///
-    /// The supplied deadline is normalized to millisecond precision. This only
-    /// changes the stored deadline: the expiration policy, duration, payload,
-    /// and all other metadata remain unchanged.
+    /// This only changes the stored deadline: the expiration policy, duration,
+    /// payload, and all other metadata remain unchanged.
     ///
     /// Returns `true` when the deadline was extended or was already at least as
     /// late as `expire_at`. Returns `false` when the object is absent, expired,
@@ -294,29 +293,6 @@ pub struct Tombstone {
 
     /// The concrete deadline stored on the redirect.
     pub time_expires: Option<SystemTime>,
-}
-
-/// Normalizes an expiry deadline to the millisecond precision shared by all
-/// backends.
-pub(crate) fn normalize_expiry(expire_at: SystemTime) -> Result<SystemTime> {
-    let millis = expire_at
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .map_err(|error| {
-            Error::with_context(
-                ErrorKind::Internal,
-                "normalizing expiration timestamp",
-                error,
-            )
-        })?
-        .as_millis();
-    let millis = u64::try_from(millis).map_err(|error| {
-        Error::with_context(
-            ErrorKind::Internal,
-            "normalizing expiration timestamp",
-            error,
-        )
-    })?;
-    Ok(SystemTime::UNIX_EPOCH + Duration::from_millis(millis))
 }
 
 /// Typed response from [`HighVolumeBackend::get_tiered_object`].

--- a/objectstore-service/src/backend/common.rs
+++ b/objectstore-service/src/backend/common.rs
@@ -295,6 +295,13 @@ pub struct Tombstone {
     pub time_expires: Option<SystemTime>,
 }
 
+impl Tombstone {
+    /// Returns whether the tombstone has expired at the given time.
+    pub fn is_expired(&self, now: SystemTime) -> bool {
+        self.time_expires.is_some_and(|deadline| deadline < now)
+    }
+}
+
 /// Typed response from [`HighVolumeBackend::get_tiered_object`].
 pub enum TieredGet {
     /// A real object was found.

--- a/objectstore-service/src/backend/common.rs
+++ b/objectstore-service/src/backend/common.rs
@@ -233,18 +233,6 @@ pub trait HighVolumeBackend: Backend {
     /// fetching up to 1 MiB of data just to discover a tombstone.
     async fn get_tiered_metadata(&self, id: &ObjectId) -> Result<TieredMetadata>;
 
-    /// Conditionally extends the deadline of an inline object or redirect.
-    ///
-    /// `expected_target = None` requires a live inline object. `Some(target)`
-    /// requires a live redirect to exactly that target. A mismatched, absent,
-    /// expired, or manual-policy entry returns `false`.
-    async fn set_expiry_if_matches(
-        &self,
-        id: &ObjectId,
-        expire_at: SystemTime,
-        expected_target: Option<&ObjectId>,
-    ) -> Result<bool>;
-
     /// Deletes the object only if it is NOT a redirect tombstone.
     ///
     /// Returns `None` after deleting the row (or if the row was already absent),
@@ -273,6 +261,22 @@ pub trait HighVolumeBackend: Backend {
         id: &ObjectId,
         current: Option<&ObjectId>,
         write: TieredWrite,
+    ) -> Result<bool>;
+
+    /// Atomically updates an existing row if its kind and redirect target match.
+    ///
+    /// `current = None` requires a live inline object. `Some(target)` requires
+    /// a live redirect to exactly that target. Updates never authorize creation
+    /// of an absent row.
+    ///
+    /// Returns `true` when the update was applied or its requested state was
+    /// already satisfied. Returns `false` for an absent, expired, manual-policy,
+    /// or conflicting entry.
+    async fn compare_and_update(
+        &self,
+        id: &ObjectId,
+        current: Option<&ObjectId>,
+        update: TieredUpdate,
     ) -> Result<bool>;
 }
 
@@ -369,6 +373,13 @@ impl TieredWrite {
             _ => None,
         }
     }
+}
+
+/// The in-place operation performed by [`HighVolumeBackend::compare_and_update`].
+#[derive(Clone, Debug)]
+pub enum TieredUpdate {
+    /// Extend the deadline while preserving the policy, payload, and other metadata.
+    SetExpiry(SystemTime),
 }
 
 /// Creates a reqwest client with required defaults.

--- a/objectstore-service/src/backend/counting.rs
+++ b/objectstore-service/src/backend/counting.rs
@@ -91,8 +91,7 @@ impl Backend for CountingBackend {
     }
 
     async fn set_expiry(&self, id: &ObjectId, expire_at: SystemTime) -> Result<bool> {
-        // Renewal is an implementation detail of the original client read and
-        // must not add another client-operation COGS unit.
+        count(&id.context.usecase);
         self.inner.set_expiry(id, expire_at).await
     }
 

--- a/objectstore-service/src/backend/counting.rs
+++ b/objectstore-service/src/backend/counting.rs
@@ -15,6 +15,7 @@
 //! [`StreamExecutor`]: crate::streaming::StreamExecutor
 
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use objectstore_types::metadata::Metadata;
 use objectstore_types::range::ByteRange;
@@ -85,6 +86,12 @@ impl Backend for CountingBackend {
     async fn get_metadata(&self, id: &ObjectId) -> Result<MetadataResponse> {
         count(&id.context.usecase);
         self.inner.get_metadata(id).await
+    }
+
+    async fn set_expiry(&self, id: &ObjectId, expire_at: SystemTime) -> Result<bool> {
+        // Renewal is an implementation detail of the original client read and
+        // must not add another client-operation COGS unit.
+        self.inner.set_expiry(id, expire_at).await
     }
 
     async fn delete_object(&self, id: &ObjectId) -> Result<DeleteResponse> {

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -640,9 +640,7 @@ impl GcsBackend {
         let access_time = SystemTime::now();
 
         // Filter already expired objects but leave them to garbage collection
-        if metadata.expiration_policy.is_timeout()
-            && metadata.time_expires.is_some_and(|ts| ts < access_time)
-        {
+        if metadata.is_expired(access_time) {
             objectstore_log::debug!("Object found but past expiry");
             return Ok(None);
         }
@@ -891,12 +889,12 @@ impl Backend for GcsBackend {
         let Some(current_expiry) = metadata.time_expires else {
             return Ok(false);
         };
+
         let now = SystemTime::now();
-        if metadata.expiration_policy.is_manual() || current_expiry < now {
-            return Ok(false);
-        }
-        if current_expiry >= expire_at {
-            return Ok(true);
+        if current_expiry < now {
+            return Ok(false); // already expired
+        } else if current_expiry >= expire_at {
+            return Ok(true); // already satisfied
         }
 
         // The metadata observation is not atomic with wall-clock expiry or

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -859,7 +859,6 @@ impl Backend for GcsBackend {
 
     #[tracing::instrument(level = "debug", skip(self))]
     async fn set_expiry(&self, id: &ObjectId, expire_at: SystemTime) -> Result<bool> {
-        let expire_at = common::normalize_expiry(expire_at)?;
         let object_url = self.object_url(id)?;
         let object = self
             .with_retry("get_metadata", || async {
@@ -1665,7 +1664,7 @@ mod tests {
         assert!(backend.set_expiry(&id, requested).await?);
         assert_eq!(
             backend.get_metadata(&id).await?.unwrap().time_expires,
-            Some(common::normalize_expiry(requested)?)
+            Some(requested)
         );
 
         // Verify the payload is still intact after extension.
@@ -1743,7 +1742,7 @@ mod tests {
             .unwrap()
             .time_expires
             .unwrap();
-        assert_eq!(post_expiry, common::normalize_expiry(requested)?);
+        assert_eq!(post_expiry, requested);
 
         Ok(())
     }

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -960,71 +960,96 @@ impl Backend for GcsBackend {
     async fn get_object(&self, id: &ObjectId, range: Option<ByteRange>) -> Result<GetResponse> {
         objectstore_log::debug!("Reading from GCS backend");
         let object_url = self.object_url(id)?;
+        let mut generation_retry_count = 0usize;
 
-        let Some(gcs_metadata) = self.get_gcs_metadata(&object_url).await? else {
-            return Ok(None);
-        };
+        loop {
+            let Some(gcs_metadata) = self.get_gcs_metadata(&object_url).await? else {
+                return Ok(None);
+            };
 
-        let mut download_url = object_url;
-        download_url
-            .query_pairs_mut()
-            .append_pair("alt", "media")
-            .append_pair("ifGenerationMatch", &gcs_metadata.generation);
+            let mut download_url = object_url.clone();
+            download_url
+                .query_pairs_mut()
+                .append_pair("alt", "media")
+                .append_pair("ifGenerationMatch", &gcs_metadata.generation);
 
-        let payload_response = self
-            .with_retry("get_payload", || async {
-                let mut req = self.request(Method::GET, download_url.clone()).await?;
-                if let Some(r) = range {
-                    req = req.header(header::RANGE, r.to_header_value());
+            let payload_response = self
+                .with_retry("get_payload", || async {
+                    let mut req = self.request(Method::GET, download_url.clone()).await?;
+                    if let Some(r) = range {
+                        req = req.header(header::RANGE, r.to_header_value());
+                    }
+
+                    let resp = req
+                        .send_traced()
+                        .await
+                        .reqwest_context("getting a GCS object payload")?;
+
+                    if resp.status() == StatusCode::PRECONDITION_FAILED {
+                        resp.drain_body().await;
+                        return Ok(None);
+                    }
+
+                    if resp.status() == StatusCode::RANGE_NOT_SATISFIABLE {
+                        let raw = resp
+                            .headers()
+                            .get(header::CONTENT_RANGE)
+                            .and_then(|v| v.to_str().ok());
+                        let total = raw.and_then(ContentRange::parse_unsatisfiable_total);
+                        let err = match total {
+                            Some(total) => ErrorKind::RangeNotSatisfiable { total }.into(),
+                            None => Error::new(
+                                ErrorKind::BackendFailure,
+                                "invalid GCS 416 Content-Range",
+                            ),
+                        };
+                        resp.drain_body().await;
+                        return Err(err);
+                    }
+
+                    resp.check_error("getting a GCS object payload")
+                        .await
+                        .map(Some)
+                })
+                .await?;
+
+            let Some(payload_response) = payload_response else {
+                if generation_retry_count >= REQUEST_RETRY_COUNT {
+                    objectstore_metrics::count!("gcs.failures", action = "get_object");
+                    return Err(Error::new(
+                        ErrorKind::BackendFailure,
+                        "GCS object kept changing while being read",
+                    ));
                 }
 
-                let resp = req
-                    .send_traced()
-                    .await
-                    .reqwest_context("getting a GCS object payload")?;
+                generation_retry_count += 1;
+                objectstore_metrics::count!("gcs.retries", action = "get_object");
+                continue;
+            };
 
-                if resp.status() == StatusCode::RANGE_NOT_SATISFIABLE {
-                    let raw = resp
+            let content_range = if payload_response.status() == StatusCode::PARTIAL_CONTENT {
+                Some(
+                    payload_response
                         .headers()
                         .get(header::CONTENT_RANGE)
-                        .and_then(|v| v.to_str().ok());
-                    let total = raw.and_then(ContentRange::parse_unsatisfiable_total);
-                    let err = match total {
-                        Some(total) => ErrorKind::RangeNotSatisfiable { total }.into(),
-                        None => {
-                            Error::new(ErrorKind::BackendFailure, "invalid GCS 416 Content-Range")
-                        }
-                    };
-                    resp.drain_body().await;
-                    return Err(err);
-                }
+                        .and_then(|v| v.to_str().ok())
+                        .and_then(|s| s.parse::<ContentRange>().ok())
+                        .ok_or_else(|| {
+                            Error::new(ErrorKind::BackendFailure, "missing GCS 206 Content-Range")
+                        })?,
+                )
+            } else {
+                None
+            };
 
-                resp.check_error("getting a GCS object payload").await
-            })
-            .await?;
+            let stream = payload_response
+                .bytes_stream()
+                .map_err(io::Error::other)
+                .boxed();
 
-        let content_range = if payload_response.status() == StatusCode::PARTIAL_CONTENT {
-            Some(
-                payload_response
-                    .headers()
-                    .get(header::CONTENT_RANGE)
-                    .and_then(|v| v.to_str().ok())
-                    .and_then(|s| s.parse::<ContentRange>().ok())
-                    .ok_or_else(|| {
-                        Error::new(ErrorKind::BackendFailure, "missing GCS 206 Content-Range")
-                    })?,
-            )
-        } else {
-            None
-        };
-
-        let stream = payload_response
-            .bytes_stream()
-            .map_err(io::Error::other)
-            .boxed();
-
-        let metadata = gcs_metadata.into_metadata()?;
-        Ok(Some((metadata, content_range, stream)))
+            let metadata = gcs_metadata.into_metadata()?;
+            return Ok(Some((metadata, content_range, stream)));
+        }
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
@@ -1637,7 +1662,11 @@ impl MultipartUploadBackend for GcsBackend {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+    use std::io::{Read, Write};
+    use std::net::{TcpListener, TcpStream};
     use std::num::{NonZeroU32, NonZeroU64};
+    use std::sync::mpsc;
+    use std::thread;
     use std::time::Duration;
 
     use anyhow::Result;
@@ -1668,6 +1697,63 @@ mod tests {
                 .await?
                 .ok_or_else(|| Error::from(ErrorKind::Unsupported).into())
         }
+    }
+
+    fn read_http_request(connection: &mut TcpStream) -> String {
+        let mut bytes = Vec::new();
+        let mut byte = [0];
+        while !bytes.ends_with(b"\r\n\r\n") {
+            connection.read_exact(&mut byte).unwrap();
+            bytes.push(byte[0]);
+        }
+        String::from_utf8(bytes).unwrap()
+    }
+
+    fn write_http_response(
+        connection: &mut TcpStream,
+        status: &str,
+        content_type: &str,
+        body: &str,
+    ) {
+        write!(
+            connection,
+            "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        )
+        .unwrap();
+    }
+
+    fn start_generation_race_server()
+    -> (String, mpsc::Receiver<Vec<String>>, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let endpoint = format!("http://{}", listener.local_addr().unwrap());
+        let (request_tx, request_rx) = mpsc::channel();
+        let server = thread::spawn(move || {
+            let responses = [
+                (
+                    "200 OK",
+                    "application/json",
+                    r#"{"contentType":"text/old","generation":"1","metageneration":"1"}"#,
+                ),
+                ("412 Precondition Failed", "text/plain", "stale generation"),
+                (
+                    "200 OK",
+                    "application/json",
+                    r#"{"contentType":"text/new","generation":"2","metageneration":"1"}"#,
+                ),
+                ("200 OK", "text/plain", "new"),
+            ];
+            let mut requests = Vec::new();
+
+            for (status, content_type, body) in responses {
+                let (mut connection, _) = listener.accept().unwrap();
+                requests.push(read_http_request(&mut connection));
+                write_http_response(&mut connection, status, content_type, body);
+            }
+
+            request_tx.send(requests).unwrap();
+        });
+        (endpoint, request_rx, server)
     }
 
     const RESUMABLE_CHUNK_SIZE: usize = 256 * 1024;
@@ -1756,6 +1842,34 @@ mod tests {
 
     fn nonzero(value: u64) -> NonZeroU64 {
         NonZeroU64::new(value).unwrap()
+    }
+
+    #[tokio::test]
+    async fn get_object_retries_from_metadata_after_generation_conflict() -> Result<()> {
+        let (endpoint, request_rx, server) = start_generation_race_server();
+        let backend = GcsBackend::new(
+            GcsConfig {
+                endpoint: Some(endpoint),
+                bucket: "bucket".into(),
+                cogs: None,
+            },
+            &ChangeStreamFactory::default(),
+        )
+        .await?;
+
+        let (metadata, _, stream) = backend.get_object(&make_id(), None).await?.unwrap();
+        assert_eq!(metadata.content_type, "text/new");
+        assert_eq!(stream::read_to_vec(stream).await?, b"new");
+
+        let requests = request_rx.recv().unwrap();
+        assert_eq!(requests.len(), 4);
+        assert!(!requests[0].contains("alt=media"));
+        assert!(requests[1].contains("alt=media&ifGenerationMatch=1"));
+        assert!(!requests[2].contains("alt=media"));
+        assert!(requests[3].contains("alt=media&ifGenerationMatch=2"));
+        server.join().unwrap();
+
+        Ok(())
     }
 
     #[test]

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -387,7 +387,7 @@ fn metadata_to_gcs_headers(metadata: &Metadata) -> Result<header::HeaderMap> {
     let mut headers = header::HeaderMap::new();
 
     if let Some(custom_time) = metadata.time_expires {
-        let formatted = humantime::format_rfc3339_seconds(custom_time);
+        let formatted = humantime::format_rfc3339_millis(custom_time);
         headers.insert(
             HeaderName::from_static("x-goog-custom-time"),
             formatted
@@ -603,17 +603,9 @@ impl GcsBackend {
         }
     }
 
-    /// Fetches the GCS object metadata (without the payload), bumps TTI if
-    /// needed, and returns the parsed [`Metadata`].
-    ///
-    /// `id` is only used to attribute a TTI bump to the right record in the change stream; the
-    /// request itself is addressed by `object_url`.
+    /// Fetches GCS object metadata without modifying the object.
     #[tracing::instrument(level = "debug", fields(%object_url), skip(self))]
-    async fn fetch_gcs_metadata(
-        &self,
-        id: &ObjectId,
-        object_url: &Url,
-    ) -> Result<Option<Metadata>> {
+    async fn fetch_gcs_metadata(&self, object_url: &Url) -> Result<Option<Metadata>> {
         let metadata_opt = self
             .with_retry("get_metadata", || async {
                 let resp = self
@@ -644,11 +636,7 @@ impl GcsBackend {
             return Ok(None);
         };
 
-        let generation = gcs_metadata.generation.clone();
-        let metageneration = gcs_metadata.metageneration.clone();
         let metadata = gcs_metadata.into_metadata()?;
-
-        // TODO: Inject the access time from the request.
         let access_time = SystemTime::now();
 
         // Filter already expired objects but leave them to garbage collection
@@ -657,23 +645,6 @@ impl GcsBackend {
         {
             objectstore_log::debug!("Object found but past expiry");
             return Ok(None);
-        }
-
-        // TODO: Schedule into background persistently so this doesn't get lost on restarts
-        if let Some(new_expire_at) = metadata.check_tti_bump(access_time) {
-            let bumped = self
-                .update_custom_time(
-                    object_url.clone(),
-                    new_expire_at,
-                    &generation,
-                    &metageneration,
-                )
-                .await?;
-
-            // Only report a deadline that actually moved.
-            if bumped {
-                self.change_stream.update(id, Some(new_expire_at));
-            }
         }
 
         Ok(Some(metadata))
@@ -712,9 +683,12 @@ impl GcsBackend {
                 .await
                 .reqwest_context("updating GCS custom time")?;
 
-            // Bumping TTI is opportunistic. A concurrent metadata writer won the CAS race, so
-            // leave its update intact and let a future read evaluate the TTI again.
-            if response.status() == StatusCode::PRECONDITION_FAILED {
+            // A concurrent metadata writer won the CAS race. Leave its update
+            // intact; automatic renewal can be retried by a later read.
+            if matches!(
+                response.status(),
+                StatusCode::NOT_FOUND | StatusCode::PRECONDITION_FAILED
+            ) {
                 response.drain_body().await;
                 return Ok(false);
             }
@@ -814,7 +788,7 @@ impl Backend for GcsBackend {
         objectstore_log::debug!("Reading from GCS backend");
         let object_url = self.object_url(id)?;
 
-        let Some(metadata) = self.fetch_gcs_metadata(id, &object_url).await? else {
+        let Some(metadata) = self.fetch_gcs_metadata(&object_url).await? else {
             return Ok(None);
         };
 
@@ -880,7 +854,62 @@ impl Backend for GcsBackend {
     async fn get_metadata(&self, id: &ObjectId) -> Result<MetadataResponse> {
         objectstore_log::debug!("Reading metadata from GCS backend");
         let object_url = self.object_url(id)?;
-        self.fetch_gcs_metadata(id, &object_url).await
+        self.fetch_gcs_metadata(&object_url).await
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    async fn set_expiry(&self, id: &ObjectId, expire_at: SystemTime) -> Result<bool> {
+        let expire_at = super::common::normalize_expiry(expire_at)?;
+        let object_url = self.object_url(id)?;
+        let object = self
+            .with_retry("get_metadata", || async {
+                let response = self
+                    .request(Method::GET, object_url.clone())
+                    .await?
+                    .send_traced()
+                    .await
+                    .reqwest_context("getting GCS object metadata for expiry extension")?;
+                if response.status() == StatusCode::NOT_FOUND {
+                    response.drain_body().await;
+                    return Ok(None);
+                }
+                let object = response
+                    .check_error("getting GCS object metadata for expiry extension")
+                    .await?
+                    .json::<GcsObject>()
+                    .await
+                    .reqwest_context("getting GCS object metadata for expiry extension")?;
+                Ok(Some(object))
+            })
+            .await?;
+
+        let Some(object) = object else {
+            return Ok(false);
+        };
+        let generation = object.generation.clone();
+        let metageneration = object.metageneration.clone();
+        let metadata = object.into_metadata()?;
+        let Some(current_expiry) = metadata.time_expires else {
+            return Ok(false);
+        };
+        let now = SystemTime::now();
+        if metadata.expiration_policy.is_manual() || current_expiry < now {
+            return Ok(false);
+        }
+        if current_expiry >= expire_at {
+            return Ok(true);
+        }
+
+        // The metadata observation is not atomic with wall-clock expiry or
+        // native GCS lifecycle collection. Fixed generation preconditions keep
+        // transport retries from applying to a replacement object.
+        let applied = self
+            .update_custom_time(object_url, expire_at, &generation, &metageneration)
+            .await?;
+        if applied {
+            self.change_stream.update(id, Some(expire_at));
+        }
+        Ok(applied)
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
@@ -1599,7 +1628,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_metadata_bumps_tti() -> Result<()> {
+    async fn test_reads_do_not_bump_tti_and_set_expiry_preserves_payload() -> Result<()> {
         let backend = create_test_backend().await?;
 
         let id = make_id();
@@ -1615,7 +1644,7 @@ mod tests {
             .put_object(&id, &metadata, stream::single("hello, world"))
             .await?;
 
-        // Backdate custom_time so it falls inside the bump window.
+        // Backdate custom_time while keeping the object live.
         let object_url = backend.object_url(&id)?;
         let old_deadline = SystemTime::now() + Duration::from_mins(1);
         let (generation, metageneration) =
@@ -1624,19 +1653,22 @@ mod tests {
             .update_custom_time(object_url, old_deadline, &generation, &metageneration)
             .await?;
 
-        // First get_metadata sees the old timestamp and triggers a TTI bump.
+        // Backend reads return the stored deadline without modifying it.
         let pre_meta = backend.get_metadata(&id).await?.unwrap();
         let pre_expiry = pre_meta.time_expires.unwrap();
-
-        // Second get_metadata sees the bumped timestamp.
-        let post_meta = backend.get_metadata(&id).await?.unwrap();
-        let post_expiry = post_meta.time_expires.unwrap();
-        assert!(
-            post_expiry > pre_expiry,
-            "TTI bump should have extended the expiry: {pre_expiry:?} -> {post_expiry:?}"
+        assert_eq!(
+            backend.get_metadata(&id).await?.unwrap().time_expires,
+            Some(pre_expiry)
         );
 
-        // Verify the payload is still intact after the bump.
+        let requested = SystemTime::now() + tti;
+        assert!(backend.set_expiry(&id, requested).await?);
+        assert_eq!(
+            backend.get_metadata(&id).await?.unwrap().time_expires,
+            Some(crate::backend::common::normalize_expiry(requested)?)
+        );
+
+        // Verify the payload is still intact after extension.
         let (_, _, stream) = backend.get_object(&id, None).await?.unwrap();
         let payload = stream::read_to_vec(stream).await?;
         assert_eq!(&payload, b"hello, world");
@@ -1678,7 +1710,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_short_tti_bumps() -> Result<()> {
+    async fn test_short_tti_can_be_extended_explicitly() -> Result<()> {
         let backend = create_test_backend().await?;
 
         let id = make_id();
@@ -1694,7 +1726,7 @@ mod tests {
             .put_object(&id, &metadata, stream::single("hello, world"))
             .await?;
 
-        // Backdate custom_time so it falls inside the bump window.
+        // Backdate custom_time while keeping the object live.
         let object_url = backend.object_url(&id)?;
         let old_deadline = SystemTime::now() + Duration::from_mins(1);
         let (generation, metageneration) =
@@ -1703,18 +1735,71 @@ mod tests {
             .update_custom_time(object_url, old_deadline, &generation, &metageneration)
             .await?;
 
-        // First get_metadata triggers the bump.
-        let pre_meta = backend.get_metadata(&id).await?.unwrap();
-        let pre_expiry = pre_meta.time_expires.unwrap();
-
-        // Second get_metadata sees the bumped timestamp.
-        let post_meta = backend.get_metadata(&id).await?.unwrap();
-        let post_expiry = post_meta.time_expires.unwrap();
-        assert!(
-            post_expiry > pre_expiry,
-            "Short TTI bump should have extended the expiry: {pre_expiry:?} -> {post_expiry:?}"
+        let requested = SystemTime::now() + tti;
+        assert!(backend.set_expiry(&id, requested).await?);
+        let post_expiry = backend
+            .get_metadata(&id)
+            .await?
+            .unwrap()
+            .time_expires
+            .unwrap();
+        assert_eq!(
+            post_expiry,
+            crate::backend::common::normalize_expiry(requested)?
         );
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn update_custom_time_treats_stale_preconditions_and_missing_objects_as_conflicts()
+    -> Result<()> {
+        let backend = create_test_backend().await?;
+        let id = make_id();
+        let metadata = Metadata {
+            expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_hours(1)),
+            time_expires: Some(SystemTime::now() + Duration::from_mins(10)),
+            ..Default::default()
+        };
+        backend
+            .put_object(&id, &metadata, stream::single("payload"))
+            .await?;
+        let object_url = backend.object_url(&id)?;
+        let (generation, metageneration) =
+            get_generation_matches(&backend, object_url.clone()).await?;
+
+        assert!(
+            backend
+                .update_custom_time(
+                    object_url.clone(),
+                    SystemTime::now() + Duration::from_hours(1),
+                    &generation,
+                    &metageneration,
+                )
+                .await?
+        );
+        assert!(
+            !backend
+                .update_custom_time(
+                    object_url.clone(),
+                    SystemTime::now() + Duration::from_hours(2),
+                    &generation,
+                    &metageneration,
+                )
+                .await?
+        );
+
+        backend.delete_object(&id).await?;
+        assert!(
+            !backend
+                .update_custom_time(
+                    object_url,
+                    SystemTime::now() + Duration::from_hours(2),
+                    &generation,
+                    &metageneration,
+                )
+                .await?
+        );
         Ok(())
     }
 
@@ -2273,7 +2358,7 @@ mod tests {
 
     #[cfg(feature = "storage-cogs")]
     #[tokio::test]
-    async fn change_stream_reports_tti_bump_as_an_update() -> Result<()> {
+    async fn change_stream_reports_expiry_extension_as_an_update() -> Result<()> {
         let (backend, producer) = create_test_backend_with_change_stream().await?;
         let id = make_id();
         let metadata = Metadata {
@@ -2291,7 +2376,9 @@ mod tests {
             .await?;
         producer.clear();
 
-        backend.get_metadata(&id).await?;
+        backend
+            .set_expiry(&id, SystemTime::now() + Duration::from_secs(3600))
+            .await?;
 
         let records = producer.records();
         assert_eq!(records.len(), 1);
@@ -2304,7 +2391,7 @@ mod tests {
 
     #[cfg(feature = "storage-cogs")]
     #[tokio::test]
-    async fn change_stream_reports_nothing_when_tti_is_not_bumped() -> Result<()> {
+    async fn change_stream_reports_nothing_for_side_effect_free_read() -> Result<()> {
         let (backend, producer) = create_test_backend_with_change_stream().await?;
         let id = make_id();
         let metadata = Metadata {

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -859,7 +859,7 @@ impl Backend for GcsBackend {
 
     #[tracing::instrument(level = "debug", skip(self))]
     async fn set_expiry(&self, id: &ObjectId, expire_at: SystemTime) -> Result<bool> {
-        let expire_at = super::common::normalize_expiry(expire_at)?;
+        let expire_at = common::normalize_expiry(expire_at)?;
         let object_url = self.object_url(id)?;
         let object = self
             .with_retry("get_metadata", || async {
@@ -1665,7 +1665,7 @@ mod tests {
         assert!(backend.set_expiry(&id, requested).await?);
         assert_eq!(
             backend.get_metadata(&id).await?.unwrap().time_expires,
-            Some(crate::backend::common::normalize_expiry(requested)?)
+            Some(common::normalize_expiry(requested)?)
         );
 
         // Verify the payload is still intact after extension.
@@ -1743,10 +1743,7 @@ mod tests {
             .unwrap()
             .time_expires
             .unwrap();
-        assert_eq!(
-            post_expiry,
-            crate::backend::common::normalize_expiry(requested)?
-        );
+        assert_eq!(post_expiry, common::normalize_expiry(requested)?);
 
         Ok(())
     }

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -328,6 +328,7 @@ impl GcsObject {
     }
 }
 
+/// The object and metadata versions of a GCS object, used for conditional updates.
 type GcsGenerations<'a> = (&'a str, &'a str);
 
 /// Key for [`GcsObject::metadata`].
@@ -402,7 +403,7 @@ fn metadata_to_gcs_headers(metadata: &Metadata) -> Result<header::HeaderMap> {
     let mut headers = header::HeaderMap::new();
 
     if let Some(custom_time) = metadata.time_expires {
-        let formatted = humantime::format_rfc3339_millis(custom_time);
+        let formatted = humantime::format_rfc3339_seconds(custom_time);
         headers.insert(
             HeaderName::from_static("x-goog-custom-time"),
             formatted

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -751,7 +751,7 @@ impl GcsBackend {
                 .reqwest_context("updating GCS custom time")?;
 
             // A concurrent metadata writer won the CAS race. Leave its update
-            // intact; automatic renewal can be retried by a later read.
+            // intact.
             if matches!(
                 response.status(),
                 StatusCode::NOT_FOUND | StatusCode::PRECONDITION_FAILED

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -193,6 +193,19 @@ impl GcsObject {
             .sum()
     }
 
+    /// Returns `true` if the object is expired at the given access time.
+    pub fn is_expired(&self, access_time: SystemTime) -> bool {
+        match self.custom_time {
+            Some(expires_at) => access_time > expires_at,
+            None => false,
+        }
+    }
+
+    /// Returns the generation and metageneration of this object.
+    pub fn generations(&self) -> GcsGenerations<'_> {
+        (&self.generation, &self.metageneration)
+    }
+
     /// Converts our Metadata type to GCS JSON object metadata.
     pub fn from_metadata(metadata: &Metadata) -> Self {
         let mut gcs_object = GcsObject {
@@ -314,6 +327,8 @@ impl GcsObject {
         })
     }
 }
+
+type GcsGenerations<'a> = (&'a str, &'a str);
 
 /// Key for [`GcsObject::metadata`].
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
@@ -605,7 +620,7 @@ impl GcsBackend {
 
     /// Fetches GCS object metadata without modifying the object.
     #[tracing::instrument(level = "debug", fields(%object_url), skip(self))]
-    async fn fetch_gcs_metadata(&self, object_url: &Url) -> Result<Option<Metadata>> {
+    async fn get_gcs_metadata(&self, object_url: &Url) -> Result<Option<GcsObject>> {
         let metadata_opt = self
             .with_retry("get_metadata", || async {
                 let resp = self
@@ -636,16 +651,14 @@ impl GcsBackend {
             return Ok(None);
         };
 
-        let metadata = gcs_metadata.into_metadata()?;
-        let access_time = SystemTime::now();
-
         // Filter already expired objects but leave them to garbage collection
-        if metadata.is_expired(access_time) {
+        let access_time = SystemTime::now();
+        if gcs_metadata.is_expired(access_time) {
             objectstore_log::debug!("Object found but past expiry");
             return Ok(None);
         }
 
-        Ok(Some(metadata))
+        Ok(Some(gcs_metadata))
     }
 
     /// Moves an object's `customTime`, which is what its lifecycle expiry is anchored to.
@@ -656,8 +669,7 @@ impl GcsBackend {
         &self,
         object_url: Url,
         custom_time: SystemTime,
-        generation: &str,
-        metageneration: &str,
+        generations: GcsGenerations<'_>,
     ) -> Result<bool> {
         #[derive(Debug, Serialize)]
         #[serde(rename_all = "camelCase")]
@@ -669,8 +681,8 @@ impl GcsBackend {
         let mut object_url = object_url;
         object_url
             .query_pairs_mut()
-            .append_pair("ifGenerationMatch", generation)
-            .append_pair("ifMetagenerationMatch", metageneration);
+            .append_pair("ifGenerationMatch", generations.0)
+            .append_pair("ifMetagenerationMatch", generations.1);
 
         self.with_retry("update_custom_time", || async {
             let response = self
@@ -786,12 +798,15 @@ impl Backend for GcsBackend {
         objectstore_log::debug!("Reading from GCS backend");
         let object_url = self.object_url(id)?;
 
-        let Some(metadata) = self.fetch_gcs_metadata(&object_url).await? else {
+        let Some(gcs_metadata) = self.get_gcs_metadata(&object_url).await? else {
             return Ok(None);
         };
 
         let mut download_url = object_url;
-        download_url.query_pairs_mut().append_pair("alt", "media");
+        download_url
+            .query_pairs_mut()
+            .append_pair("alt", "media")
+            .append_pair("ifGenerationMatch", &gcs_metadata.generation);
 
         let payload_response = self
             .with_retry("get_payload", || async {
@@ -845,6 +860,7 @@ impl Backend for GcsBackend {
             .map_err(io::Error::other)
             .boxed();
 
+        let metadata = gcs_metadata.into_metadata()?;
         Ok(Some((metadata, content_range, stream)))
     }
 
@@ -852,60 +868,32 @@ impl Backend for GcsBackend {
     async fn get_metadata(&self, id: &ObjectId) -> Result<MetadataResponse> {
         objectstore_log::debug!("Reading metadata from GCS backend");
         let object_url = self.object_url(id)?;
-        self.fetch_gcs_metadata(&object_url).await
+        match self.get_gcs_metadata(&object_url).await? {
+            Some(gcs_metadata) => Ok(Some(gcs_metadata.into_metadata()?)),
+            None => Ok(None),
+        }
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
     async fn set_expiry(&self, id: &ObjectId, expire_at: SystemTime) -> Result<bool> {
         let object_url = self.object_url(id)?;
-        let object = self
-            .with_retry("get_metadata", || async {
-                let response = self
-                    .request(Method::GET, object_url.clone())
-                    .await?
-                    .send_traced()
-                    .await
-                    .reqwest_context("getting GCS object metadata for expiry extension")?;
-                if response.status() == StatusCode::NOT_FOUND {
-                    response.drain_body().await;
-                    return Ok(None);
-                }
-                let object = response
-                    .check_error("getting GCS object metadata for expiry extension")
-                    .await?
-                    .json::<GcsObject>()
-                    .await
-                    .reqwest_context("getting GCS object metadata for expiry extension")?;
-                Ok(Some(object))
-            })
-            .await?;
-
-        let Some(object) = object else {
+        let Some(object) = self.get_gcs_metadata(&object_url).await? else {
             return Ok(false);
         };
-        let generation = object.generation.clone();
-        let metageneration = object.metageneration.clone();
-        let metadata = object.into_metadata()?;
-        let Some(current_expiry) = metadata.time_expires else {
+        let Some(current_expiry) = object.custom_time else {
             return Ok(false);
         };
-
-        let now = SystemTime::now();
-        if current_expiry < now {
-            return Ok(false); // already expired
-        } else if current_expiry >= expire_at {
+        if current_expiry >= expire_at {
             return Ok(true); // already satisfied
         }
 
-        // The metadata observation is not atomic with wall-clock expiry or
-        // native GCS lifecycle collection. Fixed generation preconditions keep
-        // transport retries from applying to a replacement object.
         let applied = self
-            .update_custom_time(object_url, expire_at, &generation, &metageneration)
+            .update_custom_time(object_url, expire_at, object.generations())
             .await?;
         if applied {
             self.change_stream.update(id, Some(expire_at));
         }
+
         Ok(applied)
     }
 
@@ -1353,7 +1341,7 @@ mod tests {
         })
     }
 
-    async fn get_generation_matches(
+    async fn get_gcs_generations(
         backend: &GcsBackend,
         object_url: Url,
     ) -> Result<(String, String)> {
@@ -1644,10 +1632,9 @@ mod tests {
         // Backdate custom_time while keeping the object live.
         let object_url = backend.object_url(&id)?;
         let old_deadline = SystemTime::now() + Duration::from_mins(1);
-        let (generation, metageneration) =
-            get_generation_matches(&backend, object_url.clone()).await?;
+        let generations = get_gcs_generations(&backend, object_url.clone()).await?;
         backend
-            .update_custom_time(object_url, old_deadline, &generation, &metageneration)
+            .update_custom_time(object_url, old_deadline, (&generations.0, &generations.1))
             .await?;
 
         // Backend reads return the stored deadline without modifying it.
@@ -1726,10 +1713,9 @@ mod tests {
         // Backdate custom_time while keeping the object live.
         let object_url = backend.object_url(&id)?;
         let old_deadline = SystemTime::now() + Duration::from_mins(1);
-        let (generation, metageneration) =
-            get_generation_matches(&backend, object_url.clone()).await?;
+        let generations = get_gcs_generations(&backend, object_url.clone()).await?;
         backend
-            .update_custom_time(object_url, old_deadline, &generation, &metageneration)
+            .update_custom_time(object_url, old_deadline, (&generations.0, &generations.1))
             .await?;
 
         let requested = SystemTime::now() + tti;
@@ -1759,16 +1745,14 @@ mod tests {
             .put_object(&id, &metadata, stream::single("payload"))
             .await?;
         let object_url = backend.object_url(&id)?;
-        let (generation, metageneration) =
-            get_generation_matches(&backend, object_url.clone()).await?;
+        let generations = get_gcs_generations(&backend, object_url.clone()).await?;
 
         assert!(
             backend
                 .update_custom_time(
                     object_url.clone(),
                     SystemTime::now() + Duration::from_hours(1),
-                    &generation,
-                    &metageneration,
+                    (&generations.0, &generations.1),
                 )
                 .await?
         );
@@ -1777,8 +1761,7 @@ mod tests {
                 .update_custom_time(
                     object_url.clone(),
                     SystemTime::now() + Duration::from_hours(2),
-                    &generation,
-                    &metageneration,
+                    (&generations.0, &generations.1),
                 )
                 .await?
         );
@@ -1789,8 +1772,7 @@ mod tests {
                 .update_custom_time(
                     object_url,
                     SystemTime::now() + Duration::from_hours(2),
-                    &generation,
-                    &metageneration,
+                    (&generations.0, &generations.1),
                 )
                 .await?
         );

--- a/objectstore-service/src/backend/gcs.rs
+++ b/objectstore-service/src/backend/gcs.rs
@@ -2494,7 +2494,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_reads_do_not_bump_tti_and_set_expiry_preserves_payload() -> Result<()> {
+    async fn test_set_expiry() -> Result<()> {
         let backend = create_test_backend().await?;
 
         let id = make_id();
@@ -2542,79 +2542,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_metadata_does_not_bump_fresh_tti() -> Result<()> {
-        let backend = create_test_backend().await?;
-
-        let id = make_id();
-        let tti = Duration::from_hours(2 * 24);
-        let metadata = Metadata {
-            content_type: "text/plain".into(),
-            expiration_policy: ExpirationPolicy::TimeToIdle(tti),
-            time_expires: Some(SystemTime::now() + tti),
-            ..Default::default()
-        };
-
-        backend
-            .put_object(&id, &metadata, stream::single("hello, world"))
-            .await?;
-
-        // A freshly written object has time_expires ≈ now + 2d, which is well outside
-        // the bump window (now + 2d - 1d = now + 1d). No bump should occur.
-        let first = backend.get_metadata(&id).await?.unwrap();
-        let first_expiry = first.time_expires.unwrap();
-
-        let second = backend.get_metadata(&id).await?.unwrap();
-        let second_expiry = second.time_expires.unwrap();
-
-        assert_eq!(
-            first_expiry, second_expiry,
-            "Fresh TTI object should not have its expiry bumped"
-        );
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_short_tti_can_be_extended_explicitly() -> Result<()> {
-        let backend = create_test_backend().await?;
-
-        let id = make_id();
-        let tti = Duration::from_hours(2);
-        let metadata = Metadata {
-            content_type: "text/plain".into(),
-            expiration_policy: ExpirationPolicy::TimeToIdle(tti),
-            time_expires: Some(SystemTime::now() + tti),
-            ..Default::default()
-        };
-
-        backend
-            .put_object(&id, &metadata, stream::single("hello, world"))
-            .await?;
-
-        // Backdate custom_time while keeping the object live.
-        let object_url = backend.object_url(&id)?;
-        let old_deadline = SystemTime::now() + Duration::from_mins(1);
-        let generations = get_gcs_generations(&backend, object_url.clone()).await?;
-        backend
-            .update_custom_time(object_url, old_deadline, (&generations.0, &generations.1))
-            .await?;
-
-        let requested = SystemTime::now() + tti;
-        assert!(backend.set_expiry(&id, requested).await?);
-        let post_expiry = backend
-            .get_metadata(&id)
-            .await?
-            .unwrap()
-            .time_expires
-            .unwrap();
-        assert_eq!(post_expiry, requested);
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn update_custom_time_treats_stale_preconditions_and_missing_objects_as_conflicts()
-    -> Result<()> {
+    async fn test_expiry_conflict() -> Result<()> {
         let backend = create_test_backend().await?;
         let id = make_id();
         let metadata = Metadata {
@@ -3315,6 +3243,9 @@ mod tests {
             .await?;
         producer.clear();
 
+        backend.get_metadata(&id).await?;
+        assert!(producer.records().is_empty());
+
         backend
             .set_expiry(&id, SystemTime::now() + Duration::from_secs(3600))
             .await?;
@@ -3324,33 +3255,6 @@ mod tests {
         assert_eq!(records[0].op_type, OpType::Update);
         assert_eq!(records[0].size, None);
         assert!(records[0].expiration_time.is_some());
-
-        Ok(())
-    }
-
-    #[cfg(feature = "storage-cogs")]
-    #[tokio::test]
-    async fn change_stream_reports_nothing_for_side_effect_free_read() -> Result<()> {
-        let (backend, producer) = create_test_backend_with_change_stream().await?;
-        let id = make_id();
-        let metadata = Metadata {
-            expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_secs(3600)),
-            time_expires: Some(SystemTime::now() + Duration::from_secs(3600)),
-            ..Default::default()
-        };
-
-        backend
-            .put_object(
-                &id,
-                &metadata,
-                stream::single::<ClientError>(b"hi".to_vec()),
-            )
-            .await?;
-        producer.clear();
-
-        backend.get_metadata(&id).await?;
-
-        assert!(producer.records().is_empty());
 
         Ok(())
     }

--- a/objectstore-service/src/backend/in_memory.rs
+++ b/objectstore-service/src/backend/in_memory.rs
@@ -16,8 +16,8 @@ use futures_util::TryStreamExt;
 use objectstore_types::metadata::Metadata;
 
 use super::common::{
-    self, DeleteResponse, GetResponse, HighVolumeBackend, MultipartUploadBackend, PutResponse,
-    TieredGet, TieredMetadata, TieredUpdate, TieredWrite, Tombstone,
+    DeleteResponse, GetResponse, HighVolumeBackend, MultipartUploadBackend, PutResponse, TieredGet,
+    TieredMetadata, TieredUpdate, TieredWrite, Tombstone,
 };
 use crate::error::{Error, ErrorKind, Result};
 use crate::id::ObjectId;
@@ -157,7 +157,6 @@ impl super::common::Backend for InMemoryBackend {
     }
 
     async fn set_expiry(&self, id: &ObjectId, expire_at: SystemTime) -> Result<bool> {
-        let expire_at = common::normalize_expiry(expire_at)?;
         let now = SystemTime::now();
         let mut store = self.store.lock().unwrap();
         let Some(StoreEntry::Object(metadata, _)) = store.get_mut(id) else {
@@ -254,7 +253,6 @@ impl HighVolumeBackend for InMemoryBackend {
     ) -> Result<bool> {
         let TieredUpdate::SetExpiry(expire_at) = update;
         let expected_target = current;
-        let expire_at = common::normalize_expiry(expire_at)?;
         let now = SystemTime::now();
         let mut store = self.store.lock().unwrap();
         let Some(entry) = store.get_mut(id) else {
@@ -657,10 +655,7 @@ mod tests {
             assert_eq!(updated.expiration_policy, policy);
             assert_eq!(updated.custom, metadata.custom);
             assert_eq!(payload, Bytes::from_static(b"payload"));
-            assert_eq!(
-                updated.time_expires,
-                Some(common::normalize_expiry(requested).unwrap())
-            );
+            assert_eq!(updated.time_expires, Some(requested));
 
             assert!(backend.set_expiry(&id, original_expiry).await.unwrap());
             assert_eq!(
@@ -751,7 +746,7 @@ mod tests {
         );
         assert_eq!(
             backend.get(&id).expect_tombstone().time_expires,
-            Some(common::normalize_expiry(new_expiry).unwrap())
+            Some(new_expiry)
         );
     }
 

--- a/objectstore-service/src/backend/in_memory.rs
+++ b/objectstore-service/src/backend/in_memory.rs
@@ -17,7 +17,7 @@ use objectstore_types::metadata::Metadata;
 
 use super::common::{
     DeleteResponse, GetResponse, HighVolumeBackend, MultipartUploadBackend, PutResponse, TieredGet,
-    TieredMetadata, TieredWrite, Tombstone,
+    TieredMetadata, TieredWrite, Tombstone, normalize_expiry,
 };
 use crate::error::{Error, ErrorKind, Result};
 use crate::id::ObjectId;
@@ -128,6 +128,7 @@ impl super::common::Backend for InMemoryBackend {
         let entry = self.store.lock().unwrap().get(id).cloned();
         match entry {
             None => Ok(None),
+            Some(entry) if entry.is_expired(SystemTime::now()) => Ok(None),
             Some(StoreEntry::Tombstone(_)) => Err(Error::new(
                 ErrorKind::Internal,
                 "unexpected in-memory tombstone",
@@ -155,6 +156,16 @@ impl super::common::Backend for InMemoryBackend {
         }
     }
 
+    async fn set_expiry(&self, id: &ObjectId, expire_at: SystemTime) -> Result<bool> {
+        let expire_at = normalize_expiry(expire_at)?;
+        let now = SystemTime::now();
+        let mut store = self.store.lock().unwrap();
+        let Some(StoreEntry::Object(metadata, _)) = store.get_mut(id) else {
+            return Ok(false);
+        };
+        extend_metadata_expiry(metadata, expire_at, now)
+    }
+
     async fn delete_object(&self, id: &ObjectId) -> Result<DeleteResponse> {
         self.store.lock().unwrap().remove(id);
         Ok(())
@@ -170,6 +181,12 @@ impl HighVolumeBackend for InMemoryBackend {
         payload: Bytes,
     ) -> Result<Option<Tombstone>> {
         let mut store = self.store.lock().unwrap();
+        if store
+            .get(id)
+            .is_some_and(|entry| entry.is_expired(SystemTime::now()))
+        {
+            store.remove(id);
+        }
         if let Some(StoreEntry::Tombstone(tombstone)) = store.get(id).cloned() {
             return Ok(Some(tombstone));
         }
@@ -188,6 +205,7 @@ impl HighVolumeBackend for InMemoryBackend {
         let entry = self.store.lock().unwrap().get(id).cloned();
         Ok(match entry {
             None => TieredGet::NotFound,
+            Some(entry) if entry.is_expired(SystemTime::now()) => TieredGet::NotFound,
             Some(StoreEntry::Tombstone(tombstone)) => TieredGet::Tombstone(tombstone),
             Some(StoreEntry::Object(mut metadata, bytes)) => {
                 let total = bytes.len() as u64;
@@ -212,6 +230,7 @@ impl HighVolumeBackend for InMemoryBackend {
         let entry = self.store.lock().unwrap().get(id).cloned();
         Ok(match entry {
             None => TieredMetadata::NotFound,
+            Some(entry) if entry.is_expired(SystemTime::now()) => TieredMetadata::NotFound,
             Some(StoreEntry::Tombstone(tombstone)) => TieredMetadata::Tombstone(tombstone),
             Some(StoreEntry::Object(metadata, _bytes)) => TieredMetadata::Object(metadata),
         })
@@ -227,6 +246,42 @@ impl HighVolumeBackend for InMemoryBackend {
         Ok(None)
     }
 
+    async fn set_expiry_if_matches(
+        &self,
+        id: &ObjectId,
+        expire_at: SystemTime,
+        expected_target: Option<&ObjectId>,
+    ) -> Result<bool> {
+        let expire_at = normalize_expiry(expire_at)?;
+        let now = SystemTime::now();
+        let mut store = self.store.lock().unwrap();
+        let Some(entry) = store.get_mut(id) else {
+            return Ok(false);
+        };
+
+        match (entry, expected_target) {
+            (StoreEntry::Object(metadata, _), None) => {
+                extend_metadata_expiry(metadata, expire_at, now)
+            }
+            (StoreEntry::Tombstone(tombstone), Some(target)) if tombstone.target == *target => {
+                if tombstone.expiration_policy.is_manual()
+                    || tombstone.time_expires.is_none_or(|deadline| deadline < now)
+                {
+                    return Ok(false);
+                }
+                if tombstone
+                    .time_expires
+                    .is_some_and(|deadline| deadline >= expire_at)
+                {
+                    return Ok(true);
+                }
+                tombstone.time_expires = Some(expire_at);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
     async fn compare_and_write(
         &self,
         id: &ObjectId,
@@ -236,8 +291,9 @@ impl HighVolumeBackend for InMemoryBackend {
         let mut store = self.store.lock().unwrap();
 
         let actual = store.get(id);
-        let matches_current = matches_redirect(actual, current);
-        let matches_next = matches_redirect(actual, write.target());
+        let now = SystemTime::now();
+        let matches_current = matches_redirect(actual, current, now);
+        let matches_next = matches_redirect(actual, write.target(), now);
 
         if matches_current {
             match write {
@@ -445,11 +501,60 @@ impl MultipartUploadBackend for InMemoryBackend {
 ///
 /// - `expected = None`: matches any non-tombstone (absent or inline object).
 /// - `expected = Some(target)`: matches a tombstone whose redirect target equals `target`.
-fn matches_redirect(entry: Option<&StoreEntry>, expected: Option<&ObjectId>) -> bool {
+fn matches_redirect(
+    entry: Option<&StoreEntry>,
+    expected: Option<&ObjectId>,
+    now: SystemTime,
+) -> bool {
     match expected {
-        None => matches!(entry, Some(StoreEntry::Object { .. }) | None),
-        Some(target) => matches!(entry, Some(StoreEntry::Tombstone(t)) if t.target == *target),
+        None => entry
+            .is_none_or(|entry| matches!(entry, StoreEntry::Object(..)) || entry.is_expired(now)),
+        Some(target) => match entry {
+            Some(StoreEntry::Tombstone(tombstone)) => {
+                tombstone.target == *target && !tombstone.is_expired(now)
+            }
+            _ => false,
+        },
     }
+}
+
+impl StoreEntry {
+    fn is_expired(&self, now: SystemTime) -> bool {
+        match self {
+            StoreEntry::Object(metadata, _) => {
+                metadata.expiration_policy.is_timeout()
+                    && metadata.time_expires.is_some_and(|deadline| deadline < now)
+            }
+            StoreEntry::Tombstone(tombstone) => tombstone.is_expired(now),
+        }
+    }
+}
+
+impl Tombstone {
+    fn is_expired(&self, now: SystemTime) -> bool {
+        self.expiration_policy.is_timeout()
+            && self.time_expires.is_some_and(|deadline| deadline < now)
+    }
+}
+
+fn extend_metadata_expiry(
+    metadata: &mut Metadata,
+    expire_at: SystemTime,
+    now: SystemTime,
+) -> Result<bool> {
+    if metadata.expiration_policy.is_manual()
+        || metadata.time_expires.is_none_or(|deadline| deadline < now)
+    {
+        return Ok(false);
+    }
+    if metadata
+        .time_expires
+        .is_some_and(|deadline| deadline >= expire_at)
+    {
+        return Ok(true);
+    }
+    metadata.time_expires = Some(expire_at);
+    Ok(true)
 }
 
 /// Type returned by [`InMemoryBackend::get`] for direct inspection of stored entries.
@@ -522,6 +627,130 @@ mod tests {
             usecase: "testing".into(),
             scopes: Scopes::from_iter([Scope::create("testing", "value").unwrap()]),
         })
+    }
+
+    #[tokio::test]
+    async fn set_expiry_extends_ttl_and_tti_without_changing_object() {
+        for policy in [
+            ExpirationPolicy::TimeToLive(Duration::from_hours(1)),
+            ExpirationPolicy::TimeToIdle(Duration::from_hours(1)),
+        ] {
+            let backend = InMemoryBackend::new("test");
+            let id = make_id();
+            let original_expiry = SystemTime::now() + Duration::from_hours(1);
+            let metadata = Metadata {
+                expiration_policy: policy,
+                time_expires: Some(original_expiry),
+                custom: [("preserved".into(), "yes".into())].into(),
+                ..Default::default()
+            };
+            backend
+                .put_object(&id, &metadata, stream::single("payload"))
+                .await
+                .unwrap();
+
+            let requested = original_expiry + Duration::from_hours(1) + Duration::from_nanos(999);
+            assert!(backend.set_expiry(&id, requested).await.unwrap());
+            let (updated, payload) = backend.get(&id).expect_object();
+            assert_eq!(updated.expiration_policy, policy);
+            assert_eq!(updated.custom, metadata.custom);
+            assert_eq!(payload, Bytes::from_static(b"payload"));
+            assert_eq!(
+                updated.time_expires,
+                Some(normalize_expiry(requested).unwrap())
+            );
+
+            assert!(backend.set_expiry(&id, original_expiry).await.unwrap());
+            assert_eq!(
+                backend.get(&id).expect_object().0.time_expires,
+                updated.time_expires
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn set_expiry_rejects_absent_manual_and_expired_objects() {
+        let backend = InMemoryBackend::new("test");
+        let absent = make_id();
+        assert!(
+            !backend
+                .set_expiry(&absent, SystemTime::now() + Duration::from_hours(1))
+                .await
+                .unwrap()
+        );
+
+        let manual = make_id();
+        backend
+            .put_object(&manual, &Metadata::default(), stream::single("manual"))
+            .await
+            .unwrap();
+        assert!(
+            !backend
+                .set_expiry(&manual, SystemTime::now() + Duration::from_hours(1))
+                .await
+                .unwrap()
+        );
+
+        let expired = make_id();
+        let metadata = Metadata {
+            expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_hours(1)),
+            time_expires: Some(SystemTime::now() - Duration::from_secs(1)),
+            ..Default::default()
+        };
+        backend
+            .put_object(&expired, &metadata, stream::single("expired"))
+            .await
+            .unwrap();
+        assert!(backend.get_object(&expired, None).await.unwrap().is_none());
+        assert!(
+            !backend
+                .set_expiry(&expired, SystemTime::now() + Duration::from_hours(1))
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn conditional_tombstone_extension_requires_exact_target() {
+        let backend = InMemoryBackend::new("test");
+        let id = make_id();
+        let target = make_id();
+        let other = make_id();
+        let old_expiry = SystemTime::now() + Duration::from_hours(1);
+        backend
+            .compare_and_write(
+                &id,
+                None,
+                TieredWrite::Tombstone(Tombstone {
+                    target: target.clone(),
+                    expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_hours(1)),
+                    time_expires: Some(old_expiry),
+                }),
+            )
+            .await
+            .unwrap();
+
+        let new_expiry = old_expiry + Duration::from_hours(1);
+        assert!(
+            !backend
+                .set_expiry_if_matches(&id, new_expiry, Some(&other))
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            backend.get(&id).expect_tombstone().time_expires,
+            Some(old_expiry)
+        );
+        assert!(
+            backend
+                .set_expiry_if_matches(&id, new_expiry, Some(&target))
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            backend.get(&id).expect_tombstone().time_expires,
+            Some(normalize_expiry(new_expiry).unwrap())
+        );
     }
 
     #[tokio::test]

--- a/objectstore-service/src/backend/in_memory.rs
+++ b/objectstore-service/src/backend/in_memory.rs
@@ -17,7 +17,7 @@ use objectstore_types::metadata::Metadata;
 
 use super::common::{
     DeleteResponse, GetResponse, HighVolumeBackend, MultipartUploadBackend, PutResponse, TieredGet,
-    TieredMetadata, TieredWrite, Tombstone, normalize_expiry,
+    TieredMetadata, TieredUpdate, TieredWrite, Tombstone, normalize_expiry,
 };
 use crate::error::{Error, ErrorKind, Result};
 use crate::id::ObjectId;
@@ -246,12 +246,14 @@ impl HighVolumeBackend for InMemoryBackend {
         Ok(None)
     }
 
-    async fn set_expiry_if_matches(
+    async fn compare_and_update(
         &self,
         id: &ObjectId,
-        expire_at: SystemTime,
-        expected_target: Option<&ObjectId>,
+        current: Option<&ObjectId>,
+        update: TieredUpdate,
     ) -> Result<bool> {
+        let TieredUpdate::SetExpiry(expire_at) = update;
+        let expected_target = current;
         let expire_at = normalize_expiry(expire_at)?;
         let now = SystemTime::now();
         let mut store = self.store.lock().unwrap();
@@ -733,7 +735,7 @@ mod tests {
         let new_expiry = old_expiry + Duration::from_hours(1);
         assert!(
             !backend
-                .set_expiry_if_matches(&id, new_expiry, Some(&other))
+                .compare_and_update(&id, Some(&other), TieredUpdate::SetExpiry(new_expiry),)
                 .await
                 .unwrap()
         );
@@ -743,7 +745,7 @@ mod tests {
         );
         assert!(
             backend
-                .set_expiry_if_matches(&id, new_expiry, Some(&target))
+                .compare_and_update(&id, Some(&target), TieredUpdate::SetExpiry(new_expiry))
                 .await
                 .unwrap()
         );

--- a/objectstore-service/src/backend/in_memory.rs
+++ b/objectstore-service/src/backend/in_memory.rs
@@ -16,8 +16,8 @@ use futures_util::TryStreamExt;
 use objectstore_types::metadata::Metadata;
 
 use super::common::{
-    DeleteResponse, GetResponse, HighVolumeBackend, MultipartUploadBackend, PutResponse, TieredGet,
-    TieredMetadata, TieredUpdate, TieredWrite, Tombstone, normalize_expiry,
+    self, DeleteResponse, GetResponse, HighVolumeBackend, MultipartUploadBackend, PutResponse,
+    TieredGet, TieredMetadata, TieredUpdate, TieredWrite, Tombstone,
 };
 use crate::error::{Error, ErrorKind, Result};
 use crate::id::ObjectId;
@@ -157,7 +157,7 @@ impl super::common::Backend for InMemoryBackend {
     }
 
     async fn set_expiry(&self, id: &ObjectId, expire_at: SystemTime) -> Result<bool> {
-        let expire_at = normalize_expiry(expire_at)?;
+        let expire_at = common::normalize_expiry(expire_at)?;
         let now = SystemTime::now();
         let mut store = self.store.lock().unwrap();
         let Some(StoreEntry::Object(metadata, _)) = store.get_mut(id) else {
@@ -254,7 +254,7 @@ impl HighVolumeBackend for InMemoryBackend {
     ) -> Result<bool> {
         let TieredUpdate::SetExpiry(expire_at) = update;
         let expected_target = current;
-        let expire_at = normalize_expiry(expire_at)?;
+        let expire_at = common::normalize_expiry(expire_at)?;
         let now = SystemTime::now();
         let mut store = self.store.lock().unwrap();
         let Some(entry) = store.get_mut(id) else {
@@ -659,7 +659,7 @@ mod tests {
             assert_eq!(payload, Bytes::from_static(b"payload"));
             assert_eq!(
                 updated.time_expires,
-                Some(normalize_expiry(requested).unwrap())
+                Some(common::normalize_expiry(requested).unwrap())
             );
 
             assert!(backend.set_expiry(&id, original_expiry).await.unwrap());
@@ -751,7 +751,7 @@ mod tests {
         );
         assert_eq!(
             backend.get(&id).expect_tombstone().time_expires,
-            Some(normalize_expiry(new_expiry).unwrap())
+            Some(common::normalize_expiry(new_expiry).unwrap())
         );
     }
 

--- a/objectstore-service/src/backend/in_memory.rs
+++ b/objectstore-service/src/backend/in_memory.rs
@@ -34,6 +34,15 @@ enum StoreEntry {
     Tombstone(Tombstone),
 }
 
+impl StoreEntry {
+    fn is_expired(&self, now: SystemTime) -> bool {
+        match self {
+            StoreEntry::Object(metadata, _) => metadata.is_expired(now),
+            StoreEntry::Tombstone(tombstone) => tombstone.is_expired(now),
+        }
+    }
+}
+
 type Store = HashMap<ObjectId, StoreEntry>;
 
 #[derive(Clone, Debug)]
@@ -162,7 +171,7 @@ impl super::common::Backend for InMemoryBackend {
         let Some(StoreEntry::Object(metadata, _)) = store.get_mut(id) else {
             return Ok(false);
         };
-        extend_metadata_expiry(metadata, expire_at, now)
+        Ok(extend_metadata_expiry(metadata, expire_at, now))
     }
 
     async fn delete_object(&self, id: &ObjectId) -> Result<DeleteResponse> {
@@ -259,14 +268,13 @@ impl HighVolumeBackend for InMemoryBackend {
             return Ok(false);
         };
 
-        match (entry, expected_target) {
+        // TODO: Unify this with extend expiry.
+        Ok(match (entry, expected_target) {
             (StoreEntry::Object(metadata, _), None) => {
                 extend_metadata_expiry(metadata, expire_at, now)
             }
             (StoreEntry::Tombstone(tombstone), Some(target)) if tombstone.target == *target => {
-                if tombstone.expiration_policy.is_manual()
-                    || tombstone.time_expires.is_none_or(|deadline| deadline < now)
-                {
+                if tombstone.time_expires.is_none() || tombstone.is_expired(now) {
                     return Ok(false);
                 }
                 if tombstone
@@ -276,10 +284,10 @@ impl HighVolumeBackend for InMemoryBackend {
                     return Ok(true);
                 }
                 tombstone.time_expires = Some(expire_at);
-                Ok(true)
+                true
             }
-            _ => Ok(false),
-        }
+            _ => false,
+        })
     }
 
     async fn compare_and_write(
@@ -506,55 +514,28 @@ fn matches_redirect(
     expected: Option<&ObjectId>,
     now: SystemTime,
 ) -> bool {
-    match expected {
-        None => entry
-            .is_none_or(|entry| matches!(entry, StoreEntry::Object(..)) || entry.is_expired(now)),
-        Some(target) => match entry {
-            Some(StoreEntry::Tombstone(tombstone)) => {
-                tombstone.target == *target && !tombstone.is_expired(now)
-            }
-            _ => false,
+    match entry {
+        None | Some(StoreEntry::Object(..)) => expected.is_none(),
+        Some(StoreEntry::Tombstone(tombstone)) => match expected {
+            None => tombstone.is_expired(now),
+            Some(target) => tombstone.target == *target && !tombstone.is_expired(now),
         },
     }
 }
 
-impl StoreEntry {
-    fn is_expired(&self, now: SystemTime) -> bool {
-        match self {
-            StoreEntry::Object(metadata, _) => {
-                metadata.expiration_policy.is_timeout()
-                    && metadata.time_expires.is_some_and(|deadline| deadline < now)
-            }
-            StoreEntry::Tombstone(tombstone) => tombstone.is_expired(now),
-        }
-    }
-}
+fn extend_metadata_expiry(metadata: &mut Metadata, expire_at: SystemTime, now: SystemTime) -> bool {
+    let Some(time_expires) = metadata.time_expires else {
+        return false; // manual expiration policy cannot be extended
+    };
 
-impl Tombstone {
-    fn is_expired(&self, now: SystemTime) -> bool {
-        self.expiration_policy.is_timeout()
-            && self.time_expires.is_some_and(|deadline| deadline < now)
+    if time_expires < now {
+        false // already expired
+    } else if time_expires >= expire_at {
+        true // already satisfied
+    } else {
+        metadata.time_expires = Some(expire_at);
+        true
     }
-}
-
-fn extend_metadata_expiry(
-    metadata: &mut Metadata,
-    expire_at: SystemTime,
-    now: SystemTime,
-) -> Result<bool> {
-    if metadata.expiration_policy.is_manual()
-        || metadata.time_expires.is_none_or(|deadline| deadline < now)
-    {
-        return Ok(false);
-    }
-    if metadata
-        .time_expires
-        .is_some_and(|deadline| deadline >= expire_at)
-    {
-        return Ok(true);
-    }
-    metadata.time_expires = Some(expire_at);
-    Ok(true)
 }
 
 /// Type returned by [`InMemoryBackend::get`] for direct inspection of stored entries.

--- a/objectstore-service/src/backend/in_memory.rs
+++ b/objectstore-service/src/backend/in_memory.rs
@@ -597,7 +597,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn set_expiry_extends_ttl_and_tti_without_changing_object() {
+    async fn set_expiry() {
         for policy in [
             ExpirationPolicy::TimeToLive(Duration::from_hours(1)),
             ExpirationPolicy::TimeToIdle(Duration::from_hours(1)),
@@ -633,7 +633,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn set_expiry_rejects_absent_manual_and_expired_objects() {
+    async fn set_expiry_rejected() {
         let backend = InMemoryBackend::new("test");
         let absent = make_id();
         assert!(
@@ -675,7 +675,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn conditional_tombstone_extension_requires_exact_target() {
+    async fn redirect_expiry() {
         let backend = InMemoryBackend::new("test");
         let id = make_id();
         let target = make_id();

--- a/objectstore-service/src/backend/in_memory.rs
+++ b/objectstore-service/src/backend/in_memory.rs
@@ -168,10 +168,12 @@ impl super::common::Backend for InMemoryBackend {
     async fn set_expiry(&self, id: &ObjectId, expire_at: SystemTime) -> Result<bool> {
         let now = SystemTime::now();
         let mut store = self.store.lock().unwrap();
-        let Some(StoreEntry::Object(metadata, _)) = store.get_mut(id) else {
-            return Ok(false);
-        };
-        Ok(extend_metadata_expiry(metadata, expire_at, now))
+        Ok(match store.get_mut(id) {
+            Some(StoreEntry::Object(metadata, _)) => {
+                extend_expiry(&mut metadata.time_expires, expire_at, now)
+            }
+            _ => false,
+        })
     }
 
     async fn delete_object(&self, id: &ObjectId) -> Result<DeleteResponse> {
@@ -189,14 +191,10 @@ impl HighVolumeBackend for InMemoryBackend {
         payload: Bytes,
     ) -> Result<Option<Tombstone>> {
         let mut store = self.store.lock().unwrap();
-        if store
-            .get(id)
-            .is_some_and(|entry| entry.is_expired(SystemTime::now()))
+        if let Some(StoreEntry::Tombstone(tombstone)) = store.get(id)
+            && !tombstone.is_expired(SystemTime::now())
         {
-            store.remove(id);
-        }
-        if let Some(StoreEntry::Tombstone(tombstone)) = store.get(id).cloned() {
-            return Ok(Some(tombstone));
+            return Ok(Some(tombstone.clone()));
         }
 
         let mut metadata = metadata.clone();
@@ -261,30 +259,14 @@ impl HighVolumeBackend for InMemoryBackend {
         update: TieredUpdate,
     ) -> Result<bool> {
         let TieredUpdate::SetExpiry(expire_at) = update;
-        let expected_target = current;
-        let now = SystemTime::now();
         let mut store = self.store.lock().unwrap();
-        let Some(entry) = store.get_mut(id) else {
-            return Ok(false);
-        };
 
-        // TODO: Unify this with extend expiry.
-        Ok(match (entry, expected_target) {
-            (StoreEntry::Object(metadata, _), None) => {
-                extend_metadata_expiry(metadata, expire_at, now)
+        Ok(match (store.get_mut(id), current) {
+            (Some(StoreEntry::Object(metadata, _)), None) => {
+                extend_expiry(&mut metadata.time_expires, expire_at, SystemTime::now())
             }
-            (StoreEntry::Tombstone(tombstone), Some(target)) if tombstone.target == *target => {
-                if tombstone.time_expires.is_none() || tombstone.is_expired(now) {
-                    return Ok(false);
-                }
-                if tombstone
-                    .time_expires
-                    .is_some_and(|deadline| deadline >= expire_at)
-                {
-                    return Ok(true);
-                }
-                tombstone.time_expires = Some(expire_at);
-                true
+            (Some(StoreEntry::Tombstone(t)), Some(target)) if t.target == *target => {
+                extend_expiry(&mut t.time_expires, expire_at, SystemTime::now())
             }
             _ => false,
         })
@@ -299,9 +281,9 @@ impl HighVolumeBackend for InMemoryBackend {
         let mut store = self.store.lock().unwrap();
 
         let actual = store.get(id);
-        let now = SystemTime::now();
-        let matches_current = matches_redirect(actual, current, now);
-        let matches_next = matches_redirect(actual, write.target(), now);
+        let access_time = SystemTime::now();
+        let matches_current = matches_redirect(actual, current, access_time);
+        let matches_next = matches_redirect(actual, write.target(), access_time);
 
         if matches_current {
             match write {
@@ -523,8 +505,12 @@ fn matches_redirect(
     }
 }
 
-fn extend_metadata_expiry(metadata: &mut Metadata, expire_at: SystemTime, now: SystemTime) -> bool {
-    let Some(time_expires) = metadata.time_expires else {
+/// Extends an active expiry time to `expire_at` where valid.
+///
+/// Returns `true` if expiry was extended or already satisfied, and `false` if the expiry could not
+/// be extended (e.g. manual expiration policy or already expired).
+fn extend_expiry(field: &mut Option<SystemTime>, expire_at: SystemTime, now: SystemTime) -> bool {
+    let Some(time_expires) = *field else {
         return false; // manual expiration policy cannot be extended
     };
 
@@ -533,7 +519,7 @@ fn extend_metadata_expiry(metadata: &mut Metadata, expire_at: SystemTime, now: S
     } else if time_expires >= expire_at {
         true // already satisfied
     } else {
-        metadata.time_expires = Some(expire_at);
+        *field = Some(expire_at);
         true
     }
 }

--- a/objectstore-service/src/backend/in_memory.rs
+++ b/objectstore-service/src/backend/in_memory.rs
@@ -244,7 +244,9 @@ impl HighVolumeBackend for InMemoryBackend {
 
     async fn delete_non_tombstone(&self, id: &ObjectId) -> Result<Option<Tombstone>> {
         let mut store = self.store.lock().unwrap();
-        if let Some(StoreEntry::Tombstone(tombstone)) = store.get(id).cloned() {
+        if let Some(StoreEntry::Tombstone(tombstone)) = store.get(id).cloned()
+            && !tombstone.is_expired(SystemTime::now())
+        {
             return Ok(Some(tombstone));
         }
 

--- a/objectstore-service/src/backend/local_fs.rs
+++ b/objectstore-service/src/backend/local_fs.rs
@@ -811,11 +811,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn set_expiry_rewrites_metadata_and_preserves_payload() {
-        let tempdir = tempfile::tempdir().unwrap();
-        let backend = LocalFsBackend::new(FileSystemConfig {
-            path: tempdir.path().to_path_buf(),
-        });
+    async fn set_expiry() {
+        let (_tempdir, backend) = make_backend();
         let id = make_id();
         let old_expiry = SystemTime::now() + Duration::from_hours(1);
         let metadata = Metadata {
@@ -845,16 +842,13 @@ mod tests {
         assert!(
             entries
                 .iter()
-                .all(|path| !path.to_string_lossy().contains("expiry-"))
+                .all(|path| !path.to_string_lossy().ends_with(".draft"))
         );
     }
 
     #[tokio::test]
-    async fn expired_objects_are_filtered_and_cannot_be_extended() {
-        let tempdir = tempfile::tempdir().unwrap();
-        let backend = LocalFsBackend::new(FileSystemConfig {
-            path: tempdir.path().to_path_buf(),
-        });
+    async fn expired_object() {
+        let (_tempdir, backend) = make_backend();
         let id = make_id();
         let metadata = Metadata {
             expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_hours(1)),

--- a/objectstore-service/src/backend/local_fs.rs
+++ b/objectstore-service/src/backend/local_fs.rs
@@ -11,10 +11,11 @@ use objectstore_types::metadata::Metadata;
 use objectstore_types::range::ByteRange;
 use tokio::fs::OpenOptions;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufReader, BufWriter};
+use tokio::sync::Mutex;
 use tokio_util::io::{ReaderStream, StreamReader};
 
 use crate::backend::common::{
-    Backend, DeleteResponse, GetResponse, MultipartUploadBackend, PutResponse,
+    self, Backend, DeleteResponse, GetResponse, MultipartUploadBackend, PutResponse,
 };
 use crate::error::{Error, ErrorKind, Result, ResultExt as _};
 use crate::id::ObjectId;
@@ -61,7 +62,7 @@ pub struct LocalFsBackend {
     // This lock coordinates mutations only within this backend instance. It
     // does not serialize another backend instance or another process using the
     // same directory.
-    mutation_lock: Arc<tokio::sync::Mutex<()>>,
+    mutation_lock: Arc<Mutex<()>>,
 }
 
 impl LocalFsBackend {
@@ -69,7 +70,7 @@ impl LocalFsBackend {
     pub fn new(config: FileSystemConfig) -> Self {
         Self {
             path: config.path,
-            mutation_lock: Arc::new(tokio::sync::Mutex::new(())),
+            mutation_lock: Arc::new(Mutex::new(())),
         }
     }
 }
@@ -217,7 +218,7 @@ impl Backend for LocalFsBackend {
 
     #[tracing::instrument(level = "debug", skip(self))]
     async fn set_expiry(&self, id: &ObjectId, expire_at: SystemTime) -> Result<bool> {
-        let expire_at = super::common::normalize_expiry(expire_at)?;
+        let expire_at = common::normalize_expiry(expire_at)?;
         let _mutation_guard = self.mutation_lock.lock().await;
         let path = self.path.join(id.as_storage_path().to_string());
         let file = match OpenOptions::new().read(true).open(&path).await {
@@ -748,7 +749,7 @@ mod tests {
         assert_eq!(updated.custom, metadata.custom);
         assert_eq!(
             updated.time_expires,
-            Some(super::super::common::normalize_expiry(requested).unwrap())
+            Some(common::normalize_expiry(requested).unwrap())
         );
         assert_eq!(stream::read_to_vec(payload).await.unwrap(), b"payload");
 

--- a/objectstore-service/src/backend/local_fs.rs
+++ b/objectstore-service/src/backend/local_fs.rs
@@ -15,7 +15,7 @@ use tokio::sync::Mutex;
 use tokio_util::io::{ReaderStream, StreamReader};
 
 use crate::backend::common::{
-    self, Backend, DeleteResponse, GetResponse, MultipartUploadBackend, PutResponse,
+    Backend, DeleteResponse, GetResponse, MultipartUploadBackend, PutResponse,
 };
 use crate::error::{Error, ErrorKind, Result, ResultExt as _};
 use crate::id::ObjectId;
@@ -218,7 +218,6 @@ impl Backend for LocalFsBackend {
 
     #[tracing::instrument(level = "debug", skip(self))]
     async fn set_expiry(&self, id: &ObjectId, expire_at: SystemTime) -> Result<bool> {
-        let expire_at = common::normalize_expiry(expire_at)?;
         let _mutation_guard = self.mutation_lock.lock().await;
         let path = self.path.join(id.as_storage_path().to_string());
         let file = match OpenOptions::new().read(true).open(&path).await {
@@ -747,10 +746,7 @@ mod tests {
         let (updated, _, payload) = backend.get_object(&id, None).await.unwrap().unwrap();
         assert_eq!(updated.expiration_policy, metadata.expiration_policy);
         assert_eq!(updated.custom, metadata.custom);
-        assert_eq!(
-            updated.time_expires,
-            Some(common::normalize_expiry(requested).unwrap())
-        );
+        assert_eq!(updated.time_expires, Some(requested));
         assert_eq!(stream::read_to_vec(payload).await.unwrap(), b"payload");
 
         let object_path = backend.path.join(id.as_storage_path().to_string());

--- a/objectstore-service/src/backend/local_fs.rs
+++ b/objectstore-service/src/backend/local_fs.rs
@@ -3,6 +3,7 @@
 use std::io;
 use std::path::PathBuf;
 use std::pin::pin;
+use std::sync::Arc;
 use std::time::SystemTime;
 
 use futures_util::StreamExt;
@@ -57,12 +58,19 @@ pub struct FileSystemConfig {
 #[derive(Debug)]
 pub struct LocalFsBackend {
     path: PathBuf,
+    // This lock coordinates mutations only within this backend instance. It
+    // does not serialize another backend instance or another process using the
+    // same directory.
+    mutation_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl LocalFsBackend {
     /// Creates a new [`LocalFsBackend`] rooted at the directory in `config`.
     pub fn new(config: FileSystemConfig) -> Self {
-        Self { path: config.path }
+        Self {
+            path: config.path,
+            mutation_lock: Arc::new(tokio::sync::Mutex::new(())),
+        }
     }
 }
 
@@ -83,6 +91,7 @@ impl Backend for LocalFsBackend {
         metadata: &Metadata,
         stream: ClientStream,
     ) -> Result<PutResponse> {
+        let _mutation_guard = self.mutation_lock.lock().await;
         let path = self.path.join(id.as_storage_path().to_string());
         objectstore_log::debug!(path=%path.display(), "Writing to local_fs backend");
         tokio::fs::create_dir_all(path.parent().unwrap())
@@ -140,7 +149,6 @@ impl Backend for LocalFsBackend {
         Ok(())
     }
 
-    // TODO: Return `Ok(None)` if object is found but past expiry
     #[tracing::instrument(level = "debug", skip(self))]
     async fn get_object(&self, id: &ObjectId, range: Option<ByteRange>) -> Result<GetResponse> {
         objectstore_log::debug!("Reading from local_fs backend");
@@ -171,6 +179,14 @@ impl Backend for LocalFsBackend {
             .len();
         let mut metadata: Metadata = serde_json::from_str(metadata_line.trim_end())
             .context(ErrorKind::CorruptData, "decoding local-fs object metadata")?;
+        if metadata.expiration_policy.is_timeout()
+            && metadata
+                .time_expires
+                .is_some_and(|deadline| deadline < SystemTime::now())
+        {
+            objectstore_log::debug!("Object found but past expiry");
+            return Ok(None);
+        }
         let payload_size = file_len
             .checked_sub(metadata_line.len() as u64)
             .ok_or_else(|| {
@@ -200,7 +216,93 @@ impl Backend for LocalFsBackend {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
+    async fn set_expiry(&self, id: &ObjectId, expire_at: SystemTime) -> Result<bool> {
+        let expire_at = super::common::normalize_expiry(expire_at)?;
+        let _mutation_guard = self.mutation_lock.lock().await;
+        let path = self.path.join(id.as_storage_path().to_string());
+        let file = match OpenOptions::new().read(true).open(&path).await {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+            result => result.context(
+                ErrorKind::BackendFailure,
+                "opening local-fs object for expiry extension",
+            )?,
+        };
+        let mut reader = BufReader::new(file);
+        let mut metadata_line = String::new();
+        reader.read_line(&mut metadata_line).await.context(
+            ErrorKind::BackendFailure,
+            "reading local-fs object metadata for expiry extension",
+        )?;
+        let mut metadata: Metadata = serde_json::from_str(metadata_line.trim_end()).context(
+            ErrorKind::CorruptData,
+            "decoding local-fs object metadata for expiry extension",
+        )?;
+        let Some(current_expiry) = metadata.time_expires else {
+            return Ok(false);
+        };
+        if metadata.expiration_policy.is_manual() || current_expiry < SystemTime::now() {
+            return Ok(false);
+        }
+        if current_expiry >= expire_at {
+            return Ok(true);
+        }
+        metadata.time_expires = Some(expire_at);
+
+        let temp_path = path.with_extension(format!("expiry-{}.tmp", uuid::Uuid::now_v7()));
+        let rewrite: Result<()> = async {
+            let temp = OpenOptions::new()
+                .create_new(true)
+                .write(true)
+                .open(&temp_path)
+                .await
+                .context(
+                    ErrorKind::BackendFailure,
+                    "creating local-fs expiry temporary file",
+                )?;
+            let mut writer = BufWriter::new(temp);
+            let metadata_json = serde_json::to_string(&metadata)
+                .context(ErrorKind::Internal, "encoding local-fs object metadata")?;
+            writer.write_all(metadata_json.as_bytes()).await.context(
+                ErrorKind::BackendFailure,
+                "writing local-fs expiry metadata",
+            )?;
+            writer.write_all(b"\n").await.context(
+                ErrorKind::BackendFailure,
+                "writing local-fs expiry metadata",
+            )?;
+            tokio::io::copy(&mut reader, &mut writer).await.context(
+                ErrorKind::BackendFailure,
+                "copying local-fs object payload for expiry extension",
+            )?;
+            writer.flush().await.context(
+                ErrorKind::BackendFailure,
+                "flushing local-fs expiry temporary file",
+            )?;
+            let temp = writer.into_inner();
+            temp.sync_data().await.context(
+                ErrorKind::BackendFailure,
+                "syncing local-fs expiry temporary file",
+            )?;
+            drop(temp);
+            tokio::fs::rename(&temp_path, &path).await.context(
+                ErrorKind::BackendFailure,
+                "publishing local-fs expiry extension",
+            )?;
+            Ok(())
+        }
+        .await;
+
+        if rewrite.is_err() {
+            let _ = tokio::fs::remove_file(&temp_path).await;
+        }
+        rewrite?;
+        Ok(true)
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn delete_object(&self, id: &ObjectId) -> Result<DeleteResponse> {
+        let _mutation_guard = self.mutation_lock.lock().await;
         objectstore_log::debug!("Deleting from local_fs backend");
         let path = self.path.join(id.as_storage_path().to_string());
         let result = tokio::fs::remove_file(path).await;
@@ -497,6 +599,7 @@ impl MultipartUploadBackend for LocalFsBackend {
         }
 
         // Stream parts directly to the final object file
+        let _mutation_guard = self.mutation_lock.lock().await;
         let path = self.path.join(id.as_storage_path().to_string());
         tokio::fs::create_dir_all(path.parent().unwrap())
             .await
@@ -617,6 +720,74 @@ mod tests {
             }
         );
         assert_eq!(file_contents.as_ref(), b"oh hai!");
+    }
+
+    #[tokio::test]
+    async fn set_expiry_rewrites_metadata_and_preserves_payload() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let backend = LocalFsBackend::new(FileSystemConfig {
+            path: tempdir.path().to_path_buf(),
+        });
+        let id = make_id();
+        let old_expiry = SystemTime::now() + Duration::from_hours(1);
+        let metadata = Metadata {
+            expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_hours(1)),
+            time_expires: Some(old_expiry),
+            custom: [("preserved".into(), "yes".into())].into(),
+            ..Default::default()
+        };
+        backend
+            .put_object(&id, &metadata, stream::single("payload"))
+            .await
+            .unwrap();
+
+        let requested = old_expiry + Duration::from_hours(1) + Duration::from_nanos(999);
+        assert!(backend.set_expiry(&id, requested).await.unwrap());
+        let (updated, _, payload) = backend.get_object(&id, None).await.unwrap().unwrap();
+        assert_eq!(updated.expiration_policy, metadata.expiration_policy);
+        assert_eq!(updated.custom, metadata.custom);
+        assert_eq!(
+            updated.time_expires,
+            Some(super::super::common::normalize_expiry(requested).unwrap())
+        );
+        assert_eq!(stream::read_to_vec(payload).await.unwrap(), b"payload");
+
+        let object_path = backend.path.join(id.as_storage_path().to_string());
+        let entries = std::fs::read_dir(object_path.parent().unwrap())
+            .unwrap()
+            .flat_map(|entry| entry.map(|entry| entry.path()))
+            .collect::<Vec<_>>();
+        assert!(
+            entries
+                .iter()
+                .all(|path| !path.to_string_lossy().contains("expiry-"))
+        );
+    }
+
+    #[tokio::test]
+    async fn expired_objects_are_filtered_and_cannot_be_extended() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let backend = LocalFsBackend::new(FileSystemConfig {
+            path: tempdir.path().to_path_buf(),
+        });
+        let id = make_id();
+        let metadata = Metadata {
+            expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_hours(1)),
+            time_expires: Some(SystemTime::now() - Duration::from_secs(1)),
+            ..Default::default()
+        };
+        backend
+            .put_object(&id, &metadata, stream::single("expired"))
+            .await
+            .unwrap();
+
+        assert!(backend.get_object(&id, None).await.unwrap().is_none());
+        assert!(
+            !backend
+                .set_expiry(&id, SystemTime::now() + Duration::from_hours(1))
+                .await
+                .unwrap()
+        );
     }
 
     #[tokio::test]

--- a/objectstore-service/src/backend/local_fs.rs
+++ b/objectstore-service/src/backend/local_fs.rs
@@ -180,11 +180,7 @@ impl Backend for LocalFsBackend {
             .len();
         let mut metadata: Metadata = serde_json::from_str(metadata_line.trim_end())
             .context(ErrorKind::CorruptData, "decoding local-fs object metadata")?;
-        if metadata.expiration_policy.is_timeout()
-            && metadata
-                .time_expires
-                .is_some_and(|deadline| deadline < SystemTime::now())
-        {
+        if metadata.is_expired(SystemTime::now()) {
             objectstore_log::debug!("Object found but past expiry");
             return Ok(None);
         }
@@ -241,11 +237,10 @@ impl Backend for LocalFsBackend {
         let Some(current_expiry) = metadata.time_expires else {
             return Ok(false);
         };
-        if metadata.expiration_policy.is_manual() || current_expiry < SystemTime::now() {
-            return Ok(false);
-        }
-        if current_expiry >= expire_at {
-            return Ok(true);
+        if current_expiry < SystemTime::now() {
+            return Ok(false); // already expired
+        } else if current_expiry >= expire_at {
+            return Ok(true); // already satisfied
         }
         metadata.time_expires = Some(expire_at);
 

--- a/objectstore-service/src/backend/local_fs.rs
+++ b/objectstore-service/src/backend/local_fs.rs
@@ -1,7 +1,11 @@
 //! Local filesystem backend for development and testing.
+//!
+//! Mutations are serialized within a backend instance and publish complete object files by
+//! atomically renaming same-directory drafts. Readers therefore observe either the previous or
+//! next complete object file.
 
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::pin::pin;
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -62,7 +66,7 @@ pub struct LocalFsBackend {
     // This lock coordinates mutations only within this backend instance. It
     // does not serialize another backend instance or another process using the
     // same directory.
-    mutation_lock: Arc<Mutex<()>>,
+    write_lock: Arc<Mutex<()>>,
 }
 
 impl LocalFsBackend {
@@ -70,8 +74,23 @@ impl LocalFsBackend {
     pub fn new(config: FileSystemConfig) -> Self {
         Self {
             path: config.path,
-            mutation_lock: Arc::new(Mutex::new(())),
+            write_lock: Arc::new(Mutex::new(())),
         }
+    }
+
+    /// Returns the filesystem path for the given object ID.
+    fn path(&self, id: &ObjectId) -> PathBuf {
+        self.path.join(id.as_storage_path().to_string())
+    }
+
+    /// Ensures that an object file can be created at the given path.
+    async fn create_dir_all(path: &Path) -> Result<()> {
+        tokio::fs::create_dir_all(path.parent().unwrap())
+            .await
+            .context(
+                ErrorKind::BackendFailure,
+                "creating local-fs object directory",
+            )
     }
 }
 
@@ -92,41 +111,15 @@ impl Backend for LocalFsBackend {
         metadata: &Metadata,
         stream: ClientStream,
     ) -> Result<PutResponse> {
-        let _mutation_guard = self.mutation_lock.lock().await;
-        let path = self.path.join(id.as_storage_path().to_string());
+        let _guard = self.write_lock.lock().await;
+
+        let path = self.path(id);
         objectstore_log::debug!(path=%path.display(), "Writing to local_fs backend");
-        tokio::fs::create_dir_all(path.parent().unwrap())
-            .await
-            .context(
-                ErrorKind::BackendFailure,
-                "creating local-fs object directory",
-            )?;
-        let file = OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(path)
-            .await
-            .context(
-                ErrorKind::BackendFailure,
-                "opening local-fs object for writing",
-            )?;
+        Self::create_dir_all(&path).await?;
 
+        let mut draft = Draft::create(&path, metadata).await?;
         let mut reader = pin!(StreamReader::new(stream));
-        let mut writer = BufWriter::new(file);
-
-        let metadata_json = serde_json::to_string(metadata)
-            .context(ErrorKind::Internal, "encoding local-fs object metadata")?;
-        writer.write_all(metadata_json.as_bytes()).await.context(
-            ErrorKind::BackendFailure,
-            "writing local-fs object metadata",
-        )?;
-        writer.write_all(b"\n").await.context(
-            ErrorKind::BackendFailure,
-            "writing local-fs object metadata",
-        )?;
-
-        tokio::io::copy(&mut reader, &mut writer)
+        let result = tokio::io::copy(&mut reader, draft.writer())
             .await
             .map_err(|e| match stream::unpack_client_error(&e) {
                 Some(ce) => Error::from(ce),
@@ -135,61 +128,34 @@ impl Backend for LocalFsBackend {
                     "writing local-fs object payload",
                     e,
                 ),
-            })?;
+            });
 
-        writer
-            .flush()
-            .await
-            .context(ErrorKind::BackendFailure, "flushing local-fs object")?;
-        let file = writer.into_inner();
-        file.sync_data()
-            .await
-            .context(ErrorKind::BackendFailure, "syncing local-fs object")?;
-        drop(file);
-
-        Ok(())
+        match result {
+            Ok(_) => {
+                draft.publish().await?;
+                Ok(())
+            }
+            Err(error) => {
+                draft.discard().await;
+                Err(error)
+            }
+        }
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
     async fn get_object(&self, id: &ObjectId, range: Option<ByteRange>) -> Result<GetResponse> {
         objectstore_log::debug!("Reading from local_fs backend");
-        let path = self.path.join(id.as_storage_path().to_string());
-        let file = match OpenOptions::new().read(true).open(path).await {
-            Ok(file) => file,
-            Err(err) if err.kind() == io::ErrorKind::NotFound => {
-                objectstore_log::debug!("Object not found");
-                return Ok(None);
-            }
-            err => err.context(
-                ErrorKind::BackendFailure,
-                "opening local-fs object for reading",
-            )?,
-        };
-
-        let mut reader = BufReader::new(file);
-        let mut metadata_line = String::new();
-        reader.read_line(&mut metadata_line).await.context(
-            ErrorKind::BackendFailure,
-            "reading local-fs object metadata",
-        )?;
-        let file_len = reader
-            .get_ref()
-            .metadata()
-            .await
-            .context(ErrorKind::BackendFailure, "reading local-fs object size")?
-            .len();
-        let mut metadata: Metadata = serde_json::from_str(metadata_line.trim_end())
-            .context(ErrorKind::CorruptData, "decoding local-fs object metadata")?;
-        if metadata.is_expired(SystemTime::now()) {
-            objectstore_log::debug!("Object found but past expiry");
+        let path = self.path(id);
+        let Some(object) = ObjectFile::try_open(&path).await? else {
+            objectstore_log::debug!("Object not found");
             return Ok(None);
-        }
-        let payload_size = file_len
-            .checked_sub(metadata_line.len() as u64)
-            .ok_or_else(|| {
-                Error::new(ErrorKind::CorruptData, "reading truncated local-fs object")
-            })?;
-        metadata.size = Some(payload_size as usize);
+        };
+        let ObjectFile {
+            metadata,
+            preamble_len,
+            payload_size,
+            mut reader,
+        } = object;
 
         let (content_range, stream) = match range {
             Some(byte_range) => {
@@ -199,7 +165,7 @@ impl Backend for LocalFsBackend {
                         .ok_or(ErrorKind::RangeNotSatisfiable {
                             total: payload_size,
                         })?;
-                let payload_start = metadata_line.len() as u64 + content_range.start;
+                let payload_start = preamble_len + content_range.start;
                 reader
                     .seek(std::io::SeekFrom::Start(payload_start))
                     .await
@@ -214,92 +180,50 @@ impl Backend for LocalFsBackend {
 
     #[tracing::instrument(level = "debug", skip(self))]
     async fn set_expiry(&self, id: &ObjectId, expire_at: SystemTime) -> Result<bool> {
-        let _mutation_guard = self.mutation_lock.lock().await;
-        let path = self.path.join(id.as_storage_path().to_string());
-        let file = match OpenOptions::new().read(true).open(&path).await {
-            Ok(file) => file,
-            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
-            result => result.context(
-                ErrorKind::BackendFailure,
-                "opening local-fs object for expiry extension",
-            )?,
+        let _guard = self.write_lock.lock().await;
+
+        let path = self.path(id);
+        let Some(object) = ObjectFile::try_open(&path).await? else {
+            return Ok(false);
         };
-        let mut reader = BufReader::new(file);
-        let mut metadata_line = String::new();
-        reader.read_line(&mut metadata_line).await.context(
-            ErrorKind::BackendFailure,
-            "reading local-fs object metadata for expiry extension",
-        )?;
-        let mut metadata: Metadata = serde_json::from_str(metadata_line.trim_end()).context(
-            ErrorKind::CorruptData,
-            "decoding local-fs object metadata for expiry extension",
-        )?;
+        let ObjectFile {
+            mut metadata,
+            mut reader,
+            ..
+        } = object;
+
         let Some(current_expiry) = metadata.time_expires else {
             return Ok(false);
         };
-        if current_expiry < SystemTime::now() {
-            return Ok(false); // already expired
-        } else if current_expiry >= expire_at {
+        if current_expiry >= expire_at {
             return Ok(true); // already satisfied
         }
         metadata.time_expires = Some(expire_at);
 
-        let temp_path = path.with_extension(format!("expiry-{}.tmp", uuid::Uuid::now_v7()));
-        let rewrite: Result<()> = async {
-            let temp = OpenOptions::new()
-                .create_new(true)
-                .write(true)
-                .open(&temp_path)
-                .await
-                .context(
-                    ErrorKind::BackendFailure,
-                    "creating local-fs expiry temporary file",
-                )?;
-            let mut writer = BufWriter::new(temp);
-            let metadata_json = serde_json::to_string(&metadata)
-                .context(ErrorKind::Internal, "encoding local-fs object metadata")?;
-            writer.write_all(metadata_json.as_bytes()).await.context(
-                ErrorKind::BackendFailure,
-                "writing local-fs expiry metadata",
-            )?;
-            writer.write_all(b"\n").await.context(
-                ErrorKind::BackendFailure,
-                "writing local-fs expiry metadata",
-            )?;
-            tokio::io::copy(&mut reader, &mut writer).await.context(
-                ErrorKind::BackendFailure,
-                "copying local-fs object payload for expiry extension",
-            )?;
-            writer.flush().await.context(
-                ErrorKind::BackendFailure,
-                "flushing local-fs expiry temporary file",
-            )?;
-            let temp = writer.into_inner();
-            temp.sync_data().await.context(
-                ErrorKind::BackendFailure,
-                "syncing local-fs expiry temporary file",
-            )?;
-            drop(temp);
-            tokio::fs::rename(&temp_path, &path).await.context(
-                ErrorKind::BackendFailure,
-                "publishing local-fs expiry extension",
-            )?;
-            Ok(())
-        }
-        .await;
+        let mut draft = Draft::create(&path, &metadata).await?;
+        let result = tokio::io::copy(&mut reader, draft.writer()).await.context(
+            ErrorKind::BackendFailure,
+            "copying local-fs object payload for expiry extension",
+        );
 
-        if rewrite.is_err() {
-            let _ = tokio::fs::remove_file(&temp_path).await;
+        match result {
+            Ok(_) => {
+                draft.publish().await?;
+                Ok(true)
+            }
+            Err(error) => {
+                draft.discard().await;
+                Err(error)
+            }
         }
-        rewrite?;
-        Ok(true)
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
     async fn delete_object(&self, id: &ObjectId) -> Result<DeleteResponse> {
-        let _mutation_guard = self.mutation_lock.lock().await;
+        let _guard = self.write_lock.lock().await;
+
         objectstore_log::debug!("Deleting from local_fs backend");
-        let path = self.path.join(id.as_storage_path().to_string());
+        let path = self.path(id);
         let result = tokio::fs::remove_file(path).await;
         if let Err(e) = &result
             && e.kind() == io::ErrorKind::NotFound
@@ -593,64 +517,38 @@ impl MultipartUploadBackend for LocalFsBackend {
             }
         }
 
-        // Stream parts directly to the final object file
-        let _mutation_guard = self.mutation_lock.lock().await;
-        let path = self.path.join(id.as_storage_path().to_string());
-        tokio::fs::create_dir_all(path.parent().unwrap())
-            .await
-            .context(
-                ErrorKind::BackendFailure,
-                "creating local-fs object directory",
-            )?;
-        let file = OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(path)
-            .await
-            .context(
-                ErrorKind::BackendFailure,
-                "opening local-fs object for writing",
-            )?;
-        let mut writer = BufWriter::new(file);
+        // Assemble the parts into a draft before publishing the object.
+        let _guard = self.write_lock.lock().await;
+        let path = self.path(id);
+        Self::create_dir_all(&path).await?;
+        let mut draft = Draft::create(&path, &metadata).await?;
+        let assembly: Result<()> = async {
+            for completed in &parts {
+                let part_path = dir.join(format!("{}.part", completed.part_number));
+                let file = tokio::fs::File::open(&part_path)
+                    .await
+                    .context(ErrorKind::BackendFailure, "opening local-fs multipart part")?;
+                let mut reader = BufReader::new(file);
+                let mut header_line = String::new();
+                reader
+                    .read_line(&mut header_line)
+                    .await
+                    .context(ErrorKind::BackendFailure, "reading local-fs part header")?;
+                tokio::io::copy(&mut reader, draft.writer()).await.context(
+                    ErrorKind::BackendFailure,
+                    "assembling local-fs object payload",
+                )?;
+            }
+            Ok(())
+        }
+        .await;
 
-        let metadata_json = serde_json::to_string(&metadata)
-            .context(ErrorKind::Internal, "encoding local-fs object metadata")?;
-        writer.write_all(metadata_json.as_bytes()).await.context(
-            ErrorKind::BackendFailure,
-            "writing local-fs object metadata",
-        )?;
-        writer.write_all(b"\n").await.context(
-            ErrorKind::BackendFailure,
-            "writing local-fs object metadata",
-        )?;
-
-        for completed in &parts {
-            let part_path = dir.join(format!("{}.part", completed.part_number));
-            let file = tokio::fs::File::open(&part_path)
-                .await
-                .context(ErrorKind::BackendFailure, "opening local-fs multipart part")?;
-            let mut reader = BufReader::new(file);
-            let mut header_line = String::new();
-            reader
-                .read_line(&mut header_line)
-                .await
-                .context(ErrorKind::BackendFailure, "reading local-fs part header")?;
-            tokio::io::copy(&mut reader, &mut writer).await.context(
-                ErrorKind::BackendFailure,
-                "assembling local-fs object payload",
-            )?;
+        if let Err(error) = assembly {
+            draft.discard().await;
+            return Err(error);
         }
 
-        writer
-            .flush()
-            .await
-            .context(ErrorKind::BackendFailure, "flushing local-fs object")?;
-        let file = writer.into_inner();
-        file.sync_data()
-            .await
-            .context(ErrorKind::BackendFailure, "syncing local-fs object")?;
-        drop(file);
+        draft.publish().await?;
 
         // Clean up multipart state
         tokio::fs::remove_dir_all(dir).await.context(
@@ -662,13 +560,162 @@ impl MultipartUploadBackend for LocalFsBackend {
     }
 }
 
+struct ObjectFile {
+    metadata: Metadata,
+    preamble_len: u64,
+    payload_size: u64,
+    reader: BufReader<tokio::fs::File>,
+}
+
+async fn read_metadata_preamble<R>(reader: &mut R) -> Result<(Metadata, usize)>
+where
+    R: tokio::io::AsyncBufRead + Unpin,
+{
+    let mut metadata_line = String::new();
+    let preamble_len = reader.read_line(&mut metadata_line).await.context(
+        ErrorKind::BackendFailure,
+        "reading local-fs object metadata",
+    )?;
+    let metadata = serde_json::from_str(metadata_line.trim_end())
+        .context(ErrorKind::CorruptData, "decoding local-fs object metadata")?;
+    Ok((metadata, preamble_len))
+}
+
+impl ObjectFile {
+    /// Opens an object file, returning `None` when it does not exist.
+    async fn try_open(path: &Path) -> Result<Option<Self>> {
+        let file = match OpenOptions::new().read(true).open(path).await {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            result => result.context(ErrorKind::BackendFailure, "opening local-fs object")?,
+        };
+
+        let mut reader = BufReader::new(file);
+        let (mut metadata, preamble_len) = read_metadata_preamble(&mut reader).await?;
+
+        if metadata.is_expired(SystemTime::now()) {
+            objectstore_log::debug!("Object found but past expiry");
+            return Ok(None);
+        }
+
+        let preamble_len = preamble_len as u64;
+        let file_len = reader
+            .get_ref()
+            .metadata()
+            .await
+            .context(ErrorKind::BackendFailure, "reading local-fs object size")?
+            .len();
+
+        let payload_size = file_len.checked_sub(preamble_len).ok_or_else(|| {
+            Error::new(ErrorKind::CorruptData, "reading truncated local-fs object")
+        })?;
+
+        metadata.size = Some(payload_size as usize);
+
+        Ok(Some(Self {
+            metadata,
+            preamble_len,
+            payload_size,
+            reader,
+        }))
+    }
+}
+
+struct Draft {
+    path: PathBuf,
+    target: PathBuf,
+    writer: BufWriter<tokio::fs::File>,
+}
+
+impl Draft {
+    async fn create(target: &Path, metadata: &Metadata) -> Result<Self> {
+        let path = target.with_extension(format!("{}.draft", uuid::Uuid::now_v7()));
+        let file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&path)
+            .await
+            .context(ErrorKind::BackendFailure, "creating local-fs object draft")?;
+
+        let mut draft = Self {
+            path,
+            target: target.to_path_buf(),
+            writer: BufWriter::new(file),
+        };
+
+        if let Err(error) = draft.write_preamble(metadata).await {
+            draft.discard().await;
+            return Err(error);
+        }
+
+        Ok(draft)
+    }
+
+    async fn write_preamble(&mut self, metadata: &Metadata) -> Result<()> {
+        let metadata_json = serde_json::to_string(metadata)
+            .context(ErrorKind::Internal, "encoding local-fs object metadata")?;
+        self.writer
+            .write_all(metadata_json.as_bytes())
+            .await
+            .context(
+                ErrorKind::BackendFailure,
+                "writing local-fs object metadata",
+            )?;
+        self.writer.write_all(b"\n").await.context(
+            ErrorKind::BackendFailure,
+            "writing local-fs object metadata",
+        )
+    }
+
+    fn writer(&mut self) -> &mut BufWriter<tokio::fs::File> {
+        &mut self.writer
+    }
+
+    async fn publish(self) -> Result<()> {
+        let Self {
+            path,
+            target,
+            mut writer,
+        } = self;
+
+        let result: Result<()> = async {
+            writer
+                .flush()
+                .await
+                .context(ErrorKind::BackendFailure, "flushing local-fs object draft")?;
+            let file = writer.into_inner();
+            file.sync_data()
+                .await
+                .context(ErrorKind::BackendFailure, "syncing local-fs object draft")?;
+            drop(file);
+            tokio::fs::rename(&path, target).await.context(
+                ErrorKind::BackendFailure,
+                "publishing local-fs object draft",
+            )?;
+            Ok(())
+        }
+        .await;
+
+        if result.is_err() {
+            let _ = tokio::fs::remove_file(path).await;
+        }
+        result
+    }
+
+    async fn discard(self) {
+        let Self { path, writer, .. } = self;
+        drop(writer);
+        let _ = tokio::fs::remove_file(path).await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::num::NonZeroU32;
     use std::time::{Duration, SystemTime};
 
-    use bytes::BytesMut;
-    use futures_util::TryStreamExt;
+    use bytes::{Bytes, BytesMut};
+    use futures_util::{TryStreamExt, stream as futures_stream};
     use objectstore_types::metadata::{Compression, ExpirationPolicy};
     use objectstore_types::scope::{Scope, Scopes};
 
@@ -718,6 +765,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn failed_put_preserves_published_object() {
+        let (_tempdir, backend) = make_backend();
+        let id = make_id();
+        let original_metadata = Metadata {
+            content_type: "text/original".into(),
+            ..Default::default()
+        };
+        backend
+            .put_object(&id, &original_metadata, stream::single("original"))
+            .await
+            .unwrap();
+
+        let replacement_metadata = Metadata {
+            content_type: "text/replacement".into(),
+            ..Default::default()
+        };
+        let replacement = futures_stream::iter([
+            Ok(Bytes::from_static(b"partial")),
+            Err(stream::ClientError::new(io::Error::other(
+                "replacement stream failed",
+            ))),
+        ])
+        .boxed();
+        let error = backend
+            .put_object(&id, &replacement_metadata, replacement)
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::ClientStream);
+
+        let (metadata, _, payload) = backend.get_object(&id, None).await.unwrap().unwrap();
+        assert_eq!(metadata.content_type, original_metadata.content_type);
+        assert_eq!(stream::read_to_vec(payload).await.unwrap(), b"original");
+
+        let object_path = backend.path(&id);
+        let entries = std::fs::read_dir(object_path.parent().unwrap())
+            .unwrap()
+            .flat_map(|entry| entry.map(|entry| entry.path()))
+            .collect::<Vec<_>>();
+        assert!(
+            entries
+                .iter()
+                .all(|path| !path.to_string_lossy().ends_with(".draft"))
+        );
+    }
+
+    #[tokio::test]
     async fn set_expiry_rewrites_metadata_and_preserves_payload() {
         let tempdir = tempfile::tempdir().unwrap();
         let backend = LocalFsBackend::new(FileSystemConfig {
@@ -744,7 +837,7 @@ mod tests {
         assert_eq!(updated.time_expires, Some(requested));
         assert_eq!(stream::read_to_vec(payload).await.unwrap(), b"payload");
 
-        let object_path = backend.path.join(id.as_storage_path().to_string());
+        let object_path = backend.path(&id);
         let entries = std::fs::read_dir(object_path.parent().unwrap())
             .unwrap()
             .flat_map(|entry| entry.map(|entry| entry.path()))

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -245,9 +245,7 @@ where
         let access_time = SystemTime::now();
 
         // Filter already expired objects but leave them to garbage collection
-        if metadata.expiration_policy.is_timeout()
-            && metadata.time_expires.is_some_and(|ts| ts < access_time)
-        {
+        if metadata.is_expired(access_time) {
             objectstore_log::debug!("Object found but past expiry");
             response.drain_body().await;
             return Ok(None);
@@ -395,13 +393,13 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
             response.drain_body().await;
             return Ok(false);
         };
+
         if metadata.expiration_policy.is_manual() || current_expiry < SystemTime::now() {
             response.drain_body().await;
-            return Ok(false);
-        }
-        if current_expiry >= expire_at {
+            return Ok(false); // already expired
+        } else if current_expiry >= expire_at {
             response.drain_body().await;
-            return Ok(true);
+            return Ok(true); // already satisfied
         }
 
         let revision = response

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -8,7 +8,7 @@ use std::{fmt, io};
 use futures_util::{StreamExt, TryStreamExt};
 use objectstore_types::metadata::{HEADER_SIZE, Metadata};
 use objectstore_types::range::{ByteRange, ContentRange};
-use reqwest::header::{HeaderMap, HeaderName};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use reqwest::{Body, IntoUrl, Method, RequestBuilder, Response, StatusCode};
 
 use super::extensions::{ResponseExt, SendTraced};
@@ -144,7 +144,7 @@ fn metadata_to_gcs_headers(
 
     // GCS custom-time for lifecycle expiration
     if let Some(expires_at) = metadata.time_expires {
-        let expires_at = humantime::format_rfc3339_millis(expires_at);
+        let expires_at = humantime::format_rfc3339_seconds(expires_at);
         headers.append(GCS_CUSTOM_TIME, expires_at.to_string().parse()?);
     }
     Ok(headers)
@@ -259,42 +259,29 @@ where
         &self,
         id: &ObjectId,
         metadata: &Metadata,
-        generation: Option<(&str, &str)>,
+        etag: &HeaderValue,
     ) -> Result<bool> {
-        // NB: Meta updates require copy + REPLACE along with *all* metadata. See
-        // https://cloud.google.com/storage/docs/xml-api/put-object-copy
-        let mut request = self
+        // NB: Meta updates require CopyObject + REPLACE along with *all* metadata. See
+        // https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html
+        let request = self
             .request(Method::PUT, self.object_url(id))
             .await?
             .header(
-                "x-goog-copy-source",
+                "x-amz-copy-source",
                 format!("/{}/{}", self.bucket, id.as_storage_path()),
             )
-            .header("x-goog-metadata-directive", "REPLACE")
+            .header("x-amz-metadata-directive", "REPLACE")
+            .header("x-amz-copy-source-if-match", etag.clone())
             .headers(
                 metadata_to_gcs_headers(metadata, GCS_CUSTOM_PREFIX)
                     .context(ErrorKind::InvalidMetadata, "encoding S3 object metadata")?,
             );
 
-        if let Some((generation, metageneration)) = generation {
-            request = request
-                .header("x-goog-copy-source-if-generation-match", generation)
-                .header("x-goog-copy-source-if-metageneration-match", metageneration)
-                .header("x-goog-if-generation-match", generation)
-                .header("x-goog-if-metageneration-match", metageneration);
-        } else {
-            // Generic S3-compatible servers do not expose GCS revision
-            // headers. This fallback can copy over a concurrent replacement or
-            // delete, and REPLACE can restore metadata from this stale HEAD.
-            // Broader provider-specific conditional-copy support is deferred.
-            objectstore_metrics::count!("s3.expiry_extension_unguarded");
-        }
-
         let response = request.send_traced().await;
         let response = response.reqwest_context("updating S3 expiration")?;
         if matches!(
             response.status(),
-            StatusCode::NOT_FOUND | StatusCode::PRECONDITION_FAILED
+            StatusCode::NOT_FOUND | StatusCode::CONFLICT | StatusCode::PRECONDITION_FAILED
         ) {
             response.drain_body().await;
             return Ok(false);
@@ -393,40 +380,19 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
             response.drain_body().await;
             return Ok(false);
         };
-
-        if metadata.expiration_policy.is_manual() || current_expiry < SystemTime::now() {
-            response.drain_body().await;
-            return Ok(false); // already expired
-        } else if current_expiry >= expire_at {
+        if current_expiry >= expire_at {
             response.drain_body().await;
             return Ok(true); // already satisfied
         }
 
-        let revision = response
-            .headers()
-            .get("x-goog-generation")
-            .and_then(|value| value.to_str().ok())
-            .zip(
-                response
-                    .headers()
-                    .get("x-goog-metageneration")
-                    .and_then(|value| value.to_str().ok()),
-            )
-            .map(|(generation, metageneration)| (generation.to_owned(), metageneration.to_owned()));
+        let etag = response.headers().get(reqwest::header::ETAG).cloned();
         response.drain_body().await;
+        let etag = etag.ok_or_else(|| {
+            Error::new(ErrorKind::BackendFailure, "S3 HEAD response missing ETag")
+        })?;
 
         metadata.time_expires = Some(expire_at);
-        // Observing a live object is not atomic with wall-clock expiry or the
-        // provider's native collection. Revision-aware implementations reject
-        // a copy after the observed object changes; the fallback below cannot.
-        self.update_metadata(
-            id,
-            &metadata,
-            revision
-                .as_ref()
-                .map(|(generation, metageneration)| (generation.as_str(), metageneration.as_str())),
-        )
-        .await
+        self.update_metadata(id, &metadata, &etag).await
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
@@ -502,37 +468,13 @@ mod tests {
         String::from_utf8(bytes).unwrap()
     }
 
-    fn start_expiry_server(
-        metadata: &Metadata,
-        include_revision: bool,
+    fn start_copy_server(
         copy_status: &'static str,
     ) -> (String, mpsc::Receiver<String>, thread::JoinHandle<()>) {
         let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
         let endpoint = format!("http://{}", listener.local_addr().unwrap());
-        let headers = metadata_to_gcs_headers(metadata, GCS_CUSTOM_PREFIX).unwrap();
-        let mut response_headers = String::new();
-        for (name, value) in &headers {
-            response_headers.push_str(name.as_str());
-            response_headers.push_str(": ");
-            response_headers.push_str(value.to_str().unwrap());
-            response_headers.push_str("\r\n");
-        }
-        if include_revision {
-            response_headers.push_str("x-goog-generation: 42\r\n");
-            response_headers.push_str("x-goog-metageneration: 7\r\n");
-        }
-
         let (request_tx, request_rx) = mpsc::channel();
         let server = thread::spawn(move || {
-            let (mut head, _) = listener.accept().unwrap();
-            let request = read_http_request(&mut head);
-            assert!(request.starts_with("HEAD "));
-            write!(
-                head,
-                "HTTP/1.1 200 OK\r\nContent-Length: 7\r\n{response_headers}Connection: close\r\n\r\n"
-            )
-            .unwrap();
-
             let (mut copy, _) = listener.accept().unwrap();
             request_tx.send(read_http_request(&mut copy)).unwrap();
             write!(
@@ -545,51 +487,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn set_expiry_guards_gcs_xml_copy_when_revision_headers_are_available() {
-        let old_expiry = SystemTime::now() + Duration::from_mins(10);
-        let metadata = Metadata {
-            expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_hours(1)),
-            time_expires: Some(old_expiry),
-            ..Default::default()
-        };
-        let (endpoint, request_rx, server) = start_expiry_server(&metadata, true, "200 OK");
-        let backend = S3CompatibleBackend::without_token(S3CompatibleConfig {
-            endpoint,
-            bucket: "bucket".into(),
-        });
-
-        assert!(
-            backend
-                .set_expiry(&make_id(), old_expiry + Duration::from_hours(1))
-                .await
-                .unwrap()
-        );
-        let request = request_rx.recv().unwrap().to_ascii_lowercase();
-        for header in [
-            "x-goog-copy-source-if-generation-match: 42",
-            "x-goog-copy-source-if-metageneration-match: 7",
-            "x-goog-if-generation-match: 42",
-            "x-goog-if-metageneration-match: 7",
+    async fn update_metadata_uses_conditional_s3_copy() {
+        for (status, expected) in [
+            ("200 OK", true),
+            ("404 Not Found", false),
+            ("409 Conflict", false),
+            ("412 Precondition Failed", false),
         ] {
-            assert!(request.contains(header), "missing {header} in {request}");
-        }
-        server.join().unwrap();
-    }
-
-    #[tokio::test]
-    async fn set_expiry_uses_unguarded_fallback_and_treats_precondition_as_conflict() {
-        for (include_revision, status, expected) in [
-            (false, "200 OK", true),
-            (true, "412 Precondition Failed", false),
-        ] {
-            let old_expiry = SystemTime::now() + Duration::from_mins(10);
-            let metadata = Metadata {
-                expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_hours(1)),
-                time_expires: Some(old_expiry),
-                ..Default::default()
-            };
-            let (endpoint, request_rx, server) =
-                start_expiry_server(&metadata, include_revision, status);
+            let (endpoint, request_rx, server) = start_copy_server(status);
             let backend = S3CompatibleBackend::without_token(S3CompatibleConfig {
                 endpoint,
                 bucket: "bucket".into(),
@@ -597,16 +502,19 @@ mod tests {
 
             assert_eq!(
                 backend
-                    .set_expiry(&make_id(), old_expiry + Duration::from_hours(1))
+                    .update_metadata(
+                        &make_id(),
+                        &Metadata::default(),
+                        &HeaderValue::from_static("\"etag\""),
+                    )
                     .await
                     .unwrap(),
                 expected
             );
             let request = request_rx.recv().unwrap().to_ascii_lowercase();
-            assert_eq!(
-                request.contains("x-goog-if-generation-match"),
-                include_revision
-            );
+            assert!(request.contains("x-amz-copy-source: /bucket/"));
+            assert!(request.contains("x-amz-metadata-directive: replace"));
+            assert!(request.contains("x-amz-copy-source-if-match: \"etag\""));
             server.join().unwrap();
         }
     }
@@ -634,11 +542,8 @@ mod tests {
         };
 
         let headers = metadata_to_gcs_headers(&metadata, GCS_CUSTOM_PREFIX).unwrap();
-
-        // The lifecycle custom-time is the server-resolved expiry at the
-        // cross-backend millisecond precision.
         let custom_time = headers.get(GCS_CUSTOM_TIME).unwrap().to_str().unwrap();
-        let expected = humantime::format_rfc3339_millis(expires).to_string();
+        let expected = humantime::format_rfc3339_seconds(expires).to_string();
         assert_eq!(custom_time, expected);
     }
 

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -387,7 +387,7 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
 
     #[tracing::instrument(level = "debug", skip(self))]
     async fn set_expiry(&self, id: &ObjectId, expire_at: SystemTime) -> Result<bool> {
-        let expire_at = super::common::normalize_expiry(expire_at)?;
+        let expire_at = common::normalize_expiry(expire_at)?;
         let Some((mut metadata, _, response)) = self.request_object(Method::HEAD, id, None).await?
         else {
             return Ok(false);
@@ -462,7 +462,7 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
 mod tests {
     use std::collections::BTreeMap;
     use std::io::{Read, Write};
-    use std::net::TcpListener;
+    use std::net::{TcpListener, TcpStream};
     use std::sync::mpsc;
     use std::thread;
     use std::time::Duration;
@@ -495,7 +495,7 @@ mod tests {
         })
     }
 
-    fn read_http_request(connection: &mut std::net::TcpStream) -> String {
+    fn read_http_request(connection: &mut TcpStream) -> String {
         let mut bytes = Vec::new();
         let mut byte = [0];
         while !bytes.ends_with(b"\r\n\r\n") {

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -144,7 +144,7 @@ fn metadata_to_gcs_headers(
 
     // GCS custom-time for lifecycle expiration
     if let Some(expires_at) = metadata.time_expires {
-        let expires_at = humantime::format_rfc3339_seconds(expires_at);
+        let expires_at = humantime::format_rfc3339_millis(expires_at);
         headers.append(GCS_CUSTOM_TIME, expires_at.to_string().parse()?);
     }
     Ok(headers)
@@ -169,9 +169,8 @@ where
         Ok(builder)
     }
 
-    /// Fetches object metadata using the given HTTP method (GET or HEAD),
-    /// bumps TTI if needed, and returns the parsed metadata along with the
-    /// response (so `get_object` can read the body from a GET).
+    /// Fetches object metadata using the given HTTP method (GET or HEAD) and
+    /// returns it with the response without modifying the object.
     async fn request_object(
         &self,
         method: Method,
@@ -243,7 +242,6 @@ where
             None
         };
 
-        // TODO: Inject the access time from the request.
         let access_time = SystemTime::now();
 
         // Filter already expired objects but leave them to garbage collection
@@ -255,22 +253,20 @@ where
             return Ok(None);
         }
 
-        // TODO: extract into dedicated call from service
-        // TODO: Schedule into background persistently so this doesn't get lost on restarts
-        if let Some(new_expire_at) = metadata.check_tti_bump(access_time) {
-            let mut bumped = metadata.clone();
-            bumped.time_expires = Some(new_expire_at);
-            self.update_metadata(id, &bumped).await?;
-        }
-
         Ok(Some((metadata, content_range, response)))
     }
 
     /// Issues a request to update the metadata for the given object.
-    async fn update_metadata(&self, id: &ObjectId, metadata: &Metadata) -> Result<()> {
+    async fn update_metadata(
+        &self,
+        id: &ObjectId,
+        metadata: &Metadata,
+        generation: Option<(&str, &str)>,
+    ) -> Result<bool> {
         // NB: Meta updates require copy + REPLACE along with *all* metadata. See
         // https://cloud.google.com/storage/docs/xml-api/put-object-copy
-        self.request(Method::PUT, self.object_url(id))
+        let mut request = self
+            .request(Method::PUT, self.object_url(id))
             .await?
             .header(
                 "x-goog-copy-source",
@@ -280,15 +276,38 @@ where
             .headers(
                 metadata_to_gcs_headers(metadata, GCS_CUSTOM_PREFIX)
                     .context(ErrorKind::InvalidMetadata, "encoding S3 object metadata")?,
-            )
-            .send_traced()
-            .await
+            );
+
+        if let Some((generation, metageneration)) = generation {
+            request = request
+                .header("x-goog-copy-source-if-generation-match", generation)
+                .header("x-goog-copy-source-if-metageneration-match", metageneration)
+                .header("x-goog-if-generation-match", generation)
+                .header("x-goog-if-metageneration-match", metageneration);
+        } else {
+            // Generic S3-compatible servers do not expose GCS revision
+            // headers. This fallback can copy over a concurrent replacement or
+            // delete, and REPLACE can restore metadata from this stale HEAD.
+            // Broader provider-specific conditional-copy support is deferred.
+            objectstore_metrics::count!("s3.expiry_extension_unguarded");
+        }
+
+        let response = request.send_traced().await;
+        let response = response.reqwest_context("updating S3 expiration")?;
+        if matches!(
+            response.status(),
+            StatusCode::NOT_FOUND | StatusCode::PRECONDITION_FAILED
+        ) {
+            response.drain_body().await;
+            return Ok(false);
+        }
+        response
             .check_error("updating S3 expiration")
             .await?
             .drain_body()
             .await;
 
-        Ok(())
+        Ok(true)
     }
 }
 
@@ -367,6 +386,53 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
+    async fn set_expiry(&self, id: &ObjectId, expire_at: SystemTime) -> Result<bool> {
+        let expire_at = super::common::normalize_expiry(expire_at)?;
+        let Some((mut metadata, _, response)) = self.request_object(Method::HEAD, id, None).await?
+        else {
+            return Ok(false);
+        };
+        let Some(current_expiry) = metadata.time_expires else {
+            response.drain_body().await;
+            return Ok(false);
+        };
+        if metadata.expiration_policy.is_manual() || current_expiry < SystemTime::now() {
+            response.drain_body().await;
+            return Ok(false);
+        }
+        if current_expiry >= expire_at {
+            response.drain_body().await;
+            return Ok(true);
+        }
+
+        let revision = response
+            .headers()
+            .get("x-goog-generation")
+            .and_then(|value| value.to_str().ok())
+            .zip(
+                response
+                    .headers()
+                    .get("x-goog-metageneration")
+                    .and_then(|value| value.to_str().ok()),
+            )
+            .map(|(generation, metageneration)| (generation.to_owned(), metageneration.to_owned()));
+        response.drain_body().await;
+
+        metadata.time_expires = Some(expire_at);
+        // Observing a live object is not atomic with wall-clock expiry or the
+        // provider's native collection. Revision-aware implementations reject
+        // a copy after the observed object changes; the fallback below cannot.
+        self.update_metadata(
+            id,
+            &metadata,
+            revision
+                .as_ref()
+                .map(|(generation, metageneration)| (generation.as_str(), metageneration.as_str())),
+        )
+        .await
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn delete_object(&self, id: &ObjectId) -> Result<DeleteResponse> {
         objectstore_log::debug!("Deleting from s3_compatible backend");
         let response = self
@@ -395,6 +461,10 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::mpsc;
+    use std::thread;
     use std::time::Duration;
 
     use anyhow::Result;
@@ -425,6 +495,125 @@ mod tests {
         })
     }
 
+    fn read_http_request(connection: &mut std::net::TcpStream) -> String {
+        let mut bytes = Vec::new();
+        let mut byte = [0];
+        while !bytes.ends_with(b"\r\n\r\n") {
+            connection.read_exact(&mut byte).unwrap();
+            bytes.push(byte[0]);
+        }
+        String::from_utf8(bytes).unwrap()
+    }
+
+    fn start_expiry_server(
+        metadata: &Metadata,
+        include_revision: bool,
+        copy_status: &'static str,
+    ) -> (String, mpsc::Receiver<String>, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let endpoint = format!("http://{}", listener.local_addr().unwrap());
+        let headers = metadata_to_gcs_headers(metadata, GCS_CUSTOM_PREFIX).unwrap();
+        let mut response_headers = String::new();
+        for (name, value) in &headers {
+            response_headers.push_str(name.as_str());
+            response_headers.push_str(": ");
+            response_headers.push_str(value.to_str().unwrap());
+            response_headers.push_str("\r\n");
+        }
+        if include_revision {
+            response_headers.push_str("x-goog-generation: 42\r\n");
+            response_headers.push_str("x-goog-metageneration: 7\r\n");
+        }
+
+        let (request_tx, request_rx) = mpsc::channel();
+        let server = thread::spawn(move || {
+            let (mut head, _) = listener.accept().unwrap();
+            let request = read_http_request(&mut head);
+            assert!(request.starts_with("HEAD "));
+            write!(
+                head,
+                "HTTP/1.1 200 OK\r\nContent-Length: 7\r\n{response_headers}Connection: close\r\n\r\n"
+            )
+            .unwrap();
+
+            let (mut copy, _) = listener.accept().unwrap();
+            request_tx.send(read_http_request(&mut copy)).unwrap();
+            write!(
+                copy,
+                "HTTP/1.1 {copy_status}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            )
+            .unwrap();
+        });
+        (endpoint, request_rx, server)
+    }
+
+    #[tokio::test]
+    async fn set_expiry_guards_gcs_xml_copy_when_revision_headers_are_available() {
+        let old_expiry = SystemTime::now() + Duration::from_mins(10);
+        let metadata = Metadata {
+            expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_hours(1)),
+            time_expires: Some(old_expiry),
+            ..Default::default()
+        };
+        let (endpoint, request_rx, server) = start_expiry_server(&metadata, true, "200 OK");
+        let backend = S3CompatibleBackend::without_token(S3CompatibleConfig {
+            endpoint,
+            bucket: "bucket".into(),
+        });
+
+        assert!(
+            backend
+                .set_expiry(&make_id(), old_expiry + Duration::from_hours(1))
+                .await
+                .unwrap()
+        );
+        let request = request_rx.recv().unwrap().to_ascii_lowercase();
+        for header in [
+            "x-goog-copy-source-if-generation-match: 42",
+            "x-goog-copy-source-if-metageneration-match: 7",
+            "x-goog-if-generation-match: 42",
+            "x-goog-if-metageneration-match: 7",
+        ] {
+            assert!(request.contains(header), "missing {header} in {request}");
+        }
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn set_expiry_uses_unguarded_fallback_and_treats_precondition_as_conflict() {
+        for (include_revision, status, expected) in [
+            (false, "200 OK", true),
+            (true, "412 Precondition Failed", false),
+        ] {
+            let old_expiry = SystemTime::now() + Duration::from_mins(10);
+            let metadata = Metadata {
+                expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_hours(1)),
+                time_expires: Some(old_expiry),
+                ..Default::default()
+            };
+            let (endpoint, request_rx, server) =
+                start_expiry_server(&metadata, include_revision, status);
+            let backend = S3CompatibleBackend::without_token(S3CompatibleConfig {
+                endpoint,
+                bucket: "bucket".into(),
+            });
+
+            assert_eq!(
+                backend
+                    .set_expiry(&make_id(), old_expiry + Duration::from_hours(1))
+                    .await
+                    .unwrap(),
+                expected
+            );
+            let request = request_rx.recv().unwrap().to_ascii_lowercase();
+            assert_eq!(
+                request.contains("x-goog-if-generation-match"),
+                include_revision
+            );
+            server.join().unwrap();
+        }
+    }
+
     #[test]
     fn metadata_to_gcs_headers_omits_size() {
         let metadata = Metadata {
@@ -449,9 +638,10 @@ mod tests {
 
         let headers = metadata_to_gcs_headers(&metadata, GCS_CUSTOM_PREFIX).unwrap();
 
-        // The lifecycle custom-time is the server-resolved expiry (second precision).
+        // The lifecycle custom-time is the server-resolved expiry at the
+        // cross-backend millisecond precision.
         let custom_time = headers.get(GCS_CUSTOM_TIME).unwrap().to_str().unwrap();
-        let expected = humantime::format_rfc3339_seconds(expires).to_string();
+        let expected = humantime::format_rfc3339_millis(expires).to_string();
         assert_eq!(custom_time, expected);
     }
 

--- a/objectstore-service/src/backend/s3_compatible.rs
+++ b/objectstore-service/src/backend/s3_compatible.rs
@@ -387,7 +387,6 @@ impl<T: TokenProvider> Backend for S3CompatibleBackend<T> {
 
     #[tracing::instrument(level = "debug", skip(self))]
     async fn set_expiry(&self, id: &ObjectId, expire_at: SystemTime) -> Result<bool> {
-        let expire_at = common::normalize_expiry(expire_at)?;
         let Some((mut metadata, _, response)) = self.request_object(Method::HEAD, id, None).await?
         else {
             return Ok(false);

--- a/objectstore-service/src/backend/testing.rs
+++ b/objectstore-service/src/backend/testing.rs
@@ -35,6 +35,7 @@
 //! ```
 
 use std::fmt;
+use std::time::SystemTime;
 
 use bytes::Bytes;
 use objectstore_types::metadata::Metadata;
@@ -102,6 +103,16 @@ pub trait Hooks: fmt::Debug + Send + Sync + 'static {
         inner.get_metadata(id).await
     }
 
+    /// Intercepts [`Backend::set_expiry`]. Default delegates to `inner`.
+    async fn set_expiry(
+        &self,
+        inner: &InMemoryBackend,
+        id: &ObjectId,
+        expire_at: SystemTime,
+    ) -> Result<bool> {
+        inner.set_expiry(id, expire_at).await
+    }
+
     /// Intercepts [`Backend::delete_object`]. Default delegates to `inner`.
     async fn delete_object(
         &self,
@@ -146,6 +157,19 @@ pub trait Hooks: fmt::Debug + Send + Sync + 'static {
         id: &ObjectId,
     ) -> Result<TieredMetadata> {
         inner.get_tiered_metadata(id).await
+    }
+
+    /// Intercepts [`HighVolumeBackend::set_expiry_if_matches`].
+    async fn set_expiry_if_matches(
+        &self,
+        inner: &InMemoryBackend,
+        id: &ObjectId,
+        expire_at: SystemTime,
+        expected_target: Option<&ObjectId>,
+    ) -> Result<bool> {
+        inner
+            .set_expiry_if_matches(id, expire_at, expected_target)
+            .await
     }
 
     /// Intercepts [`HighVolumeBackend::delete_non_tombstone`]. Default delegates to `inner`.
@@ -355,6 +379,10 @@ impl<H: Hooks> Backend for TestBackend<H> {
         self.hooks.get_metadata(&self.inner, id).await
     }
 
+    async fn set_expiry(&self, id: &ObjectId, expire_at: SystemTime) -> Result<bool> {
+        self.hooks.set_expiry(&self.inner, id, expire_at).await
+    }
+
     async fn delete_object(&self, id: &ObjectId) -> Result<DeleteResponse> {
         self.hooks.delete_object(&self.inner, id).await
     }
@@ -419,6 +447,17 @@ impl<H: Hooks> HighVolumeBackend for TestBackend<H> {
 
     async fn get_tiered_metadata(&self, id: &ObjectId) -> Result<TieredMetadata> {
         self.hooks.get_tiered_metadata(&self.inner, id).await
+    }
+
+    async fn set_expiry_if_matches(
+        &self,
+        id: &ObjectId,
+        expire_at: SystemTime,
+        expected_target: Option<&ObjectId>,
+    ) -> Result<bool> {
+        self.hooks
+            .set_expiry_if_matches(&self.inner, id, expire_at, expected_target)
+            .await
     }
 
     async fn delete_non_tombstone(&self, id: &ObjectId) -> Result<Option<Tombstone>> {

--- a/objectstore-service/src/backend/testing.rs
+++ b/objectstore-service/src/backend/testing.rs
@@ -45,7 +45,8 @@ use objectstore_types::resumable::{SessionToken, UploadProgress};
 
 use crate::backend::common::{
     Backend, DeleteResponse, GetResponse, HighVolumeBackend, MetadataResponse,
-    MultipartUploadBackend, PutResponse, TieredGet, TieredMetadata, TieredWrite, Tombstone,
+    MultipartUploadBackend, PutResponse, TieredGet, TieredMetadata, TieredUpdate, TieredWrite,
+    Tombstone,
 };
 use crate::backend::in_memory::InMemoryBackend;
 use crate::error::Result;
@@ -159,19 +160,6 @@ pub trait Hooks: fmt::Debug + Send + Sync + 'static {
         inner.get_tiered_metadata(id).await
     }
 
-    /// Intercepts [`HighVolumeBackend::set_expiry_if_matches`].
-    async fn set_expiry_if_matches(
-        &self,
-        inner: &InMemoryBackend,
-        id: &ObjectId,
-        expire_at: SystemTime,
-        expected_target: Option<&ObjectId>,
-    ) -> Result<bool> {
-        inner
-            .set_expiry_if_matches(id, expire_at, expected_target)
-            .await
-    }
-
     /// Intercepts [`HighVolumeBackend::delete_non_tombstone`]. Default delegates to `inner`.
     async fn delete_non_tombstone(
         &self,
@@ -190,6 +178,17 @@ pub trait Hooks: fmt::Debug + Send + Sync + 'static {
         write: TieredWrite,
     ) -> Result<bool> {
         inner.compare_and_write(id, current, write).await
+    }
+
+    /// Intercepts [`HighVolumeBackend::compare_and_update`]. Default delegates to `inner`.
+    async fn compare_and_update(
+        &self,
+        inner: &InMemoryBackend,
+        id: &ObjectId,
+        current: Option<&ObjectId>,
+        update: TieredUpdate,
+    ) -> Result<bool> {
+        inner.compare_and_update(id, current, update).await
     }
 
     // --- MultipartUploadBackend methods ---
@@ -449,17 +448,6 @@ impl<H: Hooks> HighVolumeBackend for TestBackend<H> {
         self.hooks.get_tiered_metadata(&self.inner, id).await
     }
 
-    async fn set_expiry_if_matches(
-        &self,
-        id: &ObjectId,
-        expire_at: SystemTime,
-        expected_target: Option<&ObjectId>,
-    ) -> Result<bool> {
-        self.hooks
-            .set_expiry_if_matches(&self.inner, id, expire_at, expected_target)
-            .await
-    }
-
     async fn delete_non_tombstone(&self, id: &ObjectId) -> Result<Option<Tombstone>> {
         self.hooks.delete_non_tombstone(&self.inner, id).await
     }
@@ -472,6 +460,17 @@ impl<H: Hooks> HighVolumeBackend for TestBackend<H> {
     ) -> Result<bool> {
         self.hooks
             .compare_and_write(&self.inner, id, current, write)
+            .await
+    }
+
+    async fn compare_and_update(
+        &self,
+        id: &ObjectId,
+        current: Option<&ObjectId>,
+        update: TieredUpdate,
+    ) -> Result<bool> {
+        self.hooks
+            .compare_and_update(&self.inner, id, current, update)
             .await
     }
 }

--- a/objectstore-service/src/backend/tiered.rs
+++ b/objectstore-service/src/backend/tiered.rs
@@ -125,7 +125,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::backend::changelog::{Change, ChangeGuard, ChangeLog, ChangeManager, ChangePhase};
 use crate::backend::common::{
-    self, Backend, DeleteResponse, GetResponse, HighVolumeBackend, MetadataResponse,
+    Backend, DeleteResponse, GetResponse, HighVolumeBackend, MetadataResponse,
     MultipartUploadBackend, PutResponse, TieredGet, TieredMetadata, TieredUpdate, TieredWrite,
     Tombstone,
 };
@@ -535,7 +535,6 @@ impl Backend for TieredStorage {
     }
 
     async fn set_expiry(&self, id: &ObjectId, expire_at: SystemTime) -> Result<bool> {
-        let expire_at = common::normalize_expiry(expire_at)?;
         match self.inner.high_volume.get_tiered_metadata(id).await? {
             TieredMetadata::NotFound => Ok(false),
             TieredMetadata::Object(_) => {
@@ -1109,14 +1108,13 @@ mod tests {
         let requested = SystemTime::now() + Duration::from_hours(1);
         assert!(storage.set_expiry(&id, requested).await.unwrap());
         assert_eq!(events.lock().unwrap().as_slice(), &["lt", "hv"]);
-        let normalized = common::normalize_expiry(requested).unwrap();
         assert_eq!(
             lt.inner.get(&target).expect_object().0.time_expires,
-            Some(normalized)
+            Some(requested)
         );
         assert_eq!(
             hv.inner.get(&id).expect_tombstone().time_expires,
-            Some(normalized)
+            Some(requested)
         );
     }
 
@@ -1125,8 +1123,7 @@ mod tests {
         let (storage, hv, lt, events) = tiered_with_expiry_hooks(true, false);
         let id = make_id("tiered-hv-failure");
         let target = new_long_term_revision(&id);
-        let old_expiry =
-            common::normalize_expiry(SystemTime::now() + Duration::from_mins(10)).unwrap();
+        let old_expiry = SystemTime::now() + Duration::from_mins(10);
         seed_redirect(&hv.inner, &lt.inner, &id, &target, old_expiry).await;
 
         let requested = SystemTime::now() + Duration::from_hours(1);

--- a/objectstore-service/src/backend/tiered.rs
+++ b/objectstore-service/src/backend/tiered.rs
@@ -158,6 +158,17 @@ fn new_long_term_revision(id: &ObjectId) -> ObjectId {
     }
 }
 
+fn effective_expiry(
+    redirect_expiry: Option<SystemTime>,
+    blob_expiry: Option<SystemTime>,
+) -> Option<SystemTime> {
+    match (redirect_expiry, blob_expiry) {
+        (Some(redirect), Some(blob)) => Some(redirect.min(blob)),
+        (Some(expiry), None) | (None, Some(expiry)) => Some(expiry),
+        (None, None) => None,
+    }
+}
+
 /// Configuration for [`TieredStorage`].
 ///
 /// Composes two backends into a tiered routing setup: `high_volume` for small
@@ -364,6 +375,10 @@ impl TieredStorage {
         let tombstone = Tombstone {
             target: new.clone(),
             expiration_policy: metadata.expiration_policy,
+            // Copy the already-resolved deadline so the HV redirect and LT
+            // blob do not drift merely because their writes happen at
+            // different times. Existing mismatches are left as-is.
+            time_expires: metadata.time_expires,
         };
         let written = self
             .inner
@@ -452,7 +467,15 @@ impl Backend for TieredStorage {
                 self.inner
                     .long_term
                     .get_object(&tombstone.target, range)
-                    .await?,
+                    .await?
+                    .map(|(mut metadata, range, stream)| {
+                        // The redirect can expire before a successfully renewed
+                        // blob. Reporting only LT's later deadline would suppress
+                        // a retry after LT success followed by HV failure.
+                        metadata.time_expires =
+                            effective_expiry(tombstone.time_expires, metadata.time_expires);
+                        (metadata, range, stream)
+                    }),
                 BackendChoice::LongTerm,
             ),
         };
@@ -487,7 +510,17 @@ impl Backend for TieredStorage {
             TieredMetadata::NotFound => (None, BackendChoice::HighVolume),
             TieredMetadata::Object(metadata) => (Some(metadata), BackendChoice::HighVolume),
             TieredMetadata::Tombstone(tombstone) => (
-                self.inner.long_term.get_metadata(&tombstone.target).await?,
+                self.inner
+                    .long_term
+                    .get_metadata(&tombstone.target)
+                    .await?
+                    .map(|mut metadata| {
+                        // See the matching GET path: the earlier deadline is
+                        // the lifetime clients can actually rely on.
+                        metadata.time_expires =
+                            effective_expiry(tombstone.time_expires, metadata.time_expires);
+                        metadata
+                    }),
                 BackendChoice::LongTerm,
             ),
         };
@@ -498,6 +531,41 @@ impl Backend for TieredStorage {
             .record();
 
         Ok(result)
+    }
+
+    async fn set_expiry(&self, id: &ObjectId, expire_at: SystemTime) -> Result<bool> {
+        let expire_at = super::common::normalize_expiry(expire_at)?;
+        match self.inner.high_volume.get_tiered_metadata(id).await? {
+            TieredMetadata::NotFound => Ok(false),
+            TieredMetadata::Object(_) => {
+                self.inner
+                    .high_volume
+                    .set_expiry_if_matches(id, expire_at, None)
+                    .await
+            }
+            TieredMetadata::Tombstone(tombstone) => {
+                // Extend LT first. Extending the redirect first could leave it
+                // alive after the blob failed to extend and was reclaimed.
+                if !self
+                    .inner
+                    .long_term
+                    .set_expiry(&tombstone.target, expire_at)
+                    .await?
+                {
+                    return Ok(false);
+                }
+
+                let extended = self
+                    .inner
+                    .high_volume
+                    .set_expiry_if_matches(id, expire_at, Some(&tombstone.target))
+                    .await?;
+                // If this fails, LT may remain extended while the redirect
+                // becomes unreachable earlier. Rolling LT back could interfere
+                // with another renewal that succeeded concurrently.
+                Ok(extended)
+            }
+        }
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
@@ -853,6 +921,9 @@ impl MultipartUploadBackend for TieredStorage {
         let tombstone = Tombstone {
             target: physical.clone(),
             expiration_policy: metadata.expiration_policy,
+            // Multipart completion reads LT's resolved deadline and copies it
+            // verbatim into HV, avoiding write-time drift between tiers.
+            time_expires: metadata.time_expires,
         };
         let written = self
             .inner
@@ -885,6 +956,7 @@ impl MultipartUploadBackend for TieredStorage {
 #[cfg(test)]
 mod tests {
     use std::num::NonZeroU32;
+    use std::sync::Mutex as StdMutex;
 
     use futures::lock::Mutex;
     use objectstore_types::metadata::{ExpirationPolicy, Metadata};
@@ -925,6 +997,176 @@ mod tests {
             Box::new(changelog.clone()),
         );
         (storage, hv, lt, changelog)
+    }
+
+    #[derive(Clone, Debug)]
+    struct ExpiryHook {
+        label: &'static str,
+        events: Arc<StdMutex<Vec<&'static str>>>,
+        reject: bool,
+    }
+
+    type ExpiryTestStorage = (
+        TieredStorage,
+        TestBackend<ExpiryHook>,
+        TestBackend<ExpiryHook>,
+        Arc<StdMutex<Vec<&'static str>>>,
+    );
+
+    #[async_trait::async_trait]
+    impl Hooks for ExpiryHook {
+        async fn set_expiry(
+            &self,
+            inner: &InMemoryBackend,
+            id: &ObjectId,
+            expire_at: SystemTime,
+        ) -> Result<bool> {
+            self.events.lock().unwrap().push(self.label);
+            if self.reject {
+                Ok(false)
+            } else {
+                inner.set_expiry(id, expire_at).await
+            }
+        }
+
+        async fn set_expiry_if_matches(
+            &self,
+            inner: &InMemoryBackend,
+            id: &ObjectId,
+            expire_at: SystemTime,
+            expected_target: Option<&ObjectId>,
+        ) -> Result<bool> {
+            self.events.lock().unwrap().push(self.label);
+            if self.reject {
+                Ok(false)
+            } else {
+                inner
+                    .set_expiry_if_matches(id, expire_at, expected_target)
+                    .await
+            }
+        }
+    }
+
+    fn tiered_with_expiry_hooks(hv_reject: bool, lt_reject: bool) -> ExpiryTestStorage {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let hv = TestBackend::new(ExpiryHook {
+            label: "hv",
+            events: Arc::clone(&events),
+            reject: hv_reject,
+        });
+        let lt = TestBackend::new(ExpiryHook {
+            label: "lt",
+            events: Arc::clone(&events),
+            reject: lt_reject,
+        });
+        let storage = TieredStorage::new(
+            Box::new(hv.clone()),
+            Box::new(lt.clone()),
+            Box::new(NoopChangeLog),
+        );
+        (storage, hv, lt, events)
+    }
+
+    async fn seed_redirect(
+        hv: &InMemoryBackend,
+        lt: &InMemoryBackend,
+        id: &ObjectId,
+        target: &ObjectId,
+        expiry: SystemTime,
+    ) {
+        let metadata = Metadata {
+            expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_hours(1)),
+            time_expires: Some(expiry),
+            ..Default::default()
+        };
+        lt.put_object(target, &metadata, stream::single("payload"))
+            .await
+            .unwrap();
+        hv.compare_and_write(
+            id,
+            None,
+            TieredWrite::Tombstone(Tombstone {
+                target: target.clone(),
+                expiration_policy: metadata.expiration_policy,
+                time_expires: metadata.time_expires,
+            }),
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn expiry_extension_updates_lt_before_conditional_hv() {
+        let (storage, hv, lt, events) = tiered_with_expiry_hooks(false, false);
+        let id = make_id("tiered-expiry-order");
+        let target = new_long_term_revision(&id);
+        let old_expiry = SystemTime::now() + Duration::from_mins(10);
+        seed_redirect(&hv.inner, &lt.inner, &id, &target, old_expiry).await;
+
+        let requested = SystemTime::now() + Duration::from_hours(1);
+        assert!(storage.set_expiry(&id, requested).await.unwrap());
+        assert_eq!(events.lock().unwrap().as_slice(), &["lt", "hv"]);
+        let normalized = crate::backend::common::normalize_expiry(requested).unwrap();
+        assert_eq!(
+            lt.inner.get(&target).expect_object().0.time_expires,
+            Some(normalized)
+        );
+        assert_eq!(
+            hv.inner.get(&id).expect_tombstone().time_expires,
+            Some(normalized)
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_hv_extension_leaves_lt_extended_and_reports_earlier_expiry() {
+        let (storage, hv, lt, events) = tiered_with_expiry_hooks(true, false);
+        let id = make_id("tiered-hv-failure");
+        let target = new_long_term_revision(&id);
+        let old_expiry =
+            crate::backend::common::normalize_expiry(SystemTime::now() + Duration::from_mins(10))
+                .unwrap();
+        seed_redirect(&hv.inner, &lt.inner, &id, &target, old_expiry).await;
+
+        let requested = SystemTime::now() + Duration::from_hours(1);
+        assert!(!storage.set_expiry(&id, requested).await.unwrap());
+        assert_eq!(events.lock().unwrap().as_slice(), &["lt", "hv"]);
+        assert_eq!(
+            hv.inner.get(&id).expect_tombstone().time_expires,
+            Some(old_expiry)
+        );
+        assert!(lt.inner.get(&target).expect_object().0.time_expires > Some(old_expiry));
+        assert_eq!(
+            storage
+                .get_metadata(&id)
+                .await
+                .unwrap()
+                .unwrap()
+                .time_expires,
+            Some(old_expiry)
+        );
+    }
+
+    #[tokio::test]
+    async fn lt_conflict_stops_before_hv_extension() {
+        let (storage, hv, lt, events) = tiered_with_expiry_hooks(false, true);
+        let id = make_id("tiered-lt-conflict");
+        let target = new_long_term_revision(&id);
+        seed_redirect(
+            &hv.inner,
+            &lt.inner,
+            &id,
+            &target,
+            SystemTime::now() + Duration::from_mins(10),
+        )
+        .await;
+
+        assert!(
+            !storage
+                .set_expiry(&id, SystemTime::now() + Duration::from_hours(1))
+                .await
+                .unwrap()
+        );
+        assert_eq!(events.lock().unwrap().as_slice(), &["lt"]);
     }
 
     // --- new_long_term_revision tests ---
@@ -1012,6 +1254,7 @@ mod tests {
         let metadata_in = Metadata {
             content_type: "image/png".into(),
             expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_hours(1)),
+            time_expires: Some(SystemTime::now() + Duration::from_hours(1)),
             origin: Some("10.0.0.1".into()),
             ..Metadata::default()
         };
@@ -1024,6 +1267,7 @@ mod tests {
         // Tombstone in HV: correct expiration_policy, target is a revision key.
         let tombstone = hv.get(&id).expect_tombstone();
         assert_eq!(tombstone.expiration_policy, metadata_in.expiration_policy);
+        assert_eq!(tombstone.time_expires, metadata_in.time_expires);
         let lt_id = tombstone.target;
         assert!(
             lt_id.key().starts_with(id.key()),
@@ -1035,6 +1279,7 @@ mod tests {
         let (lt_meta, _) = lt.get(&lt_id).expect_object();
         assert_eq!(lt_meta.content_type, "image/png");
         assert_eq!(lt_meta.expiration_policy, metadata_in.expiration_policy);
+        assert_eq!(lt_meta.time_expires, tombstone.time_expires);
 
         // get_object follows the tombstone and returns the correct payload.
         let (_, _, s) = storage.get_object(&id, None).await.unwrap().unwrap();
@@ -1268,6 +1513,7 @@ mod tests {
         let tombstone = Tombstone {
             target: make_id("lt-object"),
             expiration_policy: ExpirationPolicy::Manual,
+            time_expires: None,
         };
         inner
             .compare_and_write(&id, None, TieredWrite::Tombstone(tombstone))
@@ -1396,6 +1642,7 @@ mod tests {
         let tombstone = Tombstone {
             target: lt_id.clone(),
             expiration_policy: ExpirationPolicy::Manual,
+            time_expires: None,
         };
         hv.compare_and_write(&hv_id, None, TieredWrite::Tombstone(tombstone))
             .await
@@ -1674,6 +1921,7 @@ mod tests {
         let metadata = Metadata {
             content_type: "application/octet-stream".into(),
             expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_hours(1)),
+            time_expires: Some(SystemTime::now() + Duration::from_hours(1)),
             ..Metadata::default()
         };
         let payload = vec![0xABu8; 2 * 1024 * 1024]; // 2 MiB
@@ -1720,7 +1968,11 @@ mod tests {
             tombstone.target.key().starts_with(id.key()),
             "tombstone target should be a revision key"
         );
-        lt.get(&tombstone.target).expect_object();
+        assert_eq!(tombstone.time_expires, metadata.time_expires);
+        assert_eq!(
+            lt.get(&tombstone.target).expect_object().0.time_expires,
+            tombstone.time_expires
+        );
     }
 
     #[tokio::test]

--- a/objectstore-service/src/backend/tiered.rs
+++ b/objectstore-service/src/backend/tiered.rs
@@ -125,7 +125,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::backend::changelog::{Change, ChangeGuard, ChangeLog, ChangeManager, ChangePhase};
 use crate::backend::common::{
-    Backend, DeleteResponse, GetResponse, HighVolumeBackend, MetadataResponse,
+    self, Backend, DeleteResponse, GetResponse, HighVolumeBackend, MetadataResponse,
     MultipartUploadBackend, PutResponse, TieredGet, TieredMetadata, TieredUpdate, TieredWrite,
     Tombstone,
 };
@@ -535,7 +535,7 @@ impl Backend for TieredStorage {
     }
 
     async fn set_expiry(&self, id: &ObjectId, expire_at: SystemTime) -> Result<bool> {
-        let expire_at = super::common::normalize_expiry(expire_at)?;
+        let expire_at = common::normalize_expiry(expire_at)?;
         match self.inner.high_volume.get_tiered_metadata(id).await? {
             TieredMetadata::NotFound => Ok(false),
             TieredMetadata::Object(_) => {
@@ -1109,7 +1109,7 @@ mod tests {
         let requested = SystemTime::now() + Duration::from_hours(1);
         assert!(storage.set_expiry(&id, requested).await.unwrap());
         assert_eq!(events.lock().unwrap().as_slice(), &["lt", "hv"]);
-        let normalized = crate::backend::common::normalize_expiry(requested).unwrap();
+        let normalized = common::normalize_expiry(requested).unwrap();
         assert_eq!(
             lt.inner.get(&target).expect_object().0.time_expires,
             Some(normalized)
@@ -1126,8 +1126,7 @@ mod tests {
         let id = make_id("tiered-hv-failure");
         let target = new_long_term_revision(&id);
         let old_expiry =
-            crate::backend::common::normalize_expiry(SystemTime::now() + Duration::from_mins(10))
-                .unwrap();
+            common::normalize_expiry(SystemTime::now() + Duration::from_mins(10)).unwrap();
         seed_redirect(&hv.inner, &lt.inner, &id, &target, old_expiry).await;
 
         let requested = SystemTime::now() + Duration::from_hours(1);

--- a/objectstore-service/src/backend/tiered.rs
+++ b/objectstore-service/src/backend/tiered.rs
@@ -159,17 +159,6 @@ fn new_long_term_revision(id: &ObjectId) -> ObjectId {
     }
 }
 
-fn effective_expiry(
-    redirect_expiry: Option<SystemTime>,
-    blob_expiry: Option<SystemTime>,
-) -> Option<SystemTime> {
-    match (redirect_expiry, blob_expiry) {
-        (Some(redirect), Some(blob)) => Some(redirect.min(blob)),
-        (Some(expiry), None) | (None, Some(expiry)) => Some(expiry),
-        (None, None) => None,
-    }
-}
-
 /// Configuration for [`TieredStorage`].
 ///
 /// Composes two backends into a tiered routing setup: `high_volume` for small
@@ -376,9 +365,6 @@ impl TieredStorage {
         let tombstone = Tombstone {
             target: new.clone(),
             expiration_policy: metadata.expiration_policy,
-            // Copy the already-resolved deadline so the HV redirect and LT
-            // blob do not drift merely because their writes happen at
-            // different times. Existing mismatches are left as-is.
             time_expires: metadata.time_expires,
         };
         let written = self
@@ -469,14 +455,7 @@ impl Backend for TieredStorage {
                     .long_term
                     .get_object(&tombstone.target, range)
                     .await?
-                    .map(|(mut metadata, range, stream)| {
-                        // The redirect can expire before a successfully renewed
-                        // blob. Reporting only LT's later deadline would suppress
-                        // a retry after LT success followed by HV failure.
-                        metadata.time_expires =
-                            effective_expiry(tombstone.time_expires, metadata.time_expires);
-                        (metadata, range, stream)
-                    }),
+                    .map(|(meta, range, stream)| (align_expiry(meta, &tombstone), range, stream)),
                 BackendChoice::LongTerm,
             ),
         };
@@ -515,13 +494,7 @@ impl Backend for TieredStorage {
                     .long_term
                     .get_metadata(&tombstone.target)
                     .await?
-                    .map(|mut metadata| {
-                        // See the matching GET path: the earlier deadline is
-                        // the lifetime clients can actually rely on.
-                        metadata.time_expires =
-                            effective_expiry(tombstone.time_expires, metadata.time_expires);
-                        metadata
-                    }),
+                    .map(|metadata| align_expiry(metadata, &tombstone)),
                 BackendChoice::LongTerm,
             ),
         };
@@ -555,6 +528,9 @@ impl Backend for TieredStorage {
                     return Ok(false);
                 }
 
+                // NOTE: If this fails, LT may remain extended while the redirect
+                // becomes unreachable earlier. Rolling LT back could interfere
+                // with another renewal that succeeded concurrently.
                 let extended = self
                     .inner
                     .high_volume
@@ -564,9 +540,7 @@ impl Backend for TieredStorage {
                         TieredUpdate::SetExpiry(expire_at),
                     )
                     .await?;
-                // If this fails, LT may remain extended while the redirect
-                // becomes unreachable earlier. Rolling LT back could interfere
-                // with another renewal that succeeded concurrently.
+
                 Ok(extended)
             }
         }
@@ -640,6 +614,29 @@ impl std::fmt::Display for BackendChoice {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.as_str())
     }
+}
+
+/// Returns the lower expiry between the redirect and blob, if any.
+///
+/// This is used to ensure correct expiry if they ever drift.
+fn effective_expiry(
+    redirect_expiry: Option<SystemTime>,
+    blob_expiry: Option<SystemTime>,
+) -> Option<SystemTime> {
+    match (redirect_expiry, blob_expiry) {
+        (Some(redirect), Some(blob)) => Some(redirect.min(blob)),
+        (Some(expiry), None) | (None, Some(expiry)) => Some(expiry),
+        (None, None) => None,
+    }
+}
+
+/// Aligns the expiry of the metadata with the expiry of the tombstone.
+///
+/// Keeps the lower expiry between the metadata and the tombstone so that the client sees the most
+/// conservative expiry and automatic expiry bumps still occur.
+fn align_expiry(mut metadata: Metadata, tombstone: &Tombstone) -> Metadata {
+    metadata.time_expires = effective_expiry(tombstone.time_expires, metadata.time_expires);
+    metadata
 }
 
 /// Wraps a stream to count the total bytes yielded by successful chunks.
@@ -925,8 +922,6 @@ impl MultipartUploadBackend for TieredStorage {
         let tombstone = Tombstone {
             target: physical.clone(),
             expiration_policy: metadata.expiration_policy,
-            // Multipart completion reads LT's resolved deadline and copies it
-            // verbatim into HV, avoiding write-time drift between tiers.
             time_expires: metadata.time_expires,
         };
         let written = self

--- a/objectstore-service/src/backend/tiered.rs
+++ b/objectstore-service/src/backend/tiered.rs
@@ -126,7 +126,8 @@ use serde::{Deserialize, Serialize};
 use crate::backend::changelog::{Change, ChangeGuard, ChangeLog, ChangeManager, ChangePhase};
 use crate::backend::common::{
     Backend, DeleteResponse, GetResponse, HighVolumeBackend, MetadataResponse,
-    MultipartUploadBackend, PutResponse, TieredGet, TieredMetadata, TieredWrite, Tombstone,
+    MultipartUploadBackend, PutResponse, TieredGet, TieredMetadata, TieredUpdate, TieredWrite,
+    Tombstone,
 };
 use crate::backend::{HighVolumeStorageConfig, MultipartUploadStorageConfig};
 use crate::error::{Error, ErrorKind, Result, ResultExt as _};
@@ -540,7 +541,7 @@ impl Backend for TieredStorage {
             TieredMetadata::Object(_) => {
                 self.inner
                     .high_volume
-                    .set_expiry_if_matches(id, expire_at, None)
+                    .compare_and_update(id, None, TieredUpdate::SetExpiry(expire_at))
                     .await
             }
             TieredMetadata::Tombstone(tombstone) => {
@@ -558,7 +559,11 @@ impl Backend for TieredStorage {
                 let extended = self
                     .inner
                     .high_volume
-                    .set_expiry_if_matches(id, expire_at, Some(&tombstone.target))
+                    .compare_and_update(
+                        id,
+                        Some(&tombstone.target),
+                        TieredUpdate::SetExpiry(expire_at),
+                    )
                     .await?;
                 // If this fails, LT may remain extended while the redirect
                 // becomes unreachable earlier. Rolling LT back could interfere
@@ -1029,20 +1034,18 @@ mod tests {
             }
         }
 
-        async fn set_expiry_if_matches(
+        async fn compare_and_update(
             &self,
             inner: &InMemoryBackend,
             id: &ObjectId,
-            expire_at: SystemTime,
-            expected_target: Option<&ObjectId>,
+            current: Option<&ObjectId>,
+            update: TieredUpdate,
         ) -> Result<bool> {
             self.events.lock().unwrap().push(self.label);
             if self.reject {
                 Ok(false)
             } else {
-                inner
-                    .set_expiry_if_matches(id, expire_at, expected_target)
-                    .await
+                inner.compare_and_update(id, current, update).await
             }
         }
     }

--- a/objectstore-service/src/backend/tiered.rs
+++ b/objectstore-service/src/backend/tiered.rs
@@ -1093,7 +1093,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn expiry_extension_updates_lt_before_conditional_hv() {
+    async fn set_expiry() {
         let (storage, hv, lt, events) = tiered_with_expiry_hooks(false, false);
         let id = make_id("tiered-expiry-order");
         let target = new_long_term_revision(&id);
@@ -1114,7 +1114,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn failed_hv_extension_leaves_lt_extended_and_reports_earlier_expiry() {
+    async fn expiry_hv_conflict() {
         let (storage, hv, lt, events) = tiered_with_expiry_hooks(true, false);
         let id = make_id("tiered-hv-failure");
         let target = new_long_term_revision(&id);
@@ -1141,7 +1141,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn lt_conflict_stops_before_hv_extension() {
+    async fn expiry_lt_conflict() {
         let (storage, hv, lt, events) = tiered_with_expiry_hooks(false, true);
         let id = make_id("tiered-lt-conflict");
         let target = new_long_term_revision(&id);

--- a/objectstore-service/src/background.rs
+++ b/objectstore-service/src/background.rs
@@ -1,0 +1,339 @@
+//! Scheduling and execution of background service jobs.
+//!
+//! This module currently manages expiry renewals triggered by reads of TTI
+//! objects. Renewals are scheduled without blocking the read, deduplicated by
+//! object ID, and placed in a bounded queue. A worker executes accepted jobs
+//! using the service's bulk concurrency budget, while shutdown can wait for all
+//! pending renewals to finish. See [`RenewalScheduler`].
+
+use std::future::Future;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, SystemTime};
+
+use tokio::sync::{Notify, mpsc};
+
+use crate::backend::common::Backend;
+use crate::concurrency::ConcurrencyLimiter;
+use crate::error::ErrorKind;
+use crate::id::ObjectId;
+
+const EMITTER_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Measures the number of items currently waiting in the queue.
+#[derive(Debug, Default)]
+struct QueueCounter {
+    value: AtomicUsize,
+}
+
+impl QueueCounter {
+    fn enter(self: &Arc<Self>) -> QueueCounterGuard {
+        self.value.fetch_add(1, Ordering::Relaxed);
+        QueueCounterGuard(Arc::clone(self))
+    }
+
+    fn get(&self) -> usize {
+        self.value.load(Ordering::Relaxed)
+    }
+}
+
+/// Decrements the queue counter when a queued renewal is removed.
+#[derive(Debug)]
+struct QueueCounterGuard(Arc<QueueCounter>);
+
+impl Drop for QueueCounterGuard {
+    fn drop(&mut self) {
+        self.0.value.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+/// Removes an object from the pending set and notifies shutdown when dropped.
+#[derive(Debug)]
+struct PendingGuard {
+    id: ObjectId,
+    pending: Arc<papaya::HashSet<ObjectId>>,
+    pending_notify: Arc<Notify>,
+}
+
+impl Drop for PendingGuard {
+    fn drop(&mut self) {
+        self.pending.pin().remove(&self.id);
+        self.pending_notify.notify_waiters();
+    }
+}
+
+/// A queued expiry-renewal request and its lifecycle guards.
+#[derive(Debug)]
+struct Renewal {
+    id: ObjectId,
+    expire_at: SystemTime,
+    pending: PendingGuard,
+    queued: QueueCounterGuard,
+}
+
+/// Shared state used by renewal scheduler clones.
+#[derive(Debug)]
+struct RenewalSchedulerInner {
+    sender: mpsc::Sender<Renewal>,
+    pending: Arc<papaya::HashSet<ObjectId>>,
+    pending_notify: Arc<Notify>,
+    queue_counter: Arc<QueueCounter>,
+}
+
+/// Consumes queued renewals and starts their backend operations.
+///
+/// Created by [`RenewalScheduler`] to process queued expiry-renewal requests.
+#[derive(Debug)]
+struct RenewalWorker {
+    receiver: mpsc::Receiver<Renewal>,
+    backend: Arc<dyn Backend>,
+    concurrency: ConcurrencyLimiter,
+}
+
+impl RenewalWorker {
+    async fn run(mut self) {
+        while let Some(renewal) = self.receiver.recv().await {
+            self.process(renewal).await;
+        }
+    }
+
+    async fn process(&self, renewal: Renewal) {
+        let Renewal {
+            id,
+            expire_at,
+            pending,
+            queued,
+        } = renewal;
+
+        drop(queued);
+
+        if self.concurrency.total_permits() == 0 {
+            objectstore_metrics::count!("service.expiry_renewal", outcome = "dropped");
+            return;
+        }
+
+        let permit = loop {
+            match self.concurrency.acquire_bulk().await {
+                Ok(permit) => break permit,
+                Err(error) if error.kind() == ErrorKind::AtCapacity => continue,
+                Err(error) => {
+                    objectstore_metrics::count!(
+                        "service.expiry_renewal",
+                        outcome = "dropped",
+                        reason = "guard"
+                    );
+                    objectstore_log::error!(!!&error, "failed to acquire expiry renewal permit");
+                    return;
+                }
+            }
+        };
+
+        let backend = Arc::clone(&self.backend);
+        // This ID-only operation can run after a replacement write. Its
+        // original read timestamp and requested deadline may therefore
+        // extend a replacement TTL/TTI object. Process exit can also lose
+        // this opportunistic renewal; a later read may retry it.
+        crate::concurrency::spawn_metered("set_expiry", (pending, permit), async move {
+            match backend.set_expiry(&id, expire_at).await {
+                Ok(true) => {
+                    objectstore_metrics::count!("service.expiry_renewal", outcome = "applied");
+                    Ok(())
+                }
+                Ok(false) => {
+                    objectstore_metrics::count!(
+                        "service.expiry_renewal",
+                        outcome = "skipped",
+                        reason = "conflict"
+                    );
+                    Ok(())
+                }
+                Err(error) => {
+                    objectstore_metrics::count!("service.expiry_renewal", outcome = "failed");
+                    Err(error)
+                }
+            }
+        });
+    }
+}
+
+/// Schedules bounded, deduplicated expiry renewals in the background.
+#[derive(Debug)]
+pub struct RenewalScheduler {
+    inner: Arc<RenewalSchedulerInner>,
+    worker: Option<RenewalWorker>,
+}
+
+impl Clone for RenewalScheduler {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            worker: None,
+        }
+    }
+}
+
+impl RenewalScheduler {
+    /// Creates a renewal scheduler for `backend`.
+    ///
+    /// `concurrency` supplies the bulk permits used to run renewals alongside
+    /// foreground service operations. `capacity` bounds the number of renewals
+    /// waiting in the background queue; values below one are clamped to one.
+    pub fn new(
+        backend: Arc<dyn Backend>,
+        concurrency: ConcurrencyLimiter,
+        capacity: usize,
+    ) -> Self {
+        let (sender, receiver) = mpsc::channel(capacity.max(1));
+
+        let inner = Arc::new(RenewalSchedulerInner {
+            sender,
+            pending: Arc::new(papaya::HashSet::new()),
+            pending_notify: Arc::new(Notify::new()),
+            queue_counter: Arc::new(QueueCounter::default()),
+        });
+        let worker = Some(RenewalWorker {
+            receiver,
+            backend,
+            concurrency,
+        });
+
+        Self { inner, worker }
+    }
+
+    /// Starts the renewal worker if this instance owns the queue receiver.
+    ///
+    /// Repeated calls and calls on scheduler clones have no effect.
+    pub fn start(&mut self) {
+        if let Some(worker) = self.worker.take() {
+            tokio::spawn(worker.run());
+        }
+    }
+
+    /// Schedules an expiry renewal without waiting for queue or execution capacity.
+    ///
+    /// [`Self::start`] must be called before scheduling renewals.
+    pub fn schedule(&self, id: ObjectId, expire_at: SystemTime) {
+        let pending = Arc::clone(&self.inner.pending);
+        if !pending.pin().insert(id.clone()) {
+            objectstore_metrics::count!(
+                "service.expiry_renewal",
+                outcome = "skipped",
+                reason = "duplicate"
+            );
+            return;
+        }
+
+        let pending = PendingGuard {
+            id: id.clone(),
+            pending,
+            pending_notify: Arc::clone(&self.inner.pending_notify),
+        };
+
+        let Ok(permit) = self.inner.sender.try_reserve() else {
+            objectstore_metrics::count!(
+                "service.expiry_renewal",
+                outcome = "dropped",
+                reason = "capacity"
+            );
+            return;
+        };
+
+        permit.send(Renewal {
+            id,
+            expire_at,
+            pending,
+            queued: self.inner.queue_counter.enter(),
+        });
+    }
+
+    /// Replaces the concurrency limiter used when this instance starts the worker.
+    ///
+    /// Has no effect if this instance does not own the worker anymore.
+    pub fn set_concurrency(&mut self, concurrency: ConcurrencyLimiter) {
+        if let Some(worker) = &mut self.worker {
+            worker.concurrency = concurrency;
+        }
+    }
+
+    /// Replaces the queue capacity before the worker starts.
+    ///
+    /// Has no effect if this instance does not own the worker anymore.
+    pub fn set_capacity(&mut self, capacity: usize) {
+        let Some(worker) = self.worker.take() else {
+            return;
+        };
+
+        let (sender, receiver) = mpsc::channel(capacity.max(1));
+        self.inner = Arc::new(RenewalSchedulerInner {
+            sender,
+            pending: Arc::clone(&self.inner.pending),
+            pending_notify: Arc::clone(&self.inner.pending_notify),
+            queue_counter: Arc::clone(&self.inner.queue_counter),
+        });
+        self.worker = Some(RenewalWorker { receiver, ..worker });
+    }
+
+    /// Returns the number of renewals waiting in the queue.
+    pub fn queued(&self) -> usize {
+        self.inner.queue_counter.get()
+    }
+
+    /// Periodically calls `emit` with the number of queued renewals.
+    ///
+    /// This future runs forever and is intended to be spawned alongside the
+    /// renewal worker.
+    pub async fn run_emitter<F, Fut>(&self, mut emit: F)
+    where
+        F: FnMut(usize) -> Fut,
+        Fut: Future<Output = ()>,
+    {
+        let mut ticker = tokio::time::interval(EMITTER_INTERVAL);
+        loop {
+            ticker.tick().await;
+            emit(self.queued()).await;
+        }
+    }
+
+    /// Returns the number of deduplicated renewals queued or executing.
+    #[cfg(test)]
+    pub fn pending(&self) -> usize {
+        self.inner.pending.len()
+    }
+
+    /// Waits until every accepted renewal has finished processing.
+    ///
+    /// No new renewals may be scheduled concurrently with this method.
+    pub async fn join(&self) {
+        loop {
+            // Register before checking `pending` so the final removal cannot
+            // notify between the check and the await.
+            let notified = self.inner.pending_notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            if self.inner.pending.is_empty() {
+                break;
+            }
+
+            notified.await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn queue_counter_guard_decrements_when_dropped() {
+        let counter = Arc::new(QueueCounter::default());
+        let first = counter.enter();
+        let second = counter.enter();
+
+        assert_eq!(counter.get(), 2);
+        drop(first);
+        assert_eq!(counter.get(), 1);
+        drop(second);
+        assert_eq!(counter.get(), 0);
+    }
+}

--- a/objectstore-service/src/background.rs
+++ b/objectstore-service/src/background.rs
@@ -319,21 +319,3 @@ impl RenewalScheduler {
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn queue_counter_guard_decrements_when_dropped() {
-        let counter = Arc::new(QueueCounter::default());
-        let first = counter.enter();
-        let second = counter.enter();
-
-        assert_eq!(counter.get(), 2);
-        drop(first);
-        assert_eq!(counter.get(), 1);
-        drop(second);
-        assert_eq!(counter.get(), 0);
-    }
-}

--- a/objectstore-service/src/concurrency.rs
+++ b/objectstore-service/src/concurrency.rs
@@ -5,7 +5,8 @@
 //! waiters on drop, allowing [`ConcurrencyLimiter::wait_all`] to resolve once
 //! all permits have been returned.
 //!
-//! [`spawn_metered`] spawns an arbitrary future as an isolated task with panic
+//! [`run_metered`] runs an isolated task and waits for its result, while
+//! [`spawn_metered`] starts the same task without waiting. Both provide panic
 //! recovery and `service.task.*` metric emission.
 
 use std::future::Future;
@@ -310,7 +311,7 @@ impl Drop for ConcurrencyPermit {
     }
 }
 
-/// Spawns a future on a dedicated task with panic isolation and timing metrics.
+/// Runs a future on a dedicated task with panic isolation and timing metrics.
 ///
 /// The `guard` is moved into the spawned task and dropped after the future
 /// completes, ensuring any resource it represents (e.g. a concurrency permit)
@@ -320,7 +321,38 @@ impl Drop for ConcurrencyPermit {
 /// `service.task.duration` (distribution) when the task completes, both tagged
 /// with the given `operation` name. The duration tag includes an `outcome` of
 /// `"success"` or `"error"`.
-pub async fn spawn_metered<T, G, F>(operation: &'static str, guard: G, f: F) -> Result<T>
+pub async fn run_metered<T, G, F>(operation: &'static str, guard: G, f: F) -> Result<T>
+where
+    T: Send + 'static,
+    G: Send + 'static,
+    F: Future<Output = Result<T>> + Send + 'static,
+{
+    let receiver = spawn_metered_inner(operation, guard, f);
+    receiver.await.map_err(|_| {
+        let error = Error::new(ErrorKind::Internal, "service task dropped");
+        objectstore_log::error!(!!&error, operation, "Task failed");
+        error
+    })?
+}
+
+/// Spawns a metered future without waiting for its result.
+///
+/// The task has the same panic isolation, metrics, and guard lifetime as
+/// [`run_metered`], but its result is discarded.
+pub fn spawn_metered<T, G, F>(operation: &'static str, guard: G, f: F)
+where
+    T: Send + 'static,
+    G: Send + 'static,
+    F: Future<Output = Result<T>> + Send + 'static,
+{
+    drop(spawn_metered_inner(operation, guard, f));
+}
+
+fn spawn_metered_inner<T, G, F>(
+    operation: &'static str,
+    guard: G,
+    f: F,
+) -> tokio::sync::oneshot::Receiver<Result<T>>
 where
     T: Send + 'static,
     G: Send + 'static,
@@ -369,11 +401,7 @@ where
         .bind_hub(new_hub),
     );
 
-    rx.await.map_err(|_| {
-        let error = Error::new(ErrorKind::Internal, "service task dropped");
-        objectstore_log::error!(!!&error, operation, "Task failed");
-        error
-    })?
+    rx
 }
 
 #[cfg(test)]

--- a/objectstore-service/src/lib.rs
+++ b/objectstore-service/src/lib.rs
@@ -3,6 +3,7 @@
 #![warn(missing_debug_implementations)]
 
 pub mod backend;
+mod background;
 pub mod change_stream;
 pub mod concurrency;
 pub mod error;

--- a/objectstore-service/src/service.rs
+++ b/objectstore-service/src/service.rs
@@ -5,20 +5,18 @@
 //!
 //! See the [crate-level documentation](crate) for full architecture details.
 
-use std::collections::HashSet;
 use std::future::Future;
 use std::num::NonZeroU64;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::SystemTime;
 
 use objectstore_types::metadata::Metadata;
 use objectstore_types::range::{ByteRange, ContentRange};
 use objectstore_types::resumable::{SessionToken as EncryptedSessionToken, UploadProgress};
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
-use tokio_util::task::TaskTracker;
 
 use crate::backend::common::Backend;
 use crate::backend::counting::CountingBackend;
+use crate::background::RenewalScheduler;
 use crate::concurrency::ConcurrencyLimiter;
 use crate::error::{ErrorKind, Result, ResultExt as _};
 use crate::id::{ObjectContext, ObjectId};
@@ -45,113 +43,8 @@ pub type DeleteResponse = ();
 /// [`StorageService::with_concurrency`].
 pub const DEFAULT_CONCURRENCY_LIMIT: u32 = 500;
 
-const EXPIRY_RENEWAL_CONCURRENCY_LIMIT: usize = 32;
-
-#[derive(Debug)]
-struct RenewalGuard {
-    id: ObjectId,
-    in_flight: Arc<Mutex<HashSet<ObjectId>>>,
-    _permit: OwnedSemaphorePermit,
-}
-
-impl Drop for RenewalGuard {
-    fn drop(&mut self) {
-        self.in_flight.lock().unwrap().remove(&self.id);
-    }
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct RenewalScheduler {
-    backend: Arc<dyn Backend>,
-    capacity: Arc<Semaphore>,
-    in_flight: Arc<Mutex<HashSet<ObjectId>>>,
-    tracker: TaskTracker,
-}
-
-impl RenewalScheduler {
-    fn new(backend: Arc<dyn Backend>) -> Self {
-        Self::with_limit(backend, EXPIRY_RENEWAL_CONCURRENCY_LIMIT)
-    }
-
-    fn with_limit(backend: Arc<dyn Backend>, limit: usize) -> Self {
-        Self {
-            backend,
-            capacity: Arc::new(Semaphore::new(limit)),
-            in_flight: Arc::new(Mutex::new(HashSet::new())),
-            tracker: TaskTracker::new(),
-        }
-    }
-
-    pub(crate) fn schedule(&self, id: ObjectId, metadata: &Metadata, access_time: SystemTime) {
-        let Some(expire_at) = metadata.check_tti_bump(access_time) else {
-            return;
-        };
-
-        {
-            let mut in_flight = self.in_flight.lock().unwrap();
-            if !in_flight.insert(id.clone()) {
-                objectstore_metrics::count!(
-                    "service.expiry_renewal",
-                    outcome = "skipped",
-                    reason = "duplicate"
-                );
-                return;
-            }
-        }
-
-        let permit = match Arc::clone(&self.capacity).try_acquire_owned() {
-            Ok(permit) => permit,
-            Err(_) => {
-                self.in_flight.lock().unwrap().remove(&id);
-                objectstore_metrics::count!("service.expiry_renewal", outcome = "capacity_dropped");
-                return;
-            }
-        };
-
-        let guard = RenewalGuard {
-            id: id.clone(),
-            in_flight: Arc::clone(&self.in_flight),
-            _permit: permit,
-        };
-        let backend = Arc::clone(&self.backend);
-        self.tracker.spawn(async move {
-            // This ID-only operation can run after a replacement write. Its
-            // original read timestamp and requested deadline may therefore
-            // extend a replacement TTL/TTI object. Overload or process exit can
-            // also lose this opportunistic renewal; a later read may retry it.
-            let result = crate::concurrency::spawn_metered("set_expiry", guard, async move {
-                match backend.set_expiry(&id, expire_at).await {
-                    Ok(true) => {
-                        objectstore_metrics::count!(
-                            "service.expiry_renewal",
-                            outcome = "applied_or_already_sufficient"
-                        );
-                        Ok(())
-                    }
-                    Ok(false) => {
-                        objectstore_metrics::count!(
-                            "service.expiry_renewal",
-                            outcome = "skipped",
-                            reason = "backend_conflict"
-                        );
-                        Ok(())
-                    }
-                    Err(error) => {
-                        objectstore_metrics::count!("service.expiry_renewal", outcome = "failed");
-                        Err(error)
-                    }
-                }
-            })
-            .await;
-            let _ = result;
-        });
-    }
-
-    async fn join(&self) {
-        self.tracker.close();
-        self.tracker.wait().await;
-    }
-}
+/// Default number of TTI renewals that may wait for background processing.
+pub const DEFAULT_BACKGROUND_QUEUE_LIMIT: usize = 1_000;
 
 /// Asynchronous storage service wrapping a single [`Backend`].
 ///
@@ -203,10 +96,11 @@ impl StorageService {
     /// `resumable_token_encryption` protects tokens exposed by the resumable upload methods.
     pub fn new(backend: Box<dyn Backend>, resumable_token_encryption: Encryptor) -> Self {
         let inner: Arc<dyn Backend> = Arc::new(CountingBackend::new(backend));
+        let concurrency = ConcurrencyLimiter::new(DEFAULT_CONCURRENCY_LIMIT);
         Self {
-            renewals: RenewalScheduler::new(Arc::clone(&inner)),
-            inner,
-            concurrency: ConcurrencyLimiter::new(DEFAULT_CONCURRENCY_LIMIT),
+            inner: Arc::clone(&inner),
+            concurrency: concurrency.clone(),
+            renewals: RenewalScheduler::new(inner, concurrency, DEFAULT_BACKGROUND_QUEUE_LIMIT),
             resumable_token_encryption: Arc::new(resumable_token_encryption),
         }
     }
@@ -217,7 +111,14 @@ impl StorageService {
     /// service uses a limiter with [`DEFAULT_CONCURRENCY_LIMIT`] permits
     /// and no queue.
     pub fn with_concurrency(mut self, limiter: ConcurrencyLimiter) -> Self {
+        self.renewals.set_concurrency(limiter.clone());
         self.concurrency = limiter;
+        self
+    }
+
+    /// Replaces the default background expiry-renewal queue capacity.
+    pub fn with_background_queue_limit(mut self, limit: usize) -> Self {
+        self.renewals.set_capacity(limit);
         self
     }
 
@@ -258,11 +159,14 @@ impl StorageService {
     ///  - `service.concurrency.queue_limit`: queue size for waiting tasks
     ///  - `service.concurrency.bulk_limit`: concurrent task execution slots for bulk operations
     ///
-    /// Also spawns a task that emits concurrency gauges once per second:
+    /// Also spawns tasks that emit runtime gauges once per second:
     ///  - `service.concurrency.in_use`: currently running tasks
     ///  - `service.concurrency.queued`: currently queued tasks
     ///  - `service.concurrency.bulk_in_use`: currently running bulk tasks
-    pub fn start(&self) {
+    ///  - `service.expiry_renewal.queued`: expiry renewals waiting for the background worker
+    pub fn start(&mut self) {
+        self.renewals.start();
+
         let concurrency = self.concurrency.clone();
         objectstore_metrics::gauge!("service.concurrency.limit" = concurrency.total_permits());
         objectstore_metrics::gauge!("service.concurrency.queue_limit" = concurrency.total_queue());
@@ -276,6 +180,15 @@ impl StorageService {
                     objectstore_metrics::gauge!(
                         "service.concurrency.bulk_in_use" = stats.bulk_in_use
                     );
+                })
+                .await;
+        });
+
+        let renewals = self.renewals.clone();
+        tokio::spawn(async move {
+            renewals
+                .run_emitter(|queued| async move {
+                    objectstore_metrics::gauge!("service.expiry_renewal.queued" = queued);
                 })
                 .await;
         });
@@ -310,7 +223,7 @@ impl StorageService {
         })?;
 
         timer.record();
-        crate::concurrency::spawn_metered(operation, permit, f).await
+        crate::concurrency::run_metered(operation, permit, f).await
     }
 
     /// Creates or overwrites an object.
@@ -348,8 +261,10 @@ impl StorageService {
         let renewals = self.renewals.clone();
         self.spawn("get_metadata", async move {
             let response = inner.get_metadata(&id).await?;
-            if let Some(metadata) = &response {
-                renewals.schedule(id, metadata, access_time);
+            if let Some(ref metadata) = response
+                && let Some(expire_at) = metadata.check_tti_bump(access_time)
+            {
+                renewals.schedule(id, expire_at);
             }
             Ok(response)
         })
@@ -363,8 +278,10 @@ impl StorageService {
         let renewals = self.renewals.clone();
         self.spawn("get", async move {
             let response = inner.get_object(&id, range).await?;
-            if let Some((metadata, _, _)) = &response {
-                renewals.schedule(id, metadata, access_time);
+            if let Some((ref metadata, _, _)) = response
+                && let Some(expire_at) = metadata.check_tti_bump(access_time)
+            {
+                renewals.schedule(id, expire_at);
             }
             Ok(response)
         })
@@ -964,8 +881,9 @@ mod tests {
             .put_object(&id, &metadata, stream::single("payload"))
             .await
             .unwrap();
-        let service =
+        let mut service =
             StorageService::new(Box::new(backend.clone()), Encryptor::ephemeral().unwrap());
+        service.start();
 
         let response = tokio::time::timeout(
             Duration::from_secs(1),
@@ -1006,8 +924,9 @@ mod tests {
             .put_object(&id, &stale_tti_metadata(), stream::single("payload"))
             .await
             .unwrap();
-        let service =
+        let mut service =
             StorageService::new(Box::new(backend.clone()), Encryptor::ephemeral().unwrap());
+        service.start();
 
         service.get_metadata(id.clone()).await.unwrap();
         backend.hooks.started.notified().await;
@@ -1033,8 +952,9 @@ mod tests {
             .put_object(&id, &metadata, stream::single("payload"))
             .await
             .unwrap();
-        let service =
+        let mut service =
             StorageService::new(Box::new(backend.clone()), Encryptor::ephemeral().unwrap());
+        service.start();
 
         service.get_metadata(id).await.unwrap();
         tokio::task::yield_now().await;
@@ -1043,7 +963,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn renewal_scheduler_uses_captured_access_time_and_drops_at_capacity() {
+    async fn renewal_scheduler_uses_captured_access_time_and_queues_at_capacity() {
         let backend = TestBackend::new(GateOnExpiry::default());
         let first = ObjectId::new(make_context(), "first-renewal".into());
         let second = ObjectId::new(make_context(), "capacity-dropped-renewal".into());
@@ -1061,15 +981,19 @@ mod tests {
                 .unwrap();
         }
 
-        let scheduler = RenewalScheduler::with_limit(Arc::new(backend.clone()), 1);
-        scheduler.schedule(first, &metadata, access_time);
+        let concurrency = ConcurrencyLimiter::new(1);
+        let mut scheduler = RenewalScheduler::new(Arc::new(backend.clone()), concurrency, 1);
+        scheduler.start();
+        scheduler.start();
+        let expire_at = metadata.check_tti_bump(access_time).unwrap();
+        scheduler.schedule(first, expire_at);
         backend.hooks.started.notified().await;
         assert_eq!(
             backend.hooks.requested.lock().unwrap().as_slice(),
             &[access_time + Duration::from_hours(1)]
         );
 
-        scheduler.schedule(second.clone(), &metadata, access_time);
+        scheduler.schedule(second.clone(), expire_at);
         tokio::task::yield_now().await;
         assert_eq!(backend.hooks.calls.load(Ordering::SeqCst), 1);
         assert_eq!(
@@ -1078,7 +1002,17 @@ mod tests {
         );
 
         backend.hooks.resume.notify_waiters();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while backend.hooks.calls.load(Ordering::SeqCst) < 2 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("queued renewal did not start");
+        backend.hooks.resume.notify_waiters();
         scheduler.join().await;
+        assert_eq!(backend.hooks.calls.load(Ordering::SeqCst), 2);
+        assert!(backend.inner.get(&second).expect_object().0.time_expires > metadata.time_expires);
     }
 
     #[derive(Clone, Debug, Default)]
@@ -1111,18 +1045,21 @@ mod tests {
             .put_object(&id, &metadata, stream::single("payload"))
             .await
             .unwrap();
-        let scheduler = RenewalScheduler::with_limit(Arc::new(backend.clone()), 1);
+        let concurrency = ConcurrencyLimiter::new(1);
+        let mut scheduler = RenewalScheduler::new(Arc::new(backend.clone()), concurrency, 1);
+        scheduler.start();
+        let expire_at = metadata.check_tti_bump(SystemTime::now()).unwrap();
 
-        scheduler.schedule(id.clone(), &metadata, SystemTime::now());
+        scheduler.schedule(id.clone(), expire_at);
         tokio::time::timeout(Duration::from_secs(1), async {
-            while !scheduler.in_flight.lock().unwrap().is_empty() {
+            while scheduler.pending() != 0 {
                 tokio::task::yield_now().await;
             }
         })
         .await
         .expect("panic did not release renewal guards");
 
-        scheduler.schedule(id, &metadata, SystemTime::now());
+        scheduler.schedule(id, expire_at);
         scheduler.join().await;
         assert_eq!(backend.hooks.calls.load(Ordering::SeqCst), 2);
     }
@@ -1157,18 +1094,21 @@ mod tests {
             .put_object(&id, &metadata, stream::single("payload"))
             .await
             .unwrap();
-        let scheduler = RenewalScheduler::with_limit(Arc::new(backend.clone()), 1);
+        let concurrency = ConcurrencyLimiter::new(1);
+        let mut scheduler = RenewalScheduler::new(Arc::new(backend.clone()), concurrency, 1);
+        scheduler.start();
+        let expire_at = metadata.check_tti_bump(SystemTime::now()).unwrap();
 
-        scheduler.schedule(id.clone(), &metadata, SystemTime::now());
+        scheduler.schedule(id.clone(), expire_at);
         tokio::time::timeout(Duration::from_secs(1), async {
-            while !scheduler.in_flight.lock().unwrap().is_empty() {
+            while scheduler.pending() != 0 {
                 tokio::task::yield_now().await;
             }
         })
         .await
         .expect("error did not release renewal guards");
 
-        scheduler.schedule(id, &metadata, SystemTime::now());
+        scheduler.schedule(id, expire_at);
         scheduler.join().await;
         assert_eq!(backend.hooks.calls.load(Ordering::SeqCst), 2);
     }

--- a/objectstore-service/src/service.rs
+++ b/objectstore-service/src/service.rs
@@ -13,6 +13,8 @@ use std::time::SystemTime;
 use objectstore_types::metadata::Metadata;
 use objectstore_types::range::{ByteRange, ContentRange};
 use objectstore_types::resumable::{SessionToken, UploadProgress};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio_util::task::TaskTracker;
 
 use crate::backend::common::Backend;
 use crate::backend::counting::CountingBackend;
@@ -25,8 +27,6 @@ use crate::multipart::{
 };
 use crate::stream::{ClientStream, PayloadStream};
 use crate::streaming::StreamExecutor;
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
-use tokio_util::task::TaskTracker;
 
 /// Service response for [`StorageService::get_object`].
 pub type GetResponse = Option<(Metadata, Option<ContentRange>, PayloadStream)>;
@@ -593,7 +593,7 @@ mod tests {
     use super::*;
     use crate::backend::bigtable::{BigTableBackend, BigTableConfig};
     use crate::backend::changelog::NoopChangeLog;
-    use crate::backend::common::{HighVolumeBackend, PutResponse, TieredWrite};
+    use crate::backend::common::{self, HighVolumeBackend, PutResponse, TieredWrite};
     use crate::backend::gcs::{GcsBackend, GcsConfig};
     use crate::backend::in_memory::InMemoryBackend;
     use crate::backend::testing::{Hooks, TestBackend};
@@ -816,7 +816,7 @@ mod tests {
                 .unwrap()
                 .unwrap()
                 .time_expires,
-            Some(crate::backend::common::normalize_expiry(requested).unwrap())
+            Some(common::normalize_expiry(requested).unwrap())
         );
     }
 

--- a/objectstore-service/src/service.rs
+++ b/objectstore-service/src/service.rs
@@ -772,7 +772,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn explicit_set_expiry_runs_through_service() {
+    async fn set_expiry() {
         let service = make_service();
         let old_expiry = SystemTime::now() + Duration::from_hours(1);
         let metadata = Metadata {
@@ -844,7 +844,6 @@ mod tests {
         calls: Arc<AtomicUsize>,
         started: Arc<tokio::sync::Notify>,
         resume: Arc<tokio::sync::Notify>,
-        requested: Arc<Mutex<Vec<SystemTime>>>,
     }
 
     #[async_trait::async_trait]
@@ -855,7 +854,6 @@ mod tests {
             id: &ObjectId,
             expire_at: SystemTime,
         ) -> Result<bool> {
-            self.requested.lock().unwrap().push(expire_at);
             self.calls.fetch_add(1, Ordering::SeqCst);
             self.started.notify_one();
             self.resume.notified().await;
@@ -872,7 +870,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reads_return_without_waiting_for_renewal_and_join_drains_it() {
+    async fn background_renewal() {
         let backend = TestBackend::new(GateOnExpiry::default());
         let id = ObjectId::new(make_context(), "background-renewal".into());
         let metadata = stale_tti_metadata();
@@ -916,7 +914,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn duplicate_reads_share_one_in_flight_renewal() {
+    async fn renewal_deduplication() {
         let backend = TestBackend::new(GateOnExpiry::default());
         let id = ObjectId::new(make_context(), "deduplicated-renewal".into());
         backend
@@ -939,7 +937,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ttl_reads_do_not_schedule_renewal() {
+    async fn ttl_read() {
         let backend = TestBackend::new(GateOnExpiry::default());
         let id = ObjectId::new(make_context(), "ttl-no-renewal".into());
         let metadata = Metadata {
@@ -963,16 +961,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn renewal_scheduler_uses_captured_access_time_and_queues_at_capacity() {
+    async fn renewal_queueing() {
         let backend = TestBackend::new(GateOnExpiry::default());
         let first = ObjectId::new(make_context(), "first-renewal".into());
-        let second = ObjectId::new(make_context(), "capacity-dropped-renewal".into());
-        let access_time = SystemTime::now() - Duration::from_mins(10);
-        let metadata = Metadata {
-            expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_hours(1)),
-            time_expires: Some(SystemTime::now() + Duration::from_mins(1)),
-            ..Default::default()
-        };
+        let second = ObjectId::new(make_context(), "queued-renewal".into());
+        let metadata = stale_tti_metadata();
         for id in [&first, &second] {
             backend
                 .inner
@@ -983,15 +976,12 @@ mod tests {
 
         let concurrency = ConcurrencyLimiter::new(1);
         let mut scheduler = RenewalScheduler::new(Arc::new(backend.clone()), concurrency, 1);
-        scheduler.start();
-        scheduler.start();
-        let expire_at = metadata.check_tti_bump(access_time).unwrap();
+        let expire_at = SystemTime::now() + Duration::from_hours(1);
         scheduler.schedule(first, expire_at);
+        assert_eq!(scheduler.queued(), 1);
+        scheduler.start();
         backend.hooks.started.notified().await;
-        assert_eq!(
-            backend.hooks.requested.lock().unwrap().as_slice(),
-            &[access_time + Duration::from_hours(1)]
-        );
+        assert_eq!(scheduler.queued(), 0);
 
         scheduler.schedule(second.clone(), expire_at);
         tokio::task::yield_now().await;
@@ -1011,62 +1001,15 @@ mod tests {
         .expect("queued renewal did not start");
         backend.hooks.resume.notify_waiters();
         scheduler.join().await;
+        assert_eq!(scheduler.queued(), 0);
         assert_eq!(backend.hooks.calls.load(Ordering::SeqCst), 2);
         assert!(backend.inner.get(&second).expect_object().0.time_expires > metadata.time_expires);
     }
 
     #[derive(Clone, Debug, Default)]
-    struct PanicFirstExpiry {
-        calls: Arc<AtomicUsize>,
-    }
-
-    #[async_trait::async_trait]
-    impl Hooks for PanicFirstExpiry {
-        async fn set_expiry(
-            &self,
-            inner: &InMemoryBackend,
-            id: &ObjectId,
-            expire_at: SystemTime,
-        ) -> Result<bool> {
-            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
-                panic!("intentional renewal panic");
-            }
-            inner.set_expiry(id, expire_at).await
-        }
-    }
-
-    #[tokio::test]
-    async fn renewal_panic_releases_duplicate_and_capacity_guards() {
-        let backend = TestBackend::new(PanicFirstExpiry::default());
-        let id = ObjectId::new(make_context(), "panic-renewal".into());
-        let metadata = stale_tti_metadata();
-        backend
-            .inner
-            .put_object(&id, &metadata, stream::single("payload"))
-            .await
-            .unwrap();
-        let concurrency = ConcurrencyLimiter::new(1);
-        let mut scheduler = RenewalScheduler::new(Arc::new(backend.clone()), concurrency, 1);
-        scheduler.start();
-        let expire_at = metadata.check_tti_bump(SystemTime::now()).unwrap();
-
-        scheduler.schedule(id.clone(), expire_at);
-        tokio::time::timeout(Duration::from_secs(1), async {
-            while scheduler.pending() != 0 {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("panic did not release renewal guards");
-
-        scheduler.schedule(id, expire_at);
-        scheduler.join().await;
-        assert_eq!(backend.hooks.calls.load(Ordering::SeqCst), 2);
-    }
-
-    #[derive(Clone, Debug, Default)]
     struct FailFirstExpiry {
         calls: Arc<AtomicUsize>,
+        panic: bool,
     }
 
     #[async_trait::async_trait]
@@ -1078,6 +1021,7 @@ mod tests {
             expire_at: SystemTime,
         ) -> Result<bool> {
             if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                assert!(!self.panic, "intentional renewal panic");
                 return Err(ErrorKind::BackendFailure.into());
             }
             inner.set_expiry(id, expire_at).await
@@ -1085,32 +1029,37 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn renewal_error_releases_duplicate_and_capacity_guards() {
-        let backend = TestBackend::new(FailFirstExpiry::default());
-        let id = ObjectId::new(make_context(), "failed-renewal".into());
-        let metadata = stale_tti_metadata();
-        backend
-            .inner
-            .put_object(&id, &metadata, stream::single("payload"))
+    async fn renewal_failure_cleanup() {
+        for panic in [false, true] {
+            let backend = TestBackend::new(FailFirstExpiry {
+                panic,
+                ..Default::default()
+            });
+            let id = ObjectId::new(make_context(), "failed-renewal".into());
+            let metadata = stale_tti_metadata();
+            backend
+                .inner
+                .put_object(&id, &metadata, stream::single("payload"))
+                .await
+                .unwrap();
+            let concurrency = ConcurrencyLimiter::new(1);
+            let mut scheduler = RenewalScheduler::new(Arc::new(backend.clone()), concurrency, 1);
+            scheduler.start();
+            let expire_at = metadata.check_tti_bump(SystemTime::now()).unwrap();
+
+            scheduler.schedule(id.clone(), expire_at);
+            tokio::time::timeout(Duration::from_secs(1), async {
+                while scheduler.pending() != 0 {
+                    tokio::task::yield_now().await;
+                }
+            })
             .await
-            .unwrap();
-        let concurrency = ConcurrencyLimiter::new(1);
-        let mut scheduler = RenewalScheduler::new(Arc::new(backend.clone()), concurrency, 1);
-        scheduler.start();
-        let expire_at = metadata.check_tti_bump(SystemTime::now()).unwrap();
+            .expect("failure did not release renewal guards");
 
-        scheduler.schedule(id.clone(), expire_at);
-        tokio::time::timeout(Duration::from_secs(1), async {
-            while scheduler.pending() != 0 {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("error did not release renewal guards");
-
-        scheduler.schedule(id, expire_at);
-        scheduler.join().await;
-        assert_eq!(backend.hooks.calls.load(Ordering::SeqCst), 2);
+            scheduler.schedule(id, expire_at);
+            scheduler.join().await;
+            assert_eq!(backend.hooks.calls.load(Ordering::SeqCst), 2);
+        }
     }
 
     /// In-memory backend with optional synchronization for `put_object`.

--- a/objectstore-service/src/service.rs
+++ b/objectstore-service/src/service.rs
@@ -5,8 +5,10 @@
 //!
 //! See the [crate-level documentation](crate) for full architecture details.
 
+use std::collections::HashSet;
 use std::future::Future;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::time::SystemTime;
 
 use objectstore_types::metadata::Metadata;
 use objectstore_types::range::{ByteRange, ContentRange};
@@ -23,6 +25,8 @@ use crate::multipart::{
 };
 use crate::stream::{ClientStream, PayloadStream};
 use crate::streaming::StreamExecutor;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio_util::task::TaskTracker;
 
 /// Service response for [`StorageService::get_object`].
 pub type GetResponse = Option<(Metadata, Option<ContentRange>, PayloadStream)>;
@@ -38,6 +42,114 @@ pub type DeleteResponse = ();
 /// This value is used when no explicit limiter is set via
 /// [`StorageService::with_concurrency`].
 pub const DEFAULT_CONCURRENCY_LIMIT: u32 = 500;
+
+const EXPIRY_RENEWAL_CONCURRENCY_LIMIT: usize = 32;
+
+#[derive(Debug)]
+struct RenewalGuard {
+    id: ObjectId,
+    in_flight: Arc<Mutex<HashSet<ObjectId>>>,
+    _permit: OwnedSemaphorePermit,
+}
+
+impl Drop for RenewalGuard {
+    fn drop(&mut self) {
+        self.in_flight.lock().unwrap().remove(&self.id);
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct RenewalScheduler {
+    backend: Arc<dyn Backend>,
+    capacity: Arc<Semaphore>,
+    in_flight: Arc<Mutex<HashSet<ObjectId>>>,
+    tracker: TaskTracker,
+}
+
+impl RenewalScheduler {
+    fn new(backend: Arc<dyn Backend>) -> Self {
+        Self::with_limit(backend, EXPIRY_RENEWAL_CONCURRENCY_LIMIT)
+    }
+
+    fn with_limit(backend: Arc<dyn Backend>, limit: usize) -> Self {
+        Self {
+            backend,
+            capacity: Arc::new(Semaphore::new(limit)),
+            in_flight: Arc::new(Mutex::new(HashSet::new())),
+            tracker: TaskTracker::new(),
+        }
+    }
+
+    pub(crate) fn schedule(&self, id: ObjectId, metadata: &Metadata, access_time: SystemTime) {
+        let Some(expire_at) = metadata.check_tti_bump(access_time) else {
+            return;
+        };
+
+        {
+            let mut in_flight = self.in_flight.lock().unwrap();
+            if !in_flight.insert(id.clone()) {
+                objectstore_metrics::count!(
+                    "service.expiry_renewal",
+                    outcome = "skipped",
+                    reason = "duplicate"
+                );
+                return;
+            }
+        }
+
+        let permit = match Arc::clone(&self.capacity).try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => {
+                self.in_flight.lock().unwrap().remove(&id);
+                objectstore_metrics::count!("service.expiry_renewal", outcome = "capacity_dropped");
+                return;
+            }
+        };
+
+        let guard = RenewalGuard {
+            id: id.clone(),
+            in_flight: Arc::clone(&self.in_flight),
+            _permit: permit,
+        };
+        let backend = Arc::clone(&self.backend);
+        self.tracker.spawn(async move {
+            // This ID-only operation can run after a replacement write. Its
+            // original read timestamp and requested deadline may therefore
+            // extend a replacement TTL/TTI object. Overload or process exit can
+            // also lose this opportunistic renewal; a later read may retry it.
+            let result = crate::concurrency::spawn_metered("set_expiry", guard, async move {
+                match backend.set_expiry(&id, expire_at).await {
+                    Ok(true) => {
+                        objectstore_metrics::count!(
+                            "service.expiry_renewal",
+                            outcome = "applied_or_already_sufficient"
+                        );
+                        Ok(())
+                    }
+                    Ok(false) => {
+                        objectstore_metrics::count!(
+                            "service.expiry_renewal",
+                            outcome = "skipped",
+                            reason = "backend_conflict"
+                        );
+                        Ok(())
+                    }
+                    Err(error) => {
+                        objectstore_metrics::count!("service.expiry_renewal", outcome = "failed");
+                        Err(error)
+                    }
+                }
+            })
+            .await;
+            let _ = result;
+        });
+    }
+
+    async fn join(&self) {
+        self.tracker.close();
+        self.tracker.wait().await;
+    }
+}
 
 /// Asynchronous storage service wrapping a single [`Backend`].
 ///
@@ -74,6 +186,7 @@ pub const DEFAULT_CONCURRENCY_LIMIT: u32 = 500;
 pub struct StorageService {
     inner: Arc<dyn Backend>,
     concurrency: ConcurrencyLimiter,
+    renewals: RenewalScheduler,
 }
 
 impl StorageService {
@@ -84,8 +197,10 @@ impl StorageService {
     /// as we batched operations served by [`StreamExecutor`]. See
     /// [`backend::counting`](crate::backend::counting) for details.
     pub fn new(backend: Box<dyn Backend>) -> Self {
+        let inner: Arc<dyn Backend> = Arc::new(CountingBackend::new(backend));
         Self {
-            inner: Arc::new(CountingBackend::new(backend)),
+            renewals: RenewalScheduler::new(Arc::clone(&inner)),
+            inner,
             concurrency: ConcurrencyLimiter::new(DEFAULT_CONCURRENCY_LIMIT),
         }
     }
@@ -122,7 +237,11 @@ impl StorageService {
     /// configurable percentage of execution slots while allowing operations
     /// to queue for permits instead of requiring upfront reservation.
     pub fn stream(&self) -> StreamExecutor {
-        StreamExecutor::new(Arc::clone(&self.inner), self.concurrency.clone())
+        StreamExecutor::new(
+            Arc::clone(&self.inner),
+            self.concurrency.clone(),
+            self.renewals.clone(),
+        )
     }
 
     /// Starts background processes for the storage service.
@@ -218,16 +337,41 @@ impl StorageService {
 
     /// Retrieves only the metadata for an object, without the payload.
     pub async fn get_metadata(&self, id: ObjectId) -> Result<MetadataResponse> {
+        let access_time = SystemTime::now();
         let inner = Arc::clone(&self.inner);
-        self.spawn("get_metadata", async move { inner.get_metadata(&id).await })
-            .await
+        let renewals = self.renewals.clone();
+        self.spawn("get_metadata", async move {
+            let response = inner.get_metadata(&id).await?;
+            if let Some(metadata) = &response {
+                renewals.schedule(id, metadata, access_time);
+            }
+            Ok(response)
+        })
+        .await
     }
 
     /// Streams (part of) the contents of an object.
     pub async fn get_object(&self, id: ObjectId, range: Option<ByteRange>) -> Result<GetResponse> {
+        let access_time = SystemTime::now();
         let inner = Arc::clone(&self.inner);
-        self.spawn("get", async move { inner.get_object(&id, range).await })
-            .await
+        let renewals = self.renewals.clone();
+        self.spawn("get", async move {
+            let response = inner.get_object(&id, range).await?;
+            if let Some((metadata, _, _)) = &response {
+                renewals.schedule(id, metadata, access_time);
+            }
+            Ok(response)
+        })
+        .await
+    }
+
+    /// Extends an existing TTL or TTI object's deadline.
+    pub async fn set_expiry(&self, id: ObjectId, expire_at: SystemTime) -> Result<bool> {
+        let inner = Arc::clone(&self.inner);
+        self.spawn("set_expiry", async move {
+            inner.set_expiry(&id, expire_at).await
+        })
+        .await
     }
 
     /// Deletes an object, if it exists.
@@ -249,6 +393,7 @@ impl StorageService {
     /// backend's configured timeout. Should be called during graceful shutdown
     /// after the HTTP server has stopped accepting new requests.
     pub async fn join(&self) {
+        self.renewals.join().await;
         self.inner.join().await;
     }
 
@@ -436,6 +581,7 @@ impl StorageService {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
     use bytes::BytesMut;
@@ -642,6 +788,38 @@ mod tests {
         assert!(after.is_none());
     }
 
+    #[tokio::test]
+    async fn explicit_set_expiry_runs_through_service() {
+        let service = make_service();
+        let old_expiry = SystemTime::now() + Duration::from_hours(1);
+        let metadata = Metadata {
+            expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_hours(1)),
+            time_expires: Some(old_expiry),
+            ..Default::default()
+        };
+        let id = service
+            .insert_object(
+                make_context(),
+                Some("explicit-expiry".into()),
+                metadata,
+                stream::single("payload"),
+            )
+            .await
+            .unwrap();
+        let requested = old_expiry + Duration::from_hours(1);
+
+        assert!(service.set_expiry(id.clone(), requested).await.unwrap());
+        assert_eq!(
+            service
+                .get_metadata(id)
+                .await
+                .unwrap()
+                .unwrap()
+                .time_expires,
+            Some(crate::backend::common::normalize_expiry(requested).unwrap())
+        );
+    }
+
     #[derive(Debug)]
     struct PanicOnGet;
 
@@ -673,6 +851,254 @@ mod tests {
             std::error::Error::source(&error).unwrap().to_string(),
             "intentional panic in get_object"
         );
+    }
+
+    #[derive(Clone, Debug, Default)]
+    struct GateOnExpiry {
+        calls: Arc<AtomicUsize>,
+        started: Arc<tokio::sync::Notify>,
+        resume: Arc<tokio::sync::Notify>,
+        requested: Arc<Mutex<Vec<SystemTime>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl Hooks for GateOnExpiry {
+        async fn set_expiry(
+            &self,
+            inner: &InMemoryBackend,
+            id: &ObjectId,
+            expire_at: SystemTime,
+        ) -> Result<bool> {
+            self.requested.lock().unwrap().push(expire_at);
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.started.notify_one();
+            self.resume.notified().await;
+            inner.set_expiry(id, expire_at).await
+        }
+    }
+
+    fn stale_tti_metadata() -> Metadata {
+        Metadata {
+            expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_hours(1)),
+            time_expires: Some(SystemTime::now() + Duration::from_mins(1)),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn reads_return_without_waiting_for_renewal_and_join_drains_it() {
+        let backend = TestBackend::new(GateOnExpiry::default());
+        let id = ObjectId::new(make_context(), "background-renewal".into());
+        let metadata = stale_tti_metadata();
+        backend
+            .inner
+            .put_object(&id, &metadata, stream::single("payload"))
+            .await
+            .unwrap();
+        let service = StorageService::new(Box::new(backend.clone()));
+
+        let response = tokio::time::timeout(
+            Duration::from_secs(1),
+            service.get_object(id.clone(), Some(ByteRange::Bounded(0, 2))),
+        )
+        .await
+        .expect("GET waited for its background renewal")
+        .unwrap()
+        .unwrap();
+        assert_eq!(response.0.time_expires, metadata.time_expires);
+        backend.hooks.started.notified().await;
+
+        let join = tokio::spawn({
+            let service = service.clone();
+            async move { service.join().await }
+        });
+        tokio::pin!(join);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut join)
+                .await
+                .is_err()
+        );
+
+        backend.hooks.resume.notify_waiters();
+        tokio::time::timeout(Duration::from_secs(1), &mut join)
+            .await
+            .expect("shutdown did not drain renewal")
+            .unwrap();
+        assert!(backend.inner.get(&id).expect_object().0.time_expires > response.0.time_expires);
+    }
+
+    #[tokio::test]
+    async fn duplicate_reads_share_one_in_flight_renewal() {
+        let backend = TestBackend::new(GateOnExpiry::default());
+        let id = ObjectId::new(make_context(), "deduplicated-renewal".into());
+        backend
+            .inner
+            .put_object(&id, &stale_tti_metadata(), stream::single("payload"))
+            .await
+            .unwrap();
+        let service = StorageService::new(Box::new(backend.clone()));
+
+        service.get_metadata(id.clone()).await.unwrap();
+        backend.hooks.started.notified().await;
+        service.get_metadata(id).await.unwrap();
+        tokio::task::yield_now().await;
+        assert_eq!(backend.hooks.calls.load(Ordering::SeqCst), 1);
+
+        backend.hooks.resume.notify_waiters();
+        service.join().await;
+    }
+
+    #[tokio::test]
+    async fn ttl_reads_do_not_schedule_renewal() {
+        let backend = TestBackend::new(GateOnExpiry::default());
+        let id = ObjectId::new(make_context(), "ttl-no-renewal".into());
+        let metadata = Metadata {
+            expiration_policy: ExpirationPolicy::TimeToLive(Duration::from_hours(1)),
+            time_expires: Some(SystemTime::now() + Duration::from_mins(1)),
+            ..Default::default()
+        };
+        backend
+            .inner
+            .put_object(&id, &metadata, stream::single("payload"))
+            .await
+            .unwrap();
+        let service = StorageService::new(Box::new(backend.clone()));
+
+        service.get_metadata(id).await.unwrap();
+        tokio::task::yield_now().await;
+        assert_eq!(backend.hooks.calls.load(Ordering::SeqCst), 0);
+        service.join().await;
+    }
+
+    #[tokio::test]
+    async fn renewal_scheduler_uses_captured_access_time_and_drops_at_capacity() {
+        let backend = TestBackend::new(GateOnExpiry::default());
+        let first = ObjectId::new(make_context(), "first-renewal".into());
+        let second = ObjectId::new(make_context(), "capacity-dropped-renewal".into());
+        let access_time = SystemTime::now() - Duration::from_mins(10);
+        let metadata = Metadata {
+            expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_hours(1)),
+            time_expires: Some(SystemTime::now() + Duration::from_mins(1)),
+            ..Default::default()
+        };
+        for id in [&first, &second] {
+            backend
+                .inner
+                .put_object(id, &metadata, stream::single("payload"))
+                .await
+                .unwrap();
+        }
+
+        let scheduler = RenewalScheduler::with_limit(Arc::new(backend.clone()), 1);
+        scheduler.schedule(first, &metadata, access_time);
+        backend.hooks.started.notified().await;
+        assert_eq!(
+            backend.hooks.requested.lock().unwrap().as_slice(),
+            &[access_time + Duration::from_hours(1)]
+        );
+
+        scheduler.schedule(second.clone(), &metadata, access_time);
+        tokio::task::yield_now().await;
+        assert_eq!(backend.hooks.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            backend.inner.get(&second).expect_object().0.time_expires,
+            metadata.time_expires
+        );
+
+        backend.hooks.resume.notify_waiters();
+        scheduler.join().await;
+    }
+
+    #[derive(Clone, Debug, Default)]
+    struct PanicFirstExpiry {
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl Hooks for PanicFirstExpiry {
+        async fn set_expiry(
+            &self,
+            inner: &InMemoryBackend,
+            id: &ObjectId,
+            expire_at: SystemTime,
+        ) -> Result<bool> {
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                panic!("intentional renewal panic");
+            }
+            inner.set_expiry(id, expire_at).await
+        }
+    }
+
+    #[tokio::test]
+    async fn renewal_panic_releases_duplicate_and_capacity_guards() {
+        let backend = TestBackend::new(PanicFirstExpiry::default());
+        let id = ObjectId::new(make_context(), "panic-renewal".into());
+        let metadata = stale_tti_metadata();
+        backend
+            .inner
+            .put_object(&id, &metadata, stream::single("payload"))
+            .await
+            .unwrap();
+        let scheduler = RenewalScheduler::with_limit(Arc::new(backend.clone()), 1);
+
+        scheduler.schedule(id.clone(), &metadata, SystemTime::now());
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !scheduler.in_flight.lock().unwrap().is_empty() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("panic did not release renewal guards");
+
+        scheduler.schedule(id, &metadata, SystemTime::now());
+        scheduler.join().await;
+        assert_eq!(backend.hooks.calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[derive(Clone, Debug, Default)]
+    struct FailFirstExpiry {
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl Hooks for FailFirstExpiry {
+        async fn set_expiry(
+            &self,
+            inner: &InMemoryBackend,
+            id: &ObjectId,
+            expire_at: SystemTime,
+        ) -> Result<bool> {
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Err(ErrorKind::BackendFailure.into());
+            }
+            inner.set_expiry(id, expire_at).await
+        }
+    }
+
+    #[tokio::test]
+    async fn renewal_error_releases_duplicate_and_capacity_guards() {
+        let backend = TestBackend::new(FailFirstExpiry::default());
+        let id = ObjectId::new(make_context(), "failed-renewal".into());
+        let metadata = stale_tti_metadata();
+        backend
+            .inner
+            .put_object(&id, &metadata, stream::single("payload"))
+            .await
+            .unwrap();
+        let scheduler = RenewalScheduler::with_limit(Arc::new(backend.clone()), 1);
+
+        scheduler.schedule(id.clone(), &metadata, SystemTime::now());
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !scheduler.in_flight.lock().unwrap().is_empty() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("error did not release renewal guards");
+
+        scheduler.schedule(id, &metadata, SystemTime::now());
+        scheduler.join().await;
+        assert_eq!(backend.hooks.calls.load(Ordering::SeqCst), 2);
     }
 
     /// In-memory backend with optional synchronization for `put_object`.

--- a/objectstore-service/src/service.rs
+++ b/objectstore-service/src/service.rs
@@ -593,7 +593,7 @@ mod tests {
     use super::*;
     use crate::backend::bigtable::{BigTableBackend, BigTableConfig};
     use crate::backend::changelog::NoopChangeLog;
-    use crate::backend::common::{self, HighVolumeBackend, PutResponse, TieredWrite};
+    use crate::backend::common::{HighVolumeBackend, PutResponse, TieredWrite};
     use crate::backend::gcs::{GcsBackend, GcsConfig};
     use crate::backend::in_memory::InMemoryBackend;
     use crate::backend::testing::{Hooks, TestBackend};
@@ -816,7 +816,7 @@ mod tests {
                 .unwrap()
                 .unwrap()
                 .time_expires,
-            Some(common::normalize_expiry(requested).unwrap())
+            Some(requested)
         );
     }
 

--- a/objectstore-service/src/streaming.rs
+++ b/objectstore-service/src/streaming.rs
@@ -30,10 +30,11 @@ use futures_util::{Stream, StreamExt};
 use objectstore_types::metadata::Metadata;
 
 use crate::backend::common::Backend;
+use crate::background::RenewalScheduler;
 use crate::concurrency::ConcurrencyLimiter;
 use crate::error::{Error, Result};
 use crate::id::{ObjectContext, ObjectId, ObjectKey};
-use crate::service::{GetResponse, RenewalScheduler};
+use crate::service::GetResponse;
 
 /// An insert operation: stores an object at the given key.
 #[derive(Debug)]
@@ -291,7 +292,7 @@ impl StreamExecutor {
                         Err(e) => return (idx, Err(e)),
                     };
 
-                    let spawn = crate::concurrency::spawn_metered(op.kind(), permit, {
+                    let spawn = crate::concurrency::run_metered(op.kind(), permit, {
                         execute_operation(backend, renewals, context, op, access_time)
                     });
                     (idx, spawn.await.map_err(E::from))
@@ -312,8 +313,10 @@ async fn execute_operation(
         Operation::Get(get) => {
             let id = ObjectId::new(context, get.key);
             let response = backend.get_object(&id, None).await?;
-            if let Some((metadata, _, _)) = &response {
-                renewals.schedule(id.clone(), metadata, access_time);
+            if let Some((metadata, _, _)) = &response
+                && let Some(expire_at) = metadata.check_tti_bump(access_time)
+            {
+                renewals.schedule(id.clone(), expire_at);
             }
             Ok(OpResponse::Got {
                 key: id.key,
@@ -334,8 +337,10 @@ async fn execute_operation(
         Operation::Head(head) => {
             let id = ObjectId::new(context, head.key);
             let metadata = backend.get_metadata(&id).await?;
-            if let Some(metadata) = &metadata {
-                renewals.schedule(id.clone(), metadata, access_time);
+            if let Some(metadata) = &metadata
+                && let Some(expire_at) = metadata.check_tti_bump(access_time)
+            {
+                renewals.schedule(id.clone(), expire_at);
             }
             Ok(OpResponse::Head {
                 key: id.key,
@@ -429,8 +434,9 @@ mod tests {
                 .await
                 .unwrap();
         }
-        let service =
+        let mut service =
             StorageService::new(Box::new(backend.clone()), Encryptor::ephemeral().unwrap());
+        service.start();
         let outcomes = tokio::time::timeout(
             Duration::from_secs(1),
             service

--- a/objectstore-service/src/streaming.rs
+++ b/objectstore-service/src/streaming.rs
@@ -24,6 +24,7 @@
 //! the others.
 
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use futures_util::{Stream, StreamExt};
 use objectstore_types::metadata::Metadata;
@@ -32,7 +33,7 @@ use crate::backend::common::Backend;
 use crate::concurrency::ConcurrencyLimiter;
 use crate::error::{Error, Result};
 use crate::id::{ObjectContext, ObjectId, ObjectKey};
-use crate::service::GetResponse;
+use crate::service::{GetResponse, RenewalScheduler};
 
 /// An insert operation: stores an object at the given key.
 #[derive(Debug)]
@@ -206,14 +207,20 @@ impl std::fmt::Debug for OpResponse {
 pub struct StreamExecutor {
     backend: Arc<dyn Backend>,
     concurrency: ConcurrencyLimiter,
+    renewals: RenewalScheduler,
 }
 
 impl StreamExecutor {
     /// Creates a new `StreamExecutor` with the given backend and limiter.
-    pub fn new(backend: Arc<dyn Backend>, concurrency: ConcurrencyLimiter) -> Self {
+    pub(crate) fn new(
+        backend: Arc<dyn Backend>,
+        concurrency: ConcurrencyLimiter,
+        renewals: RenewalScheduler,
+    ) -> Self {
         Self {
             backend,
             concurrency,
+            renewals,
         }
     }
 
@@ -243,6 +250,7 @@ impl StreamExecutor {
         let StreamExecutor {
             backend,
             concurrency,
+            renewals,
         } = self;
 
         let buffer = concurrency.total_bulk().max(1) as usize;
@@ -255,12 +263,13 @@ impl StreamExecutor {
             .then(move |(idx, item)| {
                 let concurrency = concurrency.clone();
                 async move {
+                    let access_time = SystemTime::now();
                     let op = match item {
                         Ok(op) => op,
                         Err(e) => return (idx, Err(e)),
                     };
                     match concurrency.acquire_bulk().await {
-                        Ok(permit) => (idx, Ok((op, permit))),
+                        Ok(permit) => (idx, Ok((op, permit, access_time))),
                         Err(e) => {
                             objectstore_metrics::count!(
                                 "service.concurrency.rejected",
@@ -275,14 +284,15 @@ impl StreamExecutor {
             .map(move |(idx, result)| {
                 let backend = Arc::clone(&backend);
                 let context = context.clone();
+                let renewals = renewals.clone();
                 async move {
-                    let (op, permit) = match result {
+                    let (op, permit, access_time) = match result {
                         Ok(pair) => pair,
                         Err(e) => return (idx, Err(e)),
                     };
 
                     let spawn = crate::concurrency::spawn_metered(op.kind(), permit, {
-                        execute_operation(backend, context, op)
+                        execute_operation(backend, renewals, context, op, access_time)
                     });
                     (idx, spawn.await.map_err(E::from))
                 }
@@ -293,13 +303,18 @@ impl StreamExecutor {
 
 async fn execute_operation(
     backend: Arc<dyn Backend>,
+    renewals: RenewalScheduler,
     context: ObjectContext,
     op: Operation,
+    access_time: SystemTime,
 ) -> Result<OpResponse> {
     match op {
         Operation::Get(get) => {
             let id = ObjectId::new(context, get.key);
             let response = backend.get_object(&id, None).await?;
+            if let Some((metadata, _, _)) = &response {
+                renewals.schedule(id.clone(), metadata, access_time);
+            }
             Ok(OpResponse::Got {
                 key: id.key,
                 response,
@@ -319,6 +334,9 @@ async fn execute_operation(
         Operation::Head(head) => {
             let id = ObjectId::new(context, head.key);
             let metadata = backend.get_metadata(&id).await?;
+            if let Some(metadata) = &metadata {
+                renewals.schedule(id.clone(), metadata, access_time);
+            }
             Ok(OpResponse::Head {
                 key: id.key,
                 metadata,
@@ -331,11 +349,11 @@ async fn execute_operation(
 mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::time::Duration;
+    use std::time::{Duration, SystemTime};
 
     use bytes::Bytes;
     use futures_util::StreamExt;
-    use objectstore_types::metadata::Metadata;
+    use objectstore_types::metadata::{ExpirationPolicy, Metadata};
     use objectstore_types::scope::{Scope, Scopes};
 
     use super::*;
@@ -366,6 +384,75 @@ mod tests {
     // Wraps a plain `Vec<Operation>` as an indexed `Ok`-stream for `execute`.
     fn indexed_ok(ops: Vec<Operation>) -> impl Stream<Item = (usize, Result<Operation, Error>)> {
         futures_util::stream::iter(ops.into_iter().enumerate().map(|(i, op)| (i, Ok(op))))
+    }
+
+    #[derive(Clone, Debug, Default)]
+    struct GateOnExpiry {
+        calls: Arc<AtomicUsize>,
+        started: Arc<tokio::sync::Notify>,
+        resume: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait::async_trait]
+    impl Hooks for GateOnExpiry {
+        async fn set_expiry(
+            &self,
+            inner: &InMemoryBackend,
+            id: &ObjectId,
+            expire_at: SystemTime,
+        ) -> Result<bool> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.started.notify_one();
+            self.resume.notified().await;
+            inner.set_expiry(id, expire_at).await
+        }
+    }
+
+    #[tokio::test]
+    async fn batch_get_and_head_return_while_renewals_are_blocked() {
+        let backend = TestBackend::new(GateOnExpiry::default());
+        let context = make_context();
+        let metadata = Metadata {
+            expiration_policy: ExpirationPolicy::TimeToIdle(Duration::from_hours(1)),
+            time_expires: Some(SystemTime::now() + Duration::from_mins(1)),
+            ..Default::default()
+        };
+        for key in ["get", "head"] {
+            let id = ObjectId::new(context.clone(), key.into());
+            backend
+                .inner
+                .put_object(&id, &metadata, stream::single("payload"))
+                .await
+                .unwrap();
+        }
+        let service = StorageService::new(Box::new(backend.clone()));
+        let outcomes = tokio::time::timeout(
+            Duration::from_secs(1),
+            service
+                .stream()
+                .execute(
+                    context,
+                    indexed_ok(vec![
+                        Operation::Get(Get { key: "get".into() }),
+                        Operation::Head(Head { key: "head".into() }),
+                    ]),
+                )
+                .collect::<Vec<_>>(),
+        )
+        .await
+        .expect("batch reads waited for background renewal");
+        assert_eq!(outcomes.len(), 2);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while backend.hooks.calls.load(Ordering::SeqCst) < 2 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("renewals did not start");
+        assert_eq!(backend.hooks.calls.load(Ordering::SeqCst), 2);
+
+        backend.hooks.resume.notify_waiters();
+        service.join().await;
     }
 
     // --- StreamExecutor correctness tests ---

--- a/objectstore-service/src/streaming.rs
+++ b/objectstore-service/src/streaming.rs
@@ -418,7 +418,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn batch_get_and_head_return_while_renewals_are_blocked() {
+    async fn batch_renewal() {
         let backend = TestBackend::new(GateOnExpiry::default());
         let context = make_context();
         let metadata = Metadata {

--- a/objectstore-types/src/metadata.rs
+++ b/objectstore-types/src/metadata.rs
@@ -382,7 +382,17 @@ impl Metadata {
                 "expiration policy requires a resolved expiration time",
             ));
         }
+        if self.expiration_policy.is_manual() && self.time_expires.is_some() {
+            return Err(Error::Invariant(
+                "manual expiration policy must not have a resolved expiration time",
+            ));
+        }
         Ok(())
+    }
+
+    /// Returns whether the object has expired at the given time.
+    pub fn is_expired(&self, now: SystemTime) -> bool {
+        self.time_expires.is_some_and(|deadline| deadline < now)
     }
 
     /// Checks whether this object's TTI deadline needs bumping.


### PR DESCRIPTION
Backend GET and HEAD operations currently renew TTI deadlines inline. These rewrites can race with concurrent tiered-storage commits and overwrite newer state.

This change makes backend reads side-effect-free. The service schedules bounded, best-effort renewals after successful reads. It adds extend-only conditional expiry updates for each backend and renews tiered objects blob-first before updating the matching redirect.

Ref FS-405
