### PR TITLE
fix(service): Restore unexpected tombstone error kind

### DIFF
--- a/objectstore-server/src/endpoints/common.rs
+++ b/objectstore-server/src/endpoints/common.rs
@@ -148,6 +148,7 @@ impl ApiError {
                 ServiceErrorKind::BackendFailure
                 | ServiceErrorKind::CorruptData
                 | ServiceErrorKind::Panic
+                | ServiceErrorKind::UnexpectedTombstone
                 | ServiceErrorKind::Internal => StatusCode::INTERNAL_SERVER_ERROR,
             },
 

--- a/objectstore-service/src/backend/bigtable.rs
+++ b/objectstore-service/src/backend/bigtable.rs
@@ -1020,10 +1020,7 @@ impl Backend for BigTableBackend {
             TieredGet::Object(metadata, content_range, payload) => {
                 Ok(Some((metadata, content_range, payload)))
             }
-            TieredGet::Tombstone(_) => Err(Error::new(
-                ErrorKind::Internal,
-                "unexpected Bigtable tombstone",
-            )),
+            TieredGet::Tombstone(_) => Err(ErrorKind::UnexpectedTombstone.into()),
             TieredGet::NotFound => Ok(None),
         }
     }
@@ -1032,10 +1029,7 @@ impl Backend for BigTableBackend {
     async fn get_metadata(&self, id: &ObjectId) -> Result<MetadataResponse> {
         match self.get_tiered_metadata(id).await? {
             TieredMetadata::Object(metadata) => Ok(Some(metadata)),
-            TieredMetadata::Tombstone(_) => Err(Error::new(
-                ErrorKind::Internal,
-                "unexpected Bigtable tombstone",
-            )),
+            TieredMetadata::Tombstone(_) => Err(ErrorKind::UnexpectedTombstone.into()),
             TieredMetadata::NotFound => Ok(None),
         }
     }
@@ -2155,13 +2149,13 @@ mod tests {
             backend
                 .get_object(&hv_id, None)
                 .await
-                .is_err_and(|error| error.kind() == ErrorKind::Internal)
+                .is_err_and(|error| error.kind() == ErrorKind::UnexpectedTombstone)
         );
         assert!(
             backend
                 .get_metadata(&hv_id)
                 .await
-                .is_err_and(|error| error.kind() == ErrorKind::Internal)
+                .is_err_and(|error| error.kind() == ErrorKind::UnexpectedTombstone)
         );
 
         // Idempotent retry: retry with the same target succeeds

--- a/objectstore-service/src/backend/in_memory.rs
+++ b/objectstore-service/src/backend/in_memory.rs
@@ -138,10 +138,7 @@ impl super::common::Backend for InMemoryBackend {
         match entry {
             None => Ok(None),
             Some(entry) if entry.is_expired(SystemTime::now()) => Ok(None),
-            Some(StoreEntry::Tombstone(_)) => Err(Error::new(
-                ErrorKind::Internal,
-                "unexpected in-memory tombstone",
-            )),
+            Some(StoreEntry::Tombstone(_)) => Err(ErrorKind::UnexpectedTombstone.into()),
             Some(StoreEntry::Object(mut metadata, bytes)) => {
                 let total = bytes.len() as u64;
                 metadata.size = Some(bytes.len());
@@ -695,6 +692,19 @@ mod tests {
             )
             .await
             .unwrap();
+
+        assert!(
+            backend
+                .get_object(&id, None)
+                .await
+                .is_err_and(|error| error.kind() == ErrorKind::UnexpectedTombstone)
+        );
+        assert!(
+            backend
+                .get_metadata(&id)
+                .await
+                .is_err_and(|error| error.kind() == ErrorKind::UnexpectedTombstone)
+        );
 
         let new_expiry = old_expiry + Duration::from_hours(1);
         assert!(

--- a/objectstore-service/src/error.rs
+++ b/objectstore-service/src/error.rs
@@ -84,6 +84,8 @@ pub enum ErrorKind {
     BackendUnavailable,
     /// A service task panicked.
     Panic,
+    /// A redirect tombstone was encountered by a read that does not support tombstones.
+    UnexpectedTombstone,
     /// Persisted or remote data is corrupt.
     CorruptData,
     /// An unexpected internal service failure occurred.
@@ -120,6 +122,7 @@ impl fmt::Display for ErrorKind {
             Self::BackendUnavailable => f.write_str("backend unavailable"),
             Self::CorruptData => f.write_str("corrupt stored data"),
             Self::Panic => f.write_str("service task panicked"),
+            Self::UnexpectedTombstone => f.write_str("unexpected tombstone"),
             Self::Internal => f.write_str("internal service error"),
         }
     }
@@ -201,6 +204,7 @@ impl Error {
             // All other errors are service or backend failures. These become Sentry errors.
             ErrorKind::BackendFailure => Level::ERROR,
             ErrorKind::Panic => Level::ERROR,
+            ErrorKind::UnexpectedTombstone => Level::ERROR,
             ErrorKind::CorruptData => Level::ERROR,
             ErrorKind::Internal => Level::ERROR,
         }


### PR DESCRIPTION
Legacy backend reads must fail when they encounter a tiered-storage redirect tombstone. Restore the dedicated semantic error kind so the error is categorized consistently and we can identify this better in error tracking.